### PR TITLE
DonorsChoose success message copy change

### DIFF
--- a/api/controllers/DonorsChooseBotController.js
+++ b/api/controllers/DonorsChooseBotController.js
@@ -380,7 +380,7 @@ DonorsChooseBotController.prototype.respondWithSuccess = function(member, projec
 
   var delay = 2500;
   setTimeout(function() {
-    var secondMessage = '@' + project.teacherName + ': Thx! ' + project.description;
+    var secondMessage = project.teacherName + ' says: Thanks! ' + project.description;
     self.endChat(member, secondMessage);
   }, delay);
 


### PR DESCRIPTION
#### What's this PR do?
* Changes hardcoded "Teacher says" copy in 2nd success message sent upon completing a DonorsChoose donation.

#### How should this be reviewed?

Locally:
Post required params to `/v1/chatbot?bot_type=donorschoose` to confirm copy change.

Staging:
Text in keyword for staging DonorsChoose campaign upon deploy to staging server.

#### Any background context you want to provide?
Hardcoding this copy was one of the tradeoffs made when we made the move from configuring our message content from editing Mobile Commons OIP Conversations  into the Gambit Jr. API.  We could potentially add this to our own internal `{{postal_code}}` Liquid-esque logic we're doing [here](https://github.com/DoSomething/gambit/blob/280d095765cd58261ef2217e4997c8279d353369/api/controllers/DonorsChooseBotController.js#L410), but it also seems easy enough to keep hardcoded for now, since we don't run multiple DonorsChoose campaigns at a time. 

#### Relevant tickets
Fixes #601

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Tested on staging.
