### PR TITLE
Donations chatbot configuration

### DIFF
--- a/app/lib/donations/controllers/DonorsChooseDonationController.js
+++ b/app/lib/donations/controllers/DonorsChooseDonationController.js
@@ -33,75 +33,39 @@ var Q = require('q')
   , stringValidator = rootRequire('app/lib/string-validators')
   ;
 
-var connectionOperations = rootRequire('app/config/connectionOperations')
-  , donationModel = require('../models/DonationInfo')(connectionOperations)
-  ;
-
-var dcConfig = {
-  msg_ask_email: "Rad, what's your email? the teacher would like to send a thank you.",
-  msg_ask_first_name: "Rad, what's your first name?",
-  msg_ask_zip: "Rad, let's find a project in or near ur town. What's ur zipcode?",
-  msg_donation_success: "Because you played Science Sleuth, you're helping support STEM (science,tech,math & engineering) classes at ",
-  msg_invalid_zip: "Whoops! C'mon now, that's not a valid zip code. Try again.",
-  msg_project_link: "You can find your name and updates on the project here: ",
-}
+var connectionOperations = rootRequire('app/config/connectionOperations');
+var donationModel = require('../models/DonationInfo')(connectionOperations);
 
 function DonorsChooseDonationController() {
-  this.resourceName; // Resource name identifier. Specifies controller to route. 
+  this.dcConfig = app.getConfig(app.ConfigName.DONORSCHOOSE, 146943); 
 };
-
-/**
- * Posts profile_update request to Mobile Commons to send messageText as SMS.
- *
- * @param {object} member The MoCo request.body sent, containing member info.
- * @param {number} optInPath
- * @param {string} messageText
- * @param {object|null} customFields Key/values to store as MoCo Custom Fields.
- */
-function sendSMS(member, optInPath, messageText, customFields) {
-  var mobileNumber = smsHelper.getNormalizedPhone(member.phone);
-  // Save as slothbot_response MoCo custom field to display in Liquid via MoCo.
-  if (typeof customFields === 'undefined') {
-    customFields = {slothbot_response: messageText};
-  }
-  else {
-    customFields.slothbot_response = messageText;
-  }
-  // ScienceSleuth Experiment campaign.
-  // @see https://secure.mcommons.com/campaigns/146943/opt_in_paths/211133
-  mobilecommons.profile_update(mobileNumber, optInPath, customFields);
-}
 
 /**
  * Sends SMS mesage and listens for a MoCo response.
  *
  * @see sendSMS(member, optInPath, messageText, customFields)
  */
