### PR TITLE
Load DonorsChoose bot messages from new Gambit Jr. API

### DIFF
--- a/app/config/smsConfigsLoader.js
+++ b/app/config/smsConfigsLoader.js
@@ -5,7 +5,8 @@ app.ConfigName = {
   CAMPAIGN_START: 'campaign_start',
   CAMPAIGN_TRANSITIONS: 'start_campaign_transition',
   COMPETITIVE_STORIES: 'competitive_story',
-  DONORSCHOOSE: 'donorschoose_bots',
+  DONORSCHOOSE: 'donorschoose',
+  DONORSCHOOSE_BOTS: 'donorschoose_bots',
   REPORTBACK: 'reportback',
   TIPS: 'tips',
   YES_NO_PATHS: 'yes_no_path'
@@ -16,6 +17,7 @@ var connectionOperations = require('./connectionOperations')
   , configModelArray = [
       rootRequire('app/lib/ds-routing/config/tipsConfigModel')(connectionConfig)
     , rootRequire('app/lib/donations/models/donorsChooseBotModel')(connectionConfig)
+    , rootRequire('app/lib/donations/models/donorsChooseConfigModel')(connectionConfig)
     , rootRequire('app/lib/ds-routing/config/campaignStartConfigModel')(connectionConfig)
     , rootRequire('app/lib/ds-routing/config/startCampaignTransitionsConfigModel')(connectionConfig)
     , rootRequire('app/lib/ds-routing/config/yesNoPathsConfigModel')(connectionConfig)

--- a/app/config/smsConfigsLoader.js
+++ b/app/config/smsConfigsLoader.js
@@ -5,7 +5,7 @@ app.ConfigName = {
   CAMPAIGN_START: 'campaign_start',
   CAMPAIGN_TRANSITIONS: 'start_campaign_transition',
   COMPETITIVE_STORIES: 'competitive_story',
-  DONORSCHOOSE: 'donorschoose',
+  DONORSCHOOSE: 'donorschoose_bots',
   REPORTBACK: 'reportback',
   TIPS: 'tips',
   YES_NO_PATHS: 'yes_no_path'
@@ -15,7 +15,7 @@ var connectionOperations = require('./connectionOperations')
   , connectionConfig = require('./connectionConfig')
   , configModelArray = [
       rootRequire('app/lib/ds-routing/config/tipsConfigModel')(connectionConfig)
-    , rootRequire('app/lib/donations/models/donorsChooseConfigModel')(connectionConfig)
+    , rootRequire('app/lib/donations/models/donorsChooseBotModel')(connectionConfig)
     , rootRequire('app/lib/ds-routing/config/campaignStartConfigModel')(connectionConfig)
     , rootRequire('app/lib/ds-routing/config/startCampaignTransitionsConfigModel')(connectionConfig)
     , rootRequire('app/lib/ds-routing/config/yesNoPathsConfigModel')(connectionConfig)

--- a/app/lib/donations/controllers/DonorsChooseDonationController.js
+++ b/app/lib/donations/controllers/DonorsChooseDonationController.js
@@ -382,7 +382,7 @@ DonorsChooseDonationController.prototype.respondWithSuccess = function(member, p
   var customFields = {};
   customFields[DONATION_COUNT_FIELDNAME] = donationCount + 1;
 
-  var firstMessage = self.dcConfig.msg_donation_success + project.schoolName + ".";
+  var firstMessage = self.dcConfig.msg_donation_success + ' ' + project.schoolName + ".";
   self.endChat(member, firstMessage);
 
   setTimeout(function() {
@@ -394,7 +394,7 @@ DonorsChooseDonationController.prototype.respondWithSuccess = function(member, p
     shortenLink(project.url, function(shortenedLink) {
       logger.log('debug', 'dc.sendSuccessMessages user:%s shortenedLink:%s', 
         member.phone, shortenedLink);
-      var thirdMessage = self.dcConfig.msg_project_link + shortenedLink;
+      var thirdMessage = self.dcConfig.msg_project_link + ' ' + shortenedLink;
       self.endChat(member, thirdMessage, customFields);
     });
   }, 2 * END_MESSAGE_DELAY);
@@ -433,11 +433,10 @@ function getDonationCount(member) {
 }
 
 /**
- * Queries DonorsChoose API to find a STEM project by zip and sends the
- * project details back to the user.
+ * Queries Gambit Jr. API to sync donorschoose_bots config documents.
  *
- * @see https://data.donorschoose.org/docs/project-listing/json-requests/
- *
+ * @param {object} req Express request
+ * @param {object} res Express response
  */
 DonorsChooseDonationController.prototype.syncBotConfig = function(req, res) {
   var self = this;

--- a/app/lib/donations/controllers/DonorsChooseDonationController.js
+++ b/app/lib/donations/controllers/DonorsChooseDonationController.js
@@ -440,10 +440,10 @@ function getDonationCount(member) {
  * @param {object} req Express request
  * @param {object} res Express response
  */
-DonorsChooseDonationController.prototype.syncBotConfig = function(req, res) {
+DonorsChooseDonationController.prototype.syncBotConfigs = function(req, res) {
   var self = this;
-  if (!req.body.apiKey || req.body.apiKey !== process.env.GAMBIT_API_KEY) {
-    res.status(403).send('Invalid or missing apiKey.');
+  if (!req.body.api_key || req.body.api_key !== process.env.GAMBIT_API_KEY) {
+    res.status(403).send('Invalid api_key.');
     return;
   }
   var url = 'http://dev-gambit-jr.pantheonsite.io/wp-json/wp/v2/donorschoose_bots/';
@@ -472,18 +472,19 @@ DonorsChooseDonationController.prototype.syncBotConfig = function(req, res) {
     var bot, configDoc, propertyName;
     for (var i = 0; i < bots.length; i++) {
       bot = bots[i];
-      configDoc = app.getConfig(app.ConfigName.DONORSCHOOSE_BOT, bot.id);
+      configDoc = app.getConfig(app.ConfigName.DONORSCHOOSE_BOTS, bot.id);
       if (!configDoc) {
-        logger.log('info', 'dc.syncBotConfig doc not found for id:%s', bot.id);
+        logger.log('info', 'dc.syncBotConfigs doc not found for id:%s', bot.id);
         continue;
       }
       for (var j = 0; j < propertyNames.length; j++) {
         propertyName = propertyNames[j];
         configDoc[propertyName] = bot[propertyName];
       }
+      configDoc.name = bot.title;
       configDoc.refreshed_at = Date.now();
       configDoc.save();
-      logger.log('info', 'dc.syncBotConfig success for id:%s', bot.id);
+      logger.log('info', 'dc.syncBotConfigs success for id:%s', bot.id);
     }
     res.send();
   });

--- a/app/lib/donations/controllers/DonorsChooseDonationController.js
+++ b/app/lib/donations/controllers/DonorsChooseDonationController.js
@@ -39,8 +39,10 @@ var connectionOperations = rootRequire('app/config/connectionOperations');
 var donationModel = require('../models/donorsChooseDonationModel')(connectionOperations);
 
 function DonorsChooseDonationController() {
+  var mocoCampaignId = process.env.DONORSCHOOSE_MOCO_CAMPAIGN_ID;
+  this.mocoConfig = app.getConfig(app.ConfigName.DONORSCHOOSE, mocoCampaignId);
   var botId = process.env.DONORSCHOOSE_BOT_ID;
-  this.dcConfig = app.getConfig(app.ConfigName.DONORSCHOOSE, botId); 
+  this.bot = app.getConfig(app.ConfigName.DONORSCHOOSE_BOTS, botId);
 };
 
 /**
@@ -49,7 +51,7 @@ function DonorsChooseDonationController() {
  * @see sendSMS(member, optInPath, messageText, customFields)
  */
 DonorsChooseDonationController.prototype.chat = function(member, msgText, profileFields) {
-  sendSMS(member, this.dcConfig.oip_chat, msgText, profileFields);
+  sendSMS(member, this.mocoConfig.oip_chat, msgText, profileFields);
 }
 
 /**
@@ -58,14 +60,14 @@ DonorsChooseDonationController.prototype.chat = function(member, msgText, profil
  * @see sendSMS(member, optInPath, messageText, customFields)
  */
 DonorsChooseDonationController.prototype.endChat = function(member, msgText, profileFields) {
-  sendSMS(member, this.dcConfig.oip_end_chat, msgText, profileFields);
+  sendSMS(member, this.mocoConfig.oip_end_chat, msgText, profileFields);
 }
 
 /**
  * Sends SMS message with generic failure text and ends conversation.
  */
 DonorsChooseDonationController.prototype.endChatWithFail = function(member) {
-  this.endChat(member, this.dcConfig.msg_error_generic);
+  this.endChat(member, this.bot.msg_error_generic);
 }
 
 DonorsChooseDonationController.prototype.chatbot = function(request, response) {
@@ -94,23 +96,23 @@ DonorsChooseDonationController.prototype.chatbot = function(request, response) {
   if (getDonationCount(member) >= MAX_DONATIONS_ALLOWED) {
     logger.log('info', 'dc.chat msg_max_donations_reached user:%s', 
       member.phone);
-    self.endChat(member, self.dcConfig.msg_max_donations_reached);
+    self.endChat(member, self.bot.msg_max_donations_reached);
     return;
   }
 
   if (!member.profile_postal_code) {
 
     if (!firstWord) {
-      self.chat(member, self.dcConfig.msg_ask_zip);
+      self.chat(member, self.bot.msg_ask_zip);
       return;
     }
 
     if (!stringValidator.isValidZip(firstWord)) {
-      self.chat(member, self.dcConfig.msg_invalid_zip);
+      self.chat(member, self.bot.msg_invalid_zip);
       return;
     }
 
-    self.chat(member, self.dcConfig.msg_ask_first_name,
+    self.chat(member, self.bot.msg_ask_first_name,
       {postal_code: firstWord});
     return;
 
@@ -119,16 +121,16 @@ DonorsChooseDonationController.prototype.chatbot = function(request, response) {
   if (!member.profile_first_name) {
 
     if (!firstWord) {
-      self.chat(member, self.dcConfig.msg_ask_first_name);
+      self.chat(member, self.bot.msg_ask_first_name);
       return;
     }
 
     if (stringValidator.containsNaughtyWords(firstWord)) {
-      self.chat(member, self.dcConfig.msg_invalid_first_name);
+      self.chat(member, self.bot.msg_invalid_first_name);
       return;
     }
 
-    self.chat(member, self.dcConfig.msg_ask_email, {first_name: firstWord});
+    self.chat(member, self.bot.msg_ask_email, {first_name: firstWord});
     return;
 
   }
@@ -136,12 +138,12 @@ DonorsChooseDonationController.prototype.chatbot = function(request, response) {
   if (!member.profile_email) {
 
     if (!firstWord) {
-      self.chat(member, self.dcConfig.msg_ask_email);
+      self.chat(member, self.bot.msg_ask_email);
       return;
     }
 
     if (!stringValidator.isValidEmail(firstWord)) {
-      self.chat(member, self.dcConfig.msg_invalid_email);
+      self.chat(member, self.bot.msg_invalid_email);
       return;
     }
 
@@ -162,7 +164,7 @@ DonorsChooseDonationController.prototype.chatbot = function(request, response) {
  */
 DonorsChooseDonationController.prototype.findProjectAndRespond = function(member, customFields) {
   var self = this;
-  self.endChat(member, this.dcConfig.msg_search_start, customFields);
+  self.endChat(member, this.bot.msg_search_start, customFields);
 
   logger.log('debug', 'dc.findProjectAndRespond user:%s zip:%s', member.phone,
     member.profile_postal_code);
@@ -191,7 +193,7 @@ DonorsChooseDonationController.prototype.findProjectAndRespond = function(member
       if (!dcResponse.proposals || dcResponse.proposals.length == 0) {
         // If no proposals, could potentially prompt user to try different zip.
         // For now, send back error message per existing functionality.
-        self.endChat(member, this.dcConfig.msg_search_no_results);
+        self.endChat(member, this.bot.msg_search_no_results);
         logger.error('dc.findProject no results for zip:%s user:%s', zip, 
           mobileNumber);
         return;
@@ -382,7 +384,7 @@ DonorsChooseDonationController.prototype.respondWithSuccess = function(member, p
   var customFields = {};
   customFields[DONATION_COUNT_FIELDNAME] = donationCount + 1;
 
-  var firstMessage = self.dcConfig.msg_donation_success + ' ' + project.schoolName + ".";
+  var firstMessage = self.bot.msg_donation_success + ' ' + project.schoolName + ".";
   self.endChat(member, firstMessage);
 
   setTimeout(function() {
@@ -394,7 +396,7 @@ DonorsChooseDonationController.prototype.respondWithSuccess = function(member, p
     shortenLink(project.url, function(shortenedLink) {
       logger.log('debug', 'dc.sendSuccessMessages user:%s shortenedLink:%s', 
         member.phone, shortenedLink);
-      var thirdMessage = self.dcConfig.msg_project_link + ' ' + shortenedLink;
+      var thirdMessage = self.bot.msg_project_link + ' ' + shortenedLink;
       self.endChat(member, thirdMessage, customFields);
     });
   }, 2 * END_MESSAGE_DELAY);
@@ -465,14 +467,12 @@ DonorsChooseDonationController.prototype.syncBotConfig = function(req, res) {
       'msg_project_link',
       'msg_max_donations_reached',
       'msg_search_start',
-      'msg_search_no_results',
-      'oip_chat',
-      'oip_end_chat'
+      'msg_search_no_results'
     ];
     var bot, configDoc, propertyName;
     for (var i = 0; i < bots.length; i++) {
       bot = bots[i];
-      configDoc = app.getConfig(app.ConfigName.DONORSCHOOSE, bot.id);
+      configDoc = app.getConfig(app.ConfigName.DONORSCHOOSE_BOT, bot.id);
       if (!configDoc) {
         logger.log('info', 'dc.syncBotConfig doc not found for id:%s', bot.id);
         continue;

--- a/app/lib/donations/donations.js
+++ b/app/lib/donations/donations.js
@@ -17,4 +17,14 @@ router.post('/donors-choose/', function(request, response) {
   }
 });
 
+router.post('/donors-choose/sync', function(request, response) {
+  var controller = new DonorsChoose();
+  if (controller) {
+    controller.syncBotConfig(request, response);
+  }
+  else {
+    response.status(404).send('Request not available for: ' + request.params.controller);
+  }
+});
+
 module.exports = router;

--- a/app/lib/donations/donations.js
+++ b/app/lib/donations/donations.js
@@ -20,7 +20,7 @@ router.post('/donors-choose/', function(request, response) {
 router.post('/donors-choose/sync', function(request, response) {
   var controller = new DonorsChoose();
   if (controller) {
-    controller.syncBotConfig(request, response);
+    controller.syncBotConfigs(request, response);
   }
   else {
     response.status(404).send('Request not available for: ' + request.params.controller);

--- a/app/lib/donations/models/donorsChooseBotModel.js
+++ b/app/lib/donations/models/donorsChooseBotModel.js
@@ -7,7 +7,6 @@ var mongoose = require('mongoose');
 var schema = new mongoose.Schema({
   // Corresponds to the donorschoose_bot ID in Gambit Jr. API.
   _id: Number,
-  name: String,
   // Last refresh from Gambit Jr. API.
   refreshed_at: Date,
   // Donation_bot properties are loaded from Gambit Jr. API.

--- a/app/lib/donations/models/donorsChooseBotModel.js
+++ b/app/lib/donations/models/donorsChooseBotModel.js
@@ -5,15 +5,16 @@
 var mongoose = require('mongoose');
 
 var schema = new mongoose.Schema({
-
-  // Corresponds to Mobile Commons Campaign ID used for Donation conversation.
-  // v1 Used numeric convetion 101 for 2014 SS, 201 for 2015 SS.
+  // Corresponds to the donorschoose_bot ID in Gambit Jr. API.
   _id: Number,
+  // Last refresh from Gambit Jr. API.
+  refreshed_at: Date,
 
-  // Contextual information about Campaign, used for Compose admin readability. 
-  __comments: String,
+  // Correponds to the Mobile Commons Opt-in Paths to send SMS messages to.
+  oip_chat: Number,
+  oip_end_chat: Number,
 
-  // Chatbot config:
+  // Cached donation_bot message values from Gambit Jr. API.
   msg_ask_email: String,
   msg_ask_first_name: String,
   msg_ask_zip: String,
@@ -25,12 +26,9 @@ var schema = new mongoose.Schema({
   msg_project_link: String,
   msg_max_donations_reached: String,
   msg_search_start: String,
-  msg_search_no_results: String,
-  oip_chat: Number,
-  oip_end_chat: Number
-
+  msg_search_no_results: String
 });
 
 module.exports = function(connection) {
-  return connection.model(app.ConfigName.DONORSCHOOSE, schema, 'donorschoose');
+  return connection.model(app.ConfigName.DONORSCHOOSE, schema, 'donorschoose_bots');
 };

--- a/app/lib/donations/models/donorsChooseBotModel.js
+++ b/app/lib/donations/models/donorsChooseBotModel.js
@@ -7,14 +7,10 @@ var mongoose = require('mongoose');
 var schema = new mongoose.Schema({
   // Corresponds to the donorschoose_bot ID in Gambit Jr. API.
   _id: Number,
+  name: String,
   // Last refresh from Gambit Jr. API.
   refreshed_at: Date,
-
-  // Correponds to the Mobile Commons Opt-in Paths to send SMS messages to.
-  oip_chat: Number,
-  oip_end_chat: Number,
-
-  // Cached donation_bot message values from Gambit Jr. API.
+  // Donation_bot properties are loaded from Gambit Jr. API.
   msg_ask_email: String,
   msg_ask_first_name: String,
   msg_ask_zip: String,
@@ -30,5 +26,5 @@ var schema = new mongoose.Schema({
 });
 
 module.exports = function(connection) {
-  return connection.model(app.ConfigName.DONORSCHOOSE, schema, 'donorschoose_bots');
+  return connection.model(app.ConfigName.DONORSCHOOSE_BOTS, schema, 'donorschoose_bots');
 };

--- a/app/lib/donations/models/donorsChooseConfigModel.js
+++ b/app/lib/donations/models/donorsChooseConfigModel.js
@@ -1,0 +1,18 @@
+/**
+ * Model for the DonorsChoose SMS configuration document. Each 
+ * object corresponds to one DonorsChoose donation endgame flow.
+ */
+var mongoose = require('mongoose');
+
+var schema = new mongoose.Schema({
+  // Mobile Commons Campaign ID for the Donation campaign.
+  // e.g. https://secure.mcommons.com/campaigns/[id]
+  _id: Number,
+  __comments: String,
+  oip_chat: Number,
+  oip_end_chat: Number
+});
+
+module.exports = function(connection) {
+  return connection.model(app.ConfigName.DONORSCHOOSE, schema, 'donorschoose');
+};


### PR DESCRIPTION
#### What's this PR do?
* Stores our chatbot `msg` properties into a new `donorschoose_bots` collection in `config` DB, instead of `donorschoose` collection -- separating chatbot copy from Mobile Commons configuration.

    * Refactors `this.dcConfig` as 2 new properties: `this.mocoConfig` and `this.bot`

    * Adds corresponding `DONORSCHOOSE_BOT_ID` environment variable to set the `donorschoose_bot` to use during our current `DONORSCHOOSE_MOCO_CAMPAIGN_ID`

* Adds a `POST /donations/donors-choose/sync` endpoint which queries the new Gambit Jr. API endpoint `donorschoose_bots` to populate `msg_` values in existing `donorschoose_bots` config documents

    * Request must include an `api_key` in request body, must match new config variable `GAMBIT_API_KEY` (refs #576)

    * Does not automatically create a new `donorschoose_bots` document if a new `donorschoose_bot` has been found in the Gambit JR API, for now we must manually create the coprresponding document for the new ID in `config` / `donorschoose_bots` to sync



#### How should this be reviewed?
This branch has been deployed to staging. There are two `donorschoose_bot` entries created in the Gambit Jr API, switch the `DONORSCHOOSE_BOT_ID` between 18 (Staging) and 31 (Production) to verify different copy is sent during the Donation Flow when changed.

#### Any background context you want to provide?
Initially wasn't planning to build out an API to configure the DonorsChoose bot messages, figured we'd just edit the JSON through compose admin as we've been doing. Building out the backend with WordPress + the Pods and WP Rest API plugins made it relatively quick to get something up and running (with admin/editor authentication) in a day.

#### Relevant tickets
Closes code todo for Staging + Prod environments in #539 by setting up 2 separate Science Sleuth Donation Flow Mobile Commons campaigns (1 for staging and 1 for production). Each has a corresponding DonorsChoose chatbot in Gambit Jr. to maintain the copy of each message we send within the flow.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [x] Tested on staging.