### PR TITLE
DonorsChooseDonationController cleanup

### DIFF
--- a/app/lib/donations/controllers/DonorsChooseDonationController.js
+++ b/app/lib/donations/controllers/DonorsChooseDonationController.js
@@ -19,7 +19,9 @@ if (process.env.NODE_ENV != 'production') {
 
 var DONATION_AMOUNT = (process.env.DONORSCHOOSE_DONATION_AMOUNT || 10);
 var DONATION_COUNT_FIELDNAME = 'ss2016_donation_count';
+var DONORSCHOOSE_BOT_ID = process.env.DONORSCHOOSE_BOT_ID;
 var MAX_DONATIONS_ALLOWED = (process.env.DONORSCHOOSE_MAX_DONATIONS_ALLOWED || 5);
+var MOCO_CAMPAIGN_ID = process.env.DONORSCHOOSE_MOCO_CAMPAIGN_ID;
 
 var Q = require('q');
 var requestHttp = require('request');
@@ -37,10 +39,8 @@ var donationModel = require('../models/donorsChooseDonationModel')(connectionOpe
  * @constructor
  */
 function DonorsChooseDonationController() {
-  var mocoCampaignId = process.env.DONORSCHOOSE_MOCO_CAMPAIGN_ID;
-  this.mocoConfig = app.getConfig(app.ConfigName.DONORSCHOOSE, mocoCampaignId);
-  var botId = process.env.DONORSCHOOSE_BOT_ID;
-  this.bot = app.getConfig(app.ConfigName.DONORSCHOOSE_BOTS, botId);
+  this.mocoConfig = app.getConfig(app.ConfigName.DONORSCHOOSE, MOCO_CAMPAIGN_ID);
+  this.bot = app.getConfig(app.ConfigName.DONORSCHOOSE_BOTS, DONORSCHOOSE_BOT_ID);
 };
 
 /**
@@ -359,17 +359,19 @@ DonorsChooseDonationController.prototype.postDonation = function(member, project
     function createDonationDoc(donation) {
       var donationLogData = {
         mobile: member.phone,
-        email: member.profile_email,
-        first_name: member.profile_first_name,
-        postal_code: member.profile_postal_code,
-        proposal_id: project.id,
+        profile_email: member.profile_email,
+        profile_first_name: member.profile_first_name,
+        profile_postal_code: member.profile_postal_code,
+        moco_campaign_id: MOCO_CAMPAIGN_ID,
+        donorschoose_bot_id: DONORSCHOOSE_BOT_ID,
         donation_id: donation.donationId,
         donation_amount: DONATION_AMOUNT,
-        remaining_amount: donation.remainingProposalAmount,
+        proposal_id: project.id,
+        proposal_remaining_amount: donation.remainingProposalAmount,
+        proposal_url: project.url,
         school_name: project.schoolName,
         school_city: project.city,
-        school_state: project.state,
-        url: project.url
+        school_state: project.state
       };
       donationModel.create(donationLogData).then(function(doc) {
         logger.log('debug', 'dc.createDonationDoc success:%s', donation);

--- a/app/lib/donations/controllers/DonorsChooseDonationController.js
+++ b/app/lib/donations/controllers/DonorsChooseDonationController.js
@@ -153,7 +153,7 @@ DonorsChooseDonationController.prototype.chatbot = function(request, response) {
       return;
     }
 
-    self.findProjectAndRespond(member, {email: firstWord});
+    self.findProjectAndRespond(member, firstWord);
     return;
 
   }
@@ -164,16 +164,24 @@ DonorsChooseDonationController.prototype.chatbot = function(request, response) {
 /**
  * Queries DonorsChoose API to find a project, donate to it, and respond back.
  * @param {object} member
- * @param {object} profileFields
+ * @param {string} [email] - If passed, save email to profile.
  */
-DonorsChooseDonationController.prototype.findProjectAndRespond = function(member, profileFields) {
+DonorsChooseDonationController.prototype.findProjectAndRespond = function(member, email) {
   var self = this;
+
+  var profileFields = null;
+  if (typeof email === 'string') {
+    // We'll need member.profile_email later when we write donation document.
+    member.profile_email = email.toLowerCase();
+    profileFields = {email: member.profile_email};
+  }
   self.endChat(member, this.bot.msg_search_start, profileFields);
 
   logger.log('debug', 'dc.findProjectAndRespond user:%s zip:%s', member.phone,
     member.profile_postal_code);
   var mobileNumber = member.phone;
   var zip = member.profile_postal_code;
+
 
   // @see https://data.donorschoose.org/docs/project-listing/json-requests/
   var requestUrlString = donorsChooseProposalsHost + 'common/json_feed.html';
@@ -418,7 +426,7 @@ DonorsChooseDonationController.prototype.respondWithSuccess = function(member, p
  * @param {object} member
  * @param {number} optInPath - Should contain {{slothbot_response}} as Liquid
  * @param {string} msgTxt - Value to save to our slothboth_response Custom Field
- * @param {object|null} profileFields - Key/values to save as MoCo Custom Fields
+ * @param {object} [profileFields] - Key/values to save as MoCo Custom Fields
  */
 function sendSMS(member, optInPath, msgTxt, profileFields) {
   var mobileNumber = smsHelper.getNormalizedPhone(member.phone);

--- a/app/lib/donations/controllers/DonorsChooseDonationController.js
+++ b/app/lib/donations/controllers/DonorsChooseDonationController.js
@@ -438,7 +438,11 @@ function sendSMS(member, optInPath, msgTxt, profileFields) {
  * @return {number}
  */
 function getDonationCount(member) {
-  return parseInt(member['profile_' + DONATION_COUNT_FIELDNAME]);
+  var count = parseInt(member['profile_' + DONATION_COUNT_FIELDNAME]);
+  if (!count) {
+    return 0;
+  }
+  return count;
 }
 
 /**

--- a/app/lib/donations/controllers/DonorsChooseDonationController.js
+++ b/app/lib/donations/controllers/DonorsChooseDonationController.js
@@ -220,24 +220,6 @@ DonorsChooseDonationController.prototype.findProjectAndRespond = function(member
 }
 
 /**
- * Decodes proposal returned from DonorsChoose API.
- * @param {object} proposal
- * @return {object}
- */
-function decodeDonorsChooseProposal(proposal) {
-  var entities = new Entities();
-  return {
-    id: proposal.id,
-    description: entities.decode(proposal.fulfillmentTrailer),
-    city: entities.decode(proposal.city),
-    state: entities.decode(proposal.state),
-    schoolName: entities.decode(proposal.schoolName),
-    teacherName: entities.decode(proposal.teacherName),
-    url: proposal.proposalURL
-  };
-}
-
-/**
  * Posts donation to DonorsChoose API for given project, behalf of given member.
  * @param {object} member
  * @param {object} project
@@ -460,6 +442,24 @@ function getDonorsChooseProposalsQueryURL(zip) {
   url += '&max=1';
   url += '&zip=' + zip;
   return url;
+}
+
+/**
+ * Decodes proposal returned from DonorsChoose API.
+ * @param {object} proposal
+ * @return {object}
+ */
+function decodeDonorsChooseProposal(proposal) {
+  var entities = new Entities();
+  return {
+    id: proposal.id,
+    description: entities.decode(proposal.fulfillmentTrailer),
+    city: entities.decode(proposal.city),
+    state: entities.decode(proposal.state),
+    schoolName: entities.decode(proposal.schoolName),
+    teacherName: entities.decode(proposal.teacherName),
+    url: proposal.proposalURL
+  };
 }
 
 /**

--- a/app/lib/donations/models/donorsChooseBotModel.js
+++ b/app/lib/donations/models/donorsChooseBotModel.js
@@ -1,6 +1,10 @@
 /**
- * Model for the DonorsChoose SMS configuration document. Each 
- * object corresponds to one DonorsChoose donation endgame flow.
+ * Model for Gambit Jr. API donorschoose_bot. 
+ * Each document contains content to use for each message sent in
+ * DonorsChoose donation endgame flow.
+ *
+ * We keep a cache of each donorschoose_bot to avoid making
+ * more network connections to the Gambir Jr. API
  */
 var mongoose = require('mongoose');
 
@@ -9,7 +13,6 @@ var schema = new mongoose.Schema({
   _id: Number,
   // Last refresh from Gambit Jr. API.
   refreshed_at: Date,
-  // Donation_bot properties are loaded from Gambit Jr. API.
   msg_ask_email: String,
   msg_ask_first_name: String,
   msg_ask_zip: String,

--- a/app/lib/donations/models/donorsChooseConfigModel.js
+++ b/app/lib/donations/models/donorsChooseConfigModel.js
@@ -1,6 +1,6 @@
 /**
  * Model for the DonorsChoose SMS configuration document. Each 
- * object corresponds to one DonorsChoose donation endgame flow.
+ * object corresponds to one DonorsChoose Donation Mobile Commons campaign.
  */
 var mongoose = require('mongoose');
 

--- a/app/lib/donations/models/donorsChooseDonationModel.js
+++ b/app/lib/donations/models/donorsChooseDonationModel.js
@@ -9,19 +9,23 @@ var schema = new mongoose.Schema({
 
   // Member profile information:
   mobile: {type: String, index: true},
-  email: String,
-  first_name: String,
-  postal_code: String,
+  profile_email: String,
+  profile_first_name: String,
+  profile_postal_code: String,
 
-  // Donation transaction information:
+  // Keep config info for record-keeping:
+  moco_campaign_id: Number,
+  donorschoose_bot_id: Number,
+
+  // DonorsChoose information:
   donation_id: Number,
-  proposal_id: Number,
   donation_amount: Number,
-  remaining_amount: Number,
+  proposal_id: Number,
+  proposal_url: String,
+  proposal_remaining_amount: Number,
   school_name: String,
   school_city: String,
-  school_state: String,
-  url: String
+  school_state: String
 
 })
 


### PR DESCRIPTION
#### What's this PR do?
* Fixes a bug setting the Donation Count profile field upon first donation
* Adds  `DONORSCHOOSE_BOT_ID` and `DONORSCHOOSE_MOCO_CAMPAIGN_ID` constants set from environment variables, stores in the `donorschoose_donations` collection
* Adds comments for functions, general code cleanup  (refs #573)

#### How should this be reviewed?
* Remove the value from your Donation Count profile field (we're using `ss2016_donation_count` for this year's run) and then test locally with this branch.
* Confirm MoCo Campaign ID and DonorsChoose Bot ID are stored upon successful donation

#### Relevant tickets
Fixes #581, #582 

#### Checklist
- [x] Tested on staging.