-function respondAndListen(member, messageText, customFields) {
-  // Send to the chat OIP to listen for a member response to respond back to.
-  sendSMS(member, 211133, messageText, customFields);
+DonorsChooseDonationController.prototype.chat = function(member, msgText, profileFields) {
+  sendSMS(member, this.dcConfig.oip_chat, msgText, profileFields);
 }
 
 /**
- * Sends SMS message without listening for a MoCo response.
+ * Sends SMS message and ends conversation.
  *
  * @see sendSMS(member, optInPath, messageText, customFields)
  */
-function respond(member, messageText, customFields) {
-  // Send to OIP without mData, and no longer listen for member responses.
-  sendSMS(member, 211195, messageText, customFields);
+DonorsChooseDonationController.prototype.endChat = function(member, msgText, profileFields) {
+  sendSMS(member, this.dcConfig.oip_end_chat, msgText, profileFields);
 }
 
 /**
- * Sends generic failure message as SMS without listening for a MoCo response.
- *
- * @see sendSMS(member, optInPath, messageText, customFields)
+ * Sends SMS message with generic failure text and ends conversation.
  */
-function respondWithGenericFail(member) {
-  sendSMS(member, 211195, "Oops, something's not right. Please try again l8r");
+DonorsChooseDonationController.prototype.endChatWithFail = function(member) {
+  this.endChat(member, this.dcConfig.msg_error_generic);
 }
 
-DonorsChooseDonationController.prototype.chat = function(request, response) {
+DonorsChooseDonationController.prototype.chatbot = function(request, response) {
   var member = request.body;
   logger.log('verbose', 'dc.chat member:', member);
   response.send();
@@ -115,43 +79,45 @@ DonorsChooseDonationController.prototype.chat = function(request, response) {
   // @todo Could add sanity check in code that member donation count is not max.
   // Planning to rely on Liquid logic within Start OIP conversation.
 
+  // @todo Liquid in Start OIP will need to match sequence we check here
+
   if (!member.profile_postal_code) {
     if (!firstWord) {
-      respondAndListen(member, dcConfig.msg_ask_zip);
+      this.chat(member, this.dcConfig.msg_ask_zip);
       return;
     }
     if (!stringValidator.isValidZip(firstWord)) {
-      respondAndListen(member, dcConfig.msg_invalid_zip);
+      this.chat(member, this.dcConfig.msg_invalid_zip);
       return;
     }
-    respondAndListen(member, dcConfig.msg_ask_first_name, {postal_code: firstWord});
+    this.chat(member, this.dcConfig.msg_ask_first_name, {postal_code: firstWord});
     return;
   }
 
   if (!member.profile_first_name) {
     if (!firstWord) {
-      respondAndListen(member, dcConfig.msg_ask_first_name);
+      this.chat(member, this.dcConfig.msg_ask_first_name);
       return;
     }
     if (stringValidator.containsNaughtyWords(firstWord)) {
-      respondAndListen(member, "Pls don't use that tone with me. " + dcConfig.msg_ask_first_name);
+      this.chat(member, "Pls don't use that tone with me. " + this.dcConfig.msg_ask_first_name);
       return;
     }
-    respondAndListen(member, dcConfig.msg_ask_email, {first_name: firstWord});
+    this.chat(member, this.dcConfig.msg_ask_email, {first_name: firstWord});
     return;
   }
 
   if (!member.profile_email_address) {
     if (!firstWord) {
-      respondAndListen(member, dcConfig.msg_ask_email);
+      this.chat(member, this.dcConfig.msg_ask_email);
       return;
     }
     if (!stringValidator.isValidEmail(firstWord)) {
-      respondAndListen(member, "Whoops, that's not a valid email address. " + dcConfig.msg_ask_email);
+      this.chat(member, "Whoops, that's not a valid email address. " + this.dcConfig.msg_ask_email);
       return;
     }
     // @todo Does this ever get called?
-    respondAndListen(member, "Looking for a project by you, just a moment...", {email_address: firstWord});
+    this.chat(member, "Looking for a project by you, just a moment...", {email_address: firstWord});
 
     setTimeout(function() {
       findProjectAndRespond(member);
@@ -159,7 +125,7 @@ DonorsChooseDonationController.prototype.chat = function(request, response) {
     return;
   }
 
-  findProjectAndRespond(member);
+  this.findProjectAndRespond(member);
 };
 
 /**
@@ -169,7 +135,7 @@ DonorsChooseDonationController.prototype.chat = function(request, response) {
  * @see https://data.donorschoose.org/docs/project-listing/json-requests/
  *
  */
-function findProjectAndRespond(member) {
+DonorsChooseDonationController.prototype.findProjectAndRespond = function(member) {
   var mobileNumber = member.phone;
   var zip = member.profile_postal_code;
   var requestUrlString = donorsChooseProposalsQueryBaseURL;
@@ -183,7 +149,7 @@ function findProjectAndRespond(member) {
 
   requestHttp.get(requestUrlString, function(error, response, data) {
     if (error) {
-      respondWithGenericFail(member);
+      this.endChatWithFail(member);
       logger.error('dc.findProject user:%s error:%s', mobileNumber, error);
       return;
     }
@@ -191,18 +157,18 @@ function findProjectAndRespond(member) {
     try {
       var dcResponse = JSON.parse(data);
       if (!dcResponse.proposals || dcResponse.proposals.length == 0) {
-        // If no proposals, could potentially prompt user for different zip code.
+        // If no proposals, could potentially prompt user to try different zip.
         // For now, send back error message per existing functionality.
-        respond(member, "Hmm, no projects found. Try again later.");
+        this.endChat(member, "Hmm, no projects found. Try again later.");
         logger.error('dc.findProject no results for zip:%s user:%s', zip, 
           mobileNumber);
         return;
       }
       var project = decodeDonorsChooseProposal(dcResponse.proposals[0]);
-      postDonation(member, project);
+      this.postDonation(member, project);
     }
     catch (e) {
-      respondWithGenericFail(member);
+      this.endChatWithFail(member);
       logger.error('ds.findProject user:%s error:%s', mobileNumber, e); 
       return;
     }
@@ -266,7 +232,7 @@ function createDonationDoc(mobileNumber, selectedProposal) {
  * @param proposalId, the DonorsChoose proposal ID 
  *
  */
-function postDonation(member, project) {
+DonorsChooseDonationController.prototype.postDonation = function(member, project) {
   var donorPhone = member.phone;
   logger.log('debug', 'dc.submitDonation user:%s proposalId:%s', 
     donorPhone, project.id);
@@ -297,17 +263,17 @@ function postDonation(member, project) {
           }
           else {
             logger.error('dc.requestToken statusDescription!=success user:%s', donorPhone);
-            respondWithGenericFail(member);
+            this.endChatWithFail(member);
           }
         }
         catch (e) {
           logger.error('dc.requestToken failed user:'  + donorPhone + ' error:' + JSON.stringify(error));
-          respondWithGenericFail(member);
+          this.endChatWithFail(member);
         }
       }
       else {
         deferred.reject('dc.requestToken error user: ' + donorPhone + 'error: ' + JSON.stringify(err));
-        respondWithGenericFail(member);
+        this.endChatWithFail(member);
       }
     });
     return deferred.promise;
@@ -334,7 +300,7 @@ function postDonation(member, project) {
       if (err) {
         logger.error('dc.requestDonation POST user:%s error:%s',
           member.phone, error);
-        respondWithGenericFail(member);
+        this.endChatWithFail(member);
       }
       else if (response && response.statusCode != 200) {
         logger.error('dc.requestDonation response.statusCode:%s for user:%s', 
@@ -345,7 +311,7 @@ function postDonation(member, project) {
           var jsonBody = JSON.parse(body);
           if (jsonBody.statusDescription === 'success') {
             logger.info('dc.requestDonation success user:' + donorPhone + ' proposalId:' + project.id + ' body:', jsonBody);
-            sendSuccessMessages(member, project);
+            this.respondWithSuccess(member, project);
             return;
           }
           else {
@@ -356,7 +322,7 @@ function postDonation(member, project) {
           logger.error('dc.requestDonation catch exception for user:%s e:%s', donorPhone, e.message);
         }
       }
-      respondWithGenericFail(member);
+      this.endChatWithFail(member);
     });
   }
 };
@@ -367,32 +333,51 @@ function postDonation(member, project) {
  * @param project
  *   Decoded DonorsChoose proposal object.
  */
-function sendSuccessMessages(member, project) {
-  logger.log('debug', 'dc.sendSuccessMessages user:%s project%s', 
+DonorsChooseDonationController.prototype.respondWithSuccess = function(member, project) {
+  logger.log('debug', 'dc.respondWithSuccess user:%s project%s', 
     member.phone, project);
 
   var donationCount = parseInt(member['profile_' + DONATION_COUNT_FIELDNAME]);
   var customFields = {};
   customFields[DONATION_COUNT_FIELDNAME] = donationCount + 1;
 
-  var firstMessage = dcConfig.msg_donation_success + project.schoolName + ".";
-  respondAndListen(member, firstMessage);
+  var firstMessage = this.dcConfig.msg_donation_success + project.schoolName + ".";
+  this.endChat(member, firstMessage);
 
   setTimeout(function() {
     var secondMessage = '@' + project.teacherName + ': Thx! ' + project.description;
-    respondAndListen(member, secondMessage);
+    this.endChat(member, secondMessage);
   }, END_MESSAGE_DELAY);
 
   setTimeout(function() {
     shortenLink(project.url, function(shortenedLink) {
       logger.log('debug', 'dc.sendSuccessMessages user:%s shortenedLink:%s', 
         member.phone, shortenedLink);
-      var thirdMessage = dcConfig.msg_project_link + shortenedLink;
-      respond(member, thirdMessage, customFields);
+      var thirdMessage = this.dcConfig.msg_project_link + shortenedLink;
+      this.endChat(member, thirdMessage, customFields);
     });
   }, 2 * END_MESSAGE_DELAY);
 }
 
+/**
+ * Posts profile_update request to Mobile Commons to send messageText as SMS.
+ *
+ * @param {object} member The MoCo request.body sent, containing member info.
+ * @param {number} optInPath
+ * @param {string} messageText
+ * @param {object|null} customFields Key/values to store as MoCo Custom Fields.
+ */
+function sendSMS(member, optInPath, messageText, customFields) {
+  var mobileNumber = smsHelper.getNormalizedPhone(member.phone);
+  // Save as slothbot_response MoCo custom field to display in Liquid via MoCo.
+  if (typeof customFields === 'undefined') {
+    customFields = {slothbot_response: messageText};
+  }
+  else {
+    customFields.slothbot_response = messageText;
+  }
+  mobilecommons.profile_update(mobileNumber, optInPath, customFields);
+}
 
 /**
  * The following two functions are for handling Mongoose Promise chain errors.
@@ -404,7 +389,7 @@ function promiseErrorCallback(message, member) {
 function onPromiseErrorCallback(err) {
   if (err) {
     logger.error(this.message + '\n', err.stack);
-    respondWithGenericFail(this.member);
+    this.endChatWithFail(this.member);
   }
 }
 

--- a/app/lib/donations/controllers/DonorsChooseDonationController.js
+++ b/app/lib/donations/controllers/DonorsChooseDonationController.js
@@ -37,7 +37,8 @@ var connectionOperations = rootRequire('app/config/connectionOperations');
 var donationModel = require('../models/DonationInfo')(connectionOperations);
 
 function DonorsChooseDonationController() {
-  this.dcConfig = app.getConfig(app.ConfigName.DONORSCHOOSE, 146943); 
+  var mocoCampaignId = process.env.DONORSCHOOSE_MOCO_CAMPAIGN_ID;
+  this.dcConfig = app.getConfig(app.ConfigName.DONORSCHOOSE, mocoCampaignId); 
 };
 
 /**
@@ -69,6 +70,8 @@ DonorsChooseDonationController.prototype.chatbot = function(request, response) {
   var member = request.body;
   logger.log('verbose', 'dc.chat member:', member);
   response.send();
+
+  // @todo Add sanity check to make sure this.dcConfig exists
 
   var firstWord = null;
   if (request.body.args) {

--- a/app/lib/donations/donations.js
+++ b/app/lib/donations/donations.js
@@ -10,7 +10,7 @@ var DonorsChoose = require('./controllers/DonorsChooseDonationController');
 router.post('/donors-choose/', function(request, response) {
   var controller = new DonorsChoose();
   if (controller) {
-    controller.chat(request, response);
+    controller.chatbot(request, response);
   }
   else {
     response.status(404).send('Request not available for: ' + request.params.controller);

--- a/app/lib/donations/models/donorschooseConfigModel.js
+++ b/app/lib/donations/models/donorschooseConfigModel.js
@@ -4,31 +4,28 @@
  */
 var mongoose = require('mongoose');
 
-var donorschooseConfigSchema = new mongoose.Schema({
+var schema = new mongoose.Schema({
 
-  // Reassigning the _id value. 
-  _id : Number,
+  // Corresponds to Mobile Commons Campaign ID used for Donation conversation.
+  // v1 Used numeric convetion 101 for 2014 SS, 201 for 2015 SS.
+  _id: Number,
 
-  // Contextual information about the donorschoose donation flow. 
+  // Contextual information about Campaign, used for Compose admin readability. 
   __comments: String,
 
-  start_donation_flow: Number,
+  // Chatbot config:
+  msg_ask_email: String,
+  msg_ask_first_name: String,
+  msg_ask_zip: String,
+  msg_donation_success: String,
+  msg_error_generic: String,
+  msg_invalid_zip: String,
+  msg_project_link: String,
+  oip_chat: Number,
+  oip_end_chat: Number
 
-  ask_email: Number,
-
-  donation_complete_project_info_A: Number,
-
-  donation_complete_project_info_B: Number,
-
-  donation_complete_give_url: Number,
-
-  max_donations_reached_oip: Number,
-
-  error_start_again: Number,
-
-  max_donations_allowed: Number
-})
+});
 
 module.exports = function(connection) {
-  return connection.model(app.ConfigName.DONORSCHOOSE, donorschooseConfigSchema, 'donorschoose'); // Third param explicitly setting the name of the collection. 
-}
+  return connection.model(app.ConfigName.DONORSCHOOSE, schema, 'donorschoose');
+};


### PR DESCRIPTION
#### What's this PR do?
* Refactors the model of the `donorschoose` collection in the `config` database to store the Donations chatbot copy and opt-in-paths in Mongo instead of hardcoding. (refs todos in #573)

* Renames functions for better code readability:
    * `chat` renamed to `chatbot`
   * `respondAndListen` renamed to `chat`
   * `respond` renamed to `endChat`
   * `respondWithGenericFail` renamed to `endChatWithFail`
   * `requestDonation` renamed to `postDonation`

#### How should this be reviewed?
* Set your local `DONORSCHOOSE_MOCO_CAMPAIGN_ID` to our staging MoCo Campaign ID
* Same steps as #573, testing flow locally to make sure nothing has changed
* Edit values in the `donorschoose` document for the MoCo Campaign ID, restart, and confirm message copy has changed

#### Any background context you want to provide?
Need to add additional `msg_` properties to the `donorschoose` for naughty language, no projects found, etc.

#### Relevant tickets
Resolves how we'll maintain staging and production environments in #539 

#### Checklist
- [ ] Updated documentation.
- [x] Tested on staging.
