### PR TITLE
Require New Relic on line 1

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,10 +1,8 @@
+require ('newrelic');
+
 // Wrapper around require to set relative path at app root
 global.rootRequire = function(name) {
   return require(__dirname + '/' + name);
-}
-
-if (process.env.NODE_ENV == 'production' || process.env.NEW_RELIC_ENABLED) {
-  require ('newrelic');
 }
 
 var express = require('express')


### PR DESCRIPTION
#### What's this PR do?
Requires the New Relic package on line 1 (refs original description in #518), hoping this will get errors showing up in New Relic to finally close out #518.

Per [docs](https://docs.newrelic.com/docs/agents/nodejs-agent/troubleshooting/troubleshooting-your-nodejs-installation) and suggestion from New Relic support:
> Ensure that you have added `require('newrelic')`; as the first line of the app's main module. If the `require` is added later, the Node.js agent may not properly instrument your application.


#### How should this be reviewed?
Pull down locally and start up app via `heroku local`. Verify connection to New Relic in your `newrelic_agent.log`.

#### Any background context you want to provide?
We're soon looking to change our New Relic integration to use our standard DS.org license key instead of our Heroku add-on license key (essentially undoing https://github.com/DoSomething/gambit/pull/468 )

#### Relevant tickets
#518 

#### Checklist
- [ ] Tested on staging.

