### PR TITLE
DonorsChooseDonationController.createDonationDoc

### DIFF
--- a/mobilecommons/mobilecommons.js
+++ b/mobilecommons/mobilecommons.js
@@ -65,9 +65,7 @@ exports.profile_update = function(phone, optInPathId, customFields) {
   var trace = new Error().stack;
   var callback = function(error, response, body) {
     if (error) {
-      logger.error('mobilecommons.profile_update for user:'
-        + phone + ' | form data: ' + JSON.stringify(postData.form) 
-        + ' | error: ' + error + ' | stack: ' + trace);
+      logger.error('mobilecommons.profile_update user:%s form:%s error:%s', phone, JSON.stringify(postData.form), error);
     }
     else if (response && response.statusCode != 200) {
       logger.error('mobilecommons.profile_update for user:'


### PR DESCRIPTION
#### What's this PR do?
Extracts the code from `findProject` that creates a `donation_infos` document and calling Mobile Commons into a separate `createDonationDoc(mobileNumber, selectedProposal)` function. Similar to #571, no new functionality introduced. This is to help keep the code readable, and make it easier to work on #550 and #552 .

Also adds error handling to the beginning of `findProject` instead of an `else` at the end to cut down on brackets / nesting 🐦 

#### How should this be reviewed?
Pull down locally, post to the `retrieve-zip` endpoint to verify expected behavior.

#### Checklist
- [ ] Tested on staging.


