### PR TITLE
Donations chatbot

### DIFF
--- a/app.json
+++ b/app.json
@@ -13,13 +13,13 @@
       "required": true
     },
     "DONORSCHOOSE_API_KEY": {
-      "required": true
+      "required": false
     },
     "DONORSCHOOSE_API_PASSWORD": {
-      "required": true
+      "required": false
     },
     "DONORSCHOOSE_DEFAULT_EMAIL": {
-      "required": true
+      "required": false
     },
     "DS_CONTENT_API_PASSWORD": {
       "required": true
@@ -52,7 +52,7 @@
       "required": true
     },
     "NEW_RELIC_LOGGING_LEVEL": {
-      "required": true
+      "required": false
     },
     "NODE_ENV": {
       "required": true

--- a/app/lib/donations/controllers/DonorsChooseDonationController.js
+++ b/app/lib/donations/controllers/DonorsChooseDonationController.js
@@ -49,25 +49,29 @@ var connectionOperations = rootRequire('app/config/connectionOperations')
   ;
 
 // @todo: Read values from config document again, or set as environment variables.
+// OIP's from ScienceSleuth2016 Staging: 
 var donorsChooseConfig = {
   max_donations_allowed: 5,
   moco_campaign: 146307,
-  msg_ask_email: "Rad, what's your email? the teacher would like to send a thank you.",
   oip_ask_email: 209781,
-  msg_ask_first_name: "Rad, what's your first name?",
   oip_ask_first_name: 209779,
-  msg_ask_zip: "Rad, let's find a project in or near ur town. What's ur zipcode?",
   oip_ask_zip: 211113,
-  msg_donation_complete: "Rad! You donated!",
   oip_donation_complete_1: 209783,
   oip_donation_complete_2: 209785,
   oip_donation_complete_3: 209787,
   oip_error: 209791,
-  msg_invalid_zip: "Whoops! C'mon now, that's not a valid zip code. Try again.",
   oip_invalid_zip: 211115,
-  msg_max_donations: "Sorry, out of donations",
   oip_max_donations: 209789
 };
+
+var dcConfig = {
+  msg_ask_email: "Rad, what's your email? the teacher would like to send a thank you.",
+  msg_ask_first_name: "Rad, what's your first name?",
+  msg_ask_zip: "Rad, let's find a project in or near ur town. What's ur zipcode?",
+  msg_donation_complete: "Rad! You donated!",
+  msg_invalid_zip: "Whoops! C'mon now, that's not a valid zip code. Try again.",
+  msg_max_donations: "Sorry, out of donations"
+}
 
 function DonorsChooseDonationController() {
   this.resourceName; // Resource name identifier. Specifies controller to route. 
@@ -80,10 +84,10 @@ DonorsChooseDonationController.prototype.resourceName = 'donors-choose';
 
 function sendSMS(mobileNumber, message, customFields) {
   if (typeof customFields === 'undefined') {
-    customFields = {sciencesleuth_response: message};
+    customFields = {slothbot_response: message};
   }
   else {
-    customFields.sciencesleuth_response = message;
+    customFields.slothbot_response = message;
   }
   // ScienceSleuth Experiment campaign.
   // @see https://secure.mcommons.com/campaigns/146943/opt_in_paths/211133
@@ -92,12 +96,16 @@ function sendSMS(mobileNumber, message, customFields) {
 
 DonorsChooseDonationController.prototype.chat = function(request, response) {
   var member = request.body;
+  logger.log('verbose', 'DonorsChoose.chat member:', member);
   var phone = smsHelper.getNormalizedPhone(member.phone);
   userModel.findOne({phone: phone}, onUserFound);
   response.send();
 
-  var firstWord = smsHelper.getFirstWord(request.body.args)
-  console.log(phone + ' firstWord:' + firstWord);
+  var firstWord = null;
+  if (request.body.args) {
+    firstWord = smsHelper.getFirstWord(request.body.args);
+  }
+  logger.log('debug', 'DonorsChoose.chat phone:%s firstWord:%s', phone, firstWord);
 
   function onUserFound(err, userDocument) {
     logger.log('debug', 'DonorsChoose.onUserFound:%s', JSON.stringify(userDocument));
@@ -108,50 +116,50 @@ DonorsChooseDonationController.prototype.chat = function(request, response) {
     }
 
     if (getDonationCount(userDocument) > donorsChooseConfig.max_donations_allowed) {
-      sendSMS(phone, donorsChooseConfig.msg_max_donations);
+      sendSMS(phone, dcConfig.msg_max_donations);
       return;
     }
 
     if (!member.profile_postal_code) {
       if (!firstWord) {
-        sendSMS(phone, donorsChooseConfig.msg_ask_zip);
+        sendSMS(phone, dcConfig.msg_ask_zip);
         return;
       }
       if (!stringValidator.isValidZip(firstWord)) {
-        sendSMS(phone, donorsChooseConfig.msg_invalid_zip);
+        sendSMS(phone, dcConfig.msg_invalid_zip);
         return;
       }
-      sendSMS(phone, donorsChooseConfig.msg_ask_first_name, {postal_code: firstWord});
+      sendSMS(phone, dcConfig.msg_ask_first_name, {postal_code: firstWord});
       return;
     }
 
     if (!member.profile_first_name) {
       if (!firstWord) {
-        sendSMS(phone, donorsChooseConfig.msg_ask_first_name);
+        sendSMS(phone, dcConfig.msg_ask_first_name);
         return;
       }
       if (stringValidator.containsNaughtyWords(firstWord)) {
-        sendSMS(phone, "Pls don't use that tone with me. " + donorsChooseConfig.msg_ask_first_name);
+        sendSMS(phone, "Pls don't use that tone with me. " + dcConfig.msg_ask_first_name);
         return;
       }
-      sendSMS(phone, donorsChooseConfig.msg_ask_email, {first_name: firstWord});
+      sendSMS(phone, dcConfig.msg_ask_email, {first_name: firstWord});
       return;
     }
 
     if (!member.profile_email_address) {
       if (!firstWord) {
-        sendSMS(phone, donorsChooseConfig.msg_ask_email);
+        sendSMS(phone, dcConfig.msg_ask_email);
         return;
       }
       if (!stringValidator.isValidEmail(firstWord)) {
-        sendSMS(phone, "Whoops, that's not a valid email address. " + donorsChooseConfig.msg_ask_email);
+        sendSMS(phone, "Whoops, that's not a valid email address. " + dcConfig.msg_ask_email);
         return;
       }
-      sendSMS(phone, donorsChooseConfig.msg_donation_complete, {email_address: firstWord});
+      sendSMS(phone, dcConfig.msg_donation_complete, {email_address: firstWord});
       return;
     }
 
-    sendSMS(phone, donorsChooseConfig.msg_donation_complete);
+    sendSMS(phone, dcConfig.msg_donation_complete);
   }
 };
 

--- a/app/lib/donations/controllers/DonorsChooseDonationController.js
+++ b/app/lib/donations/controllers/DonorsChooseDonationController.js
@@ -20,6 +20,9 @@ var DONATION_AMOUNT = (process.env.DONORSCHOOSE_DONATION_AMOUNT || 10)
   , DONATE_API_URL = donorsChooseDonationBaseURL + '?APIKey=' + donorsChooseApiKey
   , END_MESSAGE_DELAY = 2500;
 
+// Name of MoCo Custom Field used to store member's number of donations.
+var DONATION_COUNT_FIELDNAME = 'ss2016_donation_count';
+
 var Q = require('q')
   , requestHttp = require('request')
   , Entities = require('html-entities').AllHtmlEntities
@@ -369,7 +372,12 @@ DonorsChooseDonationController.prototype.submitDonation = function(donorInfoObje
  *   Decoded DonorsChoose proposal object.
  */
 function sendSuccessMessages(member, project) {
-  logger.log('debug', 'DonorsChoose.sendSuccessMessages user:%s project%s', member.phone, project);
+  logger.log('debug', 'dc.sendSuccessMessages user:%s project%s', 
+    member.phone, project);
+
+  var donationCount = parseInt(member['profile_' + DONATION_COUNT_FIELDNAME]);
+  var customFields = {};
+  customFields[DONATION_COUNT_FIELDNAME] = donationCount + 1;
 
   var firstMessage = dcConfig.msg_donation_success + project.schoolName + ".";
   respondAndListen(member, firstMessage);
@@ -381,9 +389,10 @@ function sendSuccessMessages(member, project) {
 
   setTimeout(function() {
     shortenLink(project.url, function(shortenedLink) {
-      logger.log('debug', 'DonorsChoose.sendSuccessMessages user:%s shortenedLink:%s', member.phone, shortenedLink);
+      logger.log('debug', 'dc.sendSuccessMessages user:%s shortenedLink:%s', 
+        member.phone, shortenedLink);
       var thirdMessage = dcConfig.msg_project_link + shortenedLink;
-      respond(member, thirdMessage);
+      respond(member, thirdMessage, customFields);
     });
   }, 2 * END_MESSAGE_DELAY);
 }

--- a/app/lib/donations/donations.js
+++ b/app/lib/donations/donations.js
@@ -7,7 +7,7 @@ var express = require('express')
 
 var DonorsChoose = require('./controllers/DonorsChooseDonationController');
 
-router.post('/:controller/chat', function(request, response) {
+router.post('/donors-choose/', function(request, response) {
   var controller = new DonorsChoose();
   if (controller) {
     controller.chat(request, response);

--- a/app/lib/donations/donations.js
+++ b/app/lib/donations/donations.js
@@ -1,14 +1,5 @@
-/*
- * Donation controllers are expected to implement this interface.
- *
- * @interface {
- *   string resourceName
- *   function findProject(request, response)
- *   function retrieveEmail(request, response)
- *   function retrieveFirstName(request, response)
- *   function retrieveZip(request, response)
- *   function submitDonation(request, response)
- * }
+/**
+ * Handles donation routes for ScienceSleuth DonorsChoose donations.
  */
 
 var express = require('express')
@@ -16,96 +7,10 @@ var express = require('express')
 
 var DonorsChoose = require('./controllers/DonorsChooseDonationController');
 
-/**
- * Load the controller associated with the provided controller name.
- *
- * @param controllerName
- *   Name of the controller to load.
- *
- * @return controller
- */
-function loadController(controllerName) {
-  if (implementsInterface(DonorsChoose.prototype) &&
-      controllerName == DonorsChoose.prototype.resourceName) {
-    return new DonorsChoose();
-  }
-
-  // @todo Support for additional controllers can be added using the same logic.
-
-  return null;
-};
-
-/**
- * Checks if controller implements the donations interface.
- *
- * @param controller
- *   Controller class.
- *
- * @return boolean
- */
-function implementsInterface(controller) {
-  if (typeof controller.resourceName === 'string' &&
-      typeof controller.retrieveEmail === 'function' &&
-      typeof controller.retrieveFirstName === 'function' &&
-      typeof controller.retrieveZip === 'function' &&
-      typeof controller.submitDonation === 'function') {
-    return true;
-  }
-  else {
-    return false;
-  }
-}
-
 router.post('/:controller/chat', function(request, response) {
-  var controller = loadController(request.params.controller);
+  var controller = new DonorsChoose();
   if (controller) {
     controller.chat(request, response);
-  }
-  else {
-    response.status(404).send('Request not available for: ' + request.params.controller);
-  }
-});
-
-
-/**
- * Starts the donation flow. Any validation needed before a donation flow
- * begins should happen here. This endpoint will typically need to be
- * triggered via an mData.
- */
-router.post('/:controller/start', function(request, response) {
-  var controller = loadController(request.params.controller);
-  if (controller) {
-    controller.start(request, response);
-  }
-  else {
-    response.status(404).send('Request not available for: ' + request.params.controller);
-  }
-});
-
-router.post('/:controller/retrieve-email', function(request, response) {
-  var controller = loadController(request.params.controller);
-  if (controller) {
-    controller.retrieveEmail(request, response);
-  }
-  else {
-    response.status(404).send('Request not available for: ' + request.params.controller);
-  }
-});
-
-router.post('/:controller/retrieve-firstname', function(request, response) {
-  var controller = loadController(request.params.controller);
-  if (controller) {
-    controller.retrieveFirstName(request, response);
-  }
-  else {
-    response.status(404).send('Request not available for: ' + request.params.controller);
-  }
-});
-
-router.post('/:controller/retrieve-zip', function(request, response) {
-  var controller = loadController(request.params.controller);
-  if (controller) {
-    controller.retrieveZip(request, response);
   }
   else {
     response.status(404).send('Request not available for: ' + request.params.controller);

--- a/app/lib/donations/donations.js
+++ b/app/lib/donations/donations.js
@@ -45,7 +45,6 @@ function loadController(controllerName) {
  */
 function implementsInterface(controller) {
   if (typeof controller.resourceName === 'string' &&
-      typeof controller.findProject === 'function' &&
       typeof controller.retrieveEmail === 'function' &&
       typeof controller.retrieveFirstName === 'function' &&
       typeof controller.retrieveZip === 'function' &&

--- a/app/lib/donations/donations.js
+++ b/app/lib/donations/donations.js
@@ -57,6 +57,17 @@ function implementsInterface(controller) {
   }
 }
 
+router.post('/:controller/chat', function(request, response) {
+  var controller = loadController(request.params.controller);
+  if (controller) {
+    controller.chat(request, response);
+  }
+  else {
+    response.status(404).send('Request not available for: ' + request.params.controller);
+  }
+});
+
+
 /**
  * Starts the donation flow. Any validation needed before a donation flow
  * begins should happen here. This endpoint will typically need to be


### PR DESCRIPTION
#### What's this PR do?
This isn't a completely 100% dev complete Science Sleuth, but it does submit donations to the DC API, and it's quite a bit of changes - so merging into`develop` now to keep future pull requests readable.  Here's what's going on:

* Refactors Donors Choose Science Sleuth donations to use a single endpoint: `/donations/donors-choose`, inspired by how [custom Slack apps use a single Action URL](https://api.slack.com/docs/message-buttons) to implement custom actions.

    * Removes now deprecated endpoints and related functions
        * `/donations/donors-choose/start`
        * `/donations/donors-choose/retrieve-firstname`
        * `/donations/donors-choose/retrieve-email`
        * `/donations/donors-choose/retrieve-zip` 


    * Removes unnecessary donation controller interface code to simplify codebase


* Refactors Donation MoCo Campaigns to use 3 OIP's: 1) Start 2) Chatbot and 3) Conversation Ended.

    * We now store the majority of conversation content into new `dcConfig` variable instead of legacy convention of storing a collection of OIP's (where we'd set conversation copy in each OIP's conversation settings, ad need to set relevant mData's, e.g. #546).  The desired `dcConfig` message is stored to the MoCo `slothbot_response` Custom Field and displayed via Liquid within our OIP conversations (refs #537)

    * `dcConfig` object will be refactored as a new `config` document (see todos section)

* Adds new helper functions for sending SMS messages:

   * `respondAndListen(member, messageText, customFields)` - opts the member into the Chatbot OIP and saves the `messageText` to the `slothbot_response` MoCo custom field. The Chatbot OIP will post back to our endpoint to continue responding to the member

    * `respond(member, messageText, customFields)` - opts the member into the Conversation Ended OIP, which does not post to an mData.

* Stores required user donation info into Mobile Commons custom fields (`email`, `first_name`, and `postal_code`) if values don't exist, instead of storing in `donation_infos` documents

    * Changes flow to prompt for all member information first. When we have all information stored, query for closest project and donate. This closes #550 and closes #567 -- if donation fails, we can start over without worrying about incomplete `donation_infos` documents and fetching an incomplete donation


* Stores count of user donations as a Mobile Commons custom field instead of the `sg_users` document corresponding to the user, removes now deprecated functions like `incrementDonationCount`. The new `ss2016_donation_count` MoCo Custom Field  is updated within `sendSuccessMessages` (which may make sense to rename as something like `respondWithSuccessConfirmation`)


* Alters `app.json` to require less config variables. I changed our Heroku pipeline so that Review Apps are cloned from staging instead of production (#555)


#### How should this be reviewed?
Pull down locally and post to the `/donations/donors-choose` endpoint. You can mimic the conversation flow by posting additional body params along with the `phone`:
* `profile_postal_code`
* `profile_first_name`
* `profile_email`

#### Any background context you want to provide?
Looking to simplify our configuration by using the 3 OIP's for a whole Donation campaign, with `slothbot_response` as Liquid instead of keeping track of multiple OIP id's (and making sure each OIP is configured with the correct mData in MoCo), which introduces many opportunities for configuration errors. Especially since we need two functional donation campaigns, one for production and another for staging.

If this turns out to be a terrible idea, we can revert back to [1.1.1](https://github.com/DoSomething/gambit/releases/tag/1.1.1), which uses individual OIP's for each message within the conversation (Request Email, Invalid Email, Request Zip, Invalid Zip, Request First Name, Donation Successful 1-3, etc)

#### Relevant tickets

* #539 - simplifies creation and maintenance of staging and production Donation MoCo campaigns
 
* closes #567: Don't have to worry about filtering `donation_infos` documents for this year's run because we're only creating documents for completed donations, and inspecting a MoCo custom field value instead of anything in Mongo

* closes #550 and closes #559: Avoid gotchas by immediately donating to project once it's found (vs storing a project but not donating until a few steps later in the conversation) , hopefully right track for ways to help #463 

* closes #552: Don't prompt for zip, first name, and email on subsequent donations because we'll have them stored to MoCo profile already

### todo
* [ ] Update documentation
* [ ] Store completed donations into the `ds-mdata-responder` database, probably in a new `donations_donorschoose` collection instead of existing `donation_infos`
* [ ] Add docblocks, fix up legacy variable declarations to adhere to best practices
* [ ] End conversation with messaging if member has reached maximum # of donations
* [ ] Add secret Clean Slate keyword to clear out your first name, email, and zip code to easily test and re-test whole Donation conversation
* [ ] If user's 2nd+ donation, inform them we're finding a new project to donate to based on their zip code (e.g. We already have your zip (87101), so we're sending your donation to Mr. White's Beakers for Believers project at Albuquerque High School)
* [ ] Create staging/production instances (currently hardcoded to single campaign)
* [ ] Modify `donorschoose` config collection: 
    * [ ] store new conversation `msg_` variables instead of conversation OIP's
    * [ ] Store OIP's as properties in the `config` document of `respond` and `respondAndListen` 
* [ ] Delete `ss_` Custom Fields we no longer need in MoCo that store selected Project info for Liquid, e.g. `ss_teacher_name`, `ss_fulfillment_trailer`, `ss_school_name`
