### PR TITLE
Saving email fix + Searching By Zip message

### DIFF
--- a/app/lib/donations/controllers/DonorsChooseDonationController.js
+++ b/app/lib/donations/controllers/DonorsChooseDonationController.js
@@ -153,7 +153,7 @@ DonorsChooseDonationController.prototype.chatbot = function(request, response) {
       return;
     }
 
-    self.findProjectAndRespond(member, {email_address: firstWord});
+    self.findProjectAndRespond(member, {email: firstWord});
     return;
 
   }

--- a/app/lib/donations/controllers/DonorsChooseDonationController.js
+++ b/app/lib/donations/controllers/DonorsChooseDonationController.js
@@ -142,13 +142,15 @@ DonorsChooseDonationController.prototype.chatbot = function(request, response) {
       self.chat(member, "Whoops, that's not a valid email address. " + self.dcConfig.msg_ask_email);
       return;
     }
-    // @todo Does this ever get called?
-    self.chat(member, "Looking for a project by you, just a moment...",
-      {email_address: firstWord});
+
+    var msgTxt = '@slothbot: Looking for a classroom by your zip ('; 
+    msgTxt += member.profile_postal_code + ') - one moment pls...';
+    self.chat(member, msgTxt, {email_address: firstWord});
 
     setTimeout(function() {
-      findProjectAndRespond(member);
+      self.findProjectAndRespond(member);
     }, END_MESSAGE_DELAY);
+
     return;
   }
 

--- a/app/lib/donations/controllers/DonorsChooseDonationController.js
+++ b/app/lib/donations/controllers/DonorsChooseDonationController.js
@@ -82,24 +82,6 @@ DonorsChooseDonationController.prototype.chatbot = function(request, response) {
   }
   logger.log('debug', 'dc.chat user:%s firstWord:%s', member.phone, firstWord);
 
