### PR TITLE
Limit number of donations to a MAX_DONATIONS_ALLOWED environment variable

### DIFF
--- a/app/lib/donations/models/donorsChooseConfigModel.js
+++ b/app/lib/donations/models/donorsChooseConfigModel.js
@@ -21,6 +21,7 @@ var schema = new mongoose.Schema({
   msg_error_generic: String,
   msg_invalid_zip: String,
   msg_project_link: String,
+  msg_max_donations_reached: String,
   oip_chat: Number,
   oip_end_chat: Number
 


### PR DESCRIPTION
#### What's this PR do?
* Adds a `DONORSCHOOSE_MAX_DONATIONS_ALLOWED` environment variable to check against's a member's Donation Count to determine whether they can start a Donation conversation.
* Adds a `msg_max_donations_reached` property to the `donorschoose` config collection to set the relevant copy to display when a member has reached the max # of donations possible

#### How should this be reviewed?
Pull down locally and post against the `/donors-choose/donations` endpoint, testing with different numeric values for `profile_ss2016_donation_count` to verify the `msg_max_donations_reached` copy is displayed when given value >= `MAX_DONATIONS_ALLOWED`

#### Any background context you want to provide?
Limit first introduced in #482

#### Relevant tickets
Closes todo item in #573

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Tested on staging.