-  if (process.env.DONORSCHOOSE_CLEANSLATE_ENABLED) {
-    if (firstWord === process.env.DONORSCHOOSE_CLEANSLATE_KEYWORD) {
-      logger.log('debug', 'dc.chat DONORSCHOOSE_CLEANSLATE_KEYWORD user:%s', 
-        member.phone);
-      // @todo: Email, first_name, and postal_code aren't resetting here.
-      var profileFields = {
-        email: null,
-        first_name: null,
-        postal_code: null,
-      };
-      // Resetting our count works.
-      profileFields[DONATION_COUNT_FIELDNAME] = 0;
-      var msgTxt = '@slothbot: Whoop! Your donation count has been reset.';
-      self.endChat(member, msgTxt, profileFields);
-      return;
-    }
-  }
-
   if (getDonationCount(member) >= MAX_DONATIONS_ALLOWED) {
     logger.log('debug', 'dc.chat msg_max_donations_reached user:%s', 
       member.phone);

--- a/app/lib/donations/controllers/DonorsChooseDonationController.js
+++ b/app/lib/donations/controllers/DonorsChooseDonationController.js
@@ -82,6 +82,24 @@ DonorsChooseDonationController.prototype.chatbot = function(request, response) {
   }
   logger.log('debug', 'dc.chat user:%s firstWord:%s', member.phone, firstWord);
 
+  if (process.env.DONORSCHOOSE_CLEANSLATE_ENABLED) {
+    if (firstWord === process.env.DONORSCHOOSE_CLEANSLATE_KEYWORD) {
+      logger.log('debug', 'dc.chat DONORSCHOOSE_CLEANSLATE_KEYWORD user:%s', 
+        member.phone);
+      // @todo: Email, first_name, and postal_code aren't resetting here.
+      var profileFields = {
+        email: null,
+        first_name: null,
+        postal_code: null,
+      };
+      // Resetting our count works.
+      profileFields[DONATION_COUNT_FIELDNAME] = 0;
+      var msgTxt = '@slothbot: Whoop! Your donation count has been reset.';
+      self.endChat(member, msgTxt, profileFields);
+      return;
+    }
+  }
+
   if (getDonationCount(member) >= MAX_DONATIONS_ALLOWED) {
     logger.log('debug', 'dc.chat msg_max_donations_reached user:%s', 
       member.phone);

--- a/app/lib/donations/controllers/DonorsChooseDonationController.js
+++ b/app/lib/donations/controllers/DonorsChooseDonationController.js
@@ -170,10 +170,7 @@ DonorsChooseDonationController.prototype.chatbot = function(request, response) {
  */
 DonorsChooseDonationController.prototype.findProjectAndRespond = function(member, customFields) {
   var self = this;
-
-  var msgTxt = '@slothbot: Looking for a classroom by your zip ('; 
-  msgTxt += member.profile_postal_code + ') - one moment pls...';
-  self.endChat(member, msgTxt, customFields);
+  self.endChat(member, this.dcConfig.msg_searching_by_zip, customFields);
 
   logger.log('debug', 'dc.findProjectAndRespond user:%s zip:%s', member.phone,
     member.profile_postal_code);
@@ -420,15 +417,17 @@ DonorsChooseDonationController.prototype.respondWithSuccess = function(member, p
  * @param {string} messageText
  * @param {object|null} customFields Key/values to store as MoCo Custom Fields.
  */
-function sendSMS(member, optInPath, messageText, customFields) {
+function sendSMS(member, optInPath, msgTxt, customFields) {
   var mobileNumber = smsHelper.getNormalizedPhone(member.phone);
-  // Save as slothbot_response MoCo custom field to display in Liquid via MoCo.
+  var msgTxt = msgTxt.replace('{{postal_code}}', member.profile_postal_code);
+
   if (typeof customFields === 'undefined') {
-    customFields = {slothbot_response: messageText};
+    customFields = {slothbot_response: msgTxt};
   }
   else {
-    customFields.slothbot_response = messageText;
+    customFields.slothbot_response = msgTxt;
   }
+
   mobilecommons.profile_update(mobileNumber, optInPath, customFields);
 }
 

--- a/app/lib/donations/controllers/DonorsChooseDonationController.js
+++ b/app/lib/donations/controllers/DonorsChooseDonationController.js
@@ -108,50 +108,54 @@ DonorsChooseDonationController.prototype.chatbot = function(request, response) {
   }
 
   if (!member.profile_postal_code) {
+
     if (!firstWord) {
       self.chat(member, self.dcConfig.msg_ask_zip);
       return;
     }
+
     if (!stringValidator.isValidZip(firstWord)) {
       self.chat(member, self.dcConfig.msg_invalid_zip);
       return;
     }
+
     self.chat(member, self.dcConfig.msg_ask_first_name, {postal_code: firstWord});
     return;
+
   }
 
   if (!member.profile_first_name) {
+
     if (!firstWord) {
       self.chat(member, self.dcConfig.msg_ask_first_name);
       return;
     }
+
     if (stringValidator.containsNaughtyWords(firstWord)) {
       self.chat(member, "Pls don't use that tone with me. " + self.dcConfig.msg_ask_first_name);
       return;
     }
+
     self.chat(member, self.dcConfig.msg_ask_email, {first_name: firstWord});
     return;
+
   }
 
   if (!member.profile_email) {
+
     if (!firstWord) {
       self.chat(member, self.dcConfig.msg_ask_email);
       return;
     }
+
     if (!stringValidator.isValidEmail(firstWord)) {
       self.chat(member, "Whoops, that's not a valid email address. " + self.dcConfig.msg_ask_email);
       return;
     }
 
-    var msgTxt = '@slothbot: Looking for a classroom by your zip ('; 
-    msgTxt += member.profile_postal_code + ') - one moment pls...';
-    self.chat(member, msgTxt, {email_address: firstWord});
-
-    setTimeout(function() {
-      self.findProjectAndRespond(member);
-    }, END_MESSAGE_DELAY);
-
+    self.findProjectAndRespond(member, {email_address: firstWord});
     return;
+
   }
 
   self.findProjectAndRespond(member);
@@ -164,8 +168,12 @@ DonorsChooseDonationController.prototype.chatbot = function(request, response) {
  * @see https://data.donorschoose.org/docs/project-listing/json-requests/
  *
  */
-DonorsChooseDonationController.prototype.findProjectAndRespond = function(member) {
+DonorsChooseDonationController.prototype.findProjectAndRespond = function(member, customFields) {
   var self = this;
+
+  var msgTxt = '@slothbot: Looking for a classroom by your zip ('; 
+  msgTxt += member.profile_postal_code + ') - one moment pls...';
+  self.endChat(member, msgTxt, customFields);
 
   logger.log('debug', 'dc.findProjectAndRespond user:%s zip:%s', member.phone,
     member.profile_postal_code);

--- a/app/lib/donations/models/donorsChooseConfigModel.js
+++ b/app/lib/donations/models/donorsChooseConfigModel.js
@@ -22,6 +22,7 @@ var schema = new mongoose.Schema({
   msg_invalid_zip: String,
   msg_project_link: String,
   msg_max_donations_reached: String,
+  msg_searching_by_zip: String,
   oip_chat: Number,
   oip_end_chat: Number
 


### PR DESCRIPTION
#### What's this PR do?
* ~~Adds support for a new `DONORSCHOOSE_CLEANSLATE_KEYWORD` that will reset a member's Donation Count if corresponding new `DONORSCHOOSE_CLEANSLATE_ENABLED` is set to `true`. It also attempts to reset the member's `first_name`, `email`, and `postal_code` but for now we'll need to manually reset those in Mobile Commons by editing the profile~~
* Adds a `msg_searching_by_zip` configuration property to inform a donor (both first time and returning) that we're finding a project within their zip code.
    * Supports MoCo Liquid style variable for postcode: A `msg_searching_by_zip` value of `'Finding a school in your zipcode {{postal_code}}...'` will render as "Finding a school in your zipcode 94117..." per calling String `replace` method in our `sendSMS` method.
* Fixes a bug saving the user's email. We confusingly also have a `email_address` custom field created in Mobile Commons, which is not the same as the default `email` field set on a profile.

#### How should this be reviewed?
* Pull down this branch and run locally
* Test the Searching By Zip message by posting to your local `/donations/donors-choose` endpoint with `phone`, `profile_first_name`, `profile_postal_code`, and `profile_email` body params set
* ~~Test the Clean Slate functionality by adding `DONORSCHOOSE_CLEANSLATE_ENABLED=true` to your .`env` file, and set a `DONORSCHOOSE_CLEANSLATE_KEYWORD`. Post the keyword locally as the `args` body param.~~

#### Any background context you want to provide?
We could just reset the profile through Mobile Commons, but this aims to make testing the entire flow quicker.

#### Relevant tickets
Closes more todos in #573 

#### Checklist
- [x] Tested on staging.
