### PR TITLE
Adds mobilecommons.chatbot function to DRY

### DIFF
--- a/api/controllers/DonorsChooseBotController.js
+++ b/api/controllers/DonorsChooseBotController.js
@@ -47,7 +47,7 @@ function DonorsChooseBotController() {
  * @param {object} profileFields - key/value MoCo Custom Fields to update
  */
 DonorsChooseBotController.prototype.chat = function(member, msgText, profileFields) {
-  sendSMS(member, this.mocoCampaign.oip_chat, msgText, profileFields);
+  mobilecommons.chatbot(member, this.mocoCampaign.oip_chat, msgText, profileFields);
 }
 
 /**
@@ -57,7 +57,7 @@ DonorsChooseBotController.prototype.chat = function(member, msgText, profileFiel
  * @param {object} profileFields - key/value MoCo Custom Fields to update
  */
 DonorsChooseBotController.prototype.endChat = function(member, msgText, profileFields) {
-  sendSMS(member, this.mocoCampaign.oip_success, msgText, profileFields);
+  mobilecommons.chatbot(member, this.mocoCampaign.oip_success, msgText, profileFields);
 }
 
 /**
@@ -65,7 +65,7 @@ DonorsChooseBotController.prototype.endChat = function(member, msgText, profileF
  * @param {object} member - MoCo request.body
  */
 DonorsChooseBotController.prototype.endChatWithFail = function(member) {
-  sendSMS(member, this.mocoCampaign.oip_error, this.bot.msg_error_generic);
+  mobilecommons.chatbot(member, this.mocoCampaign.oip_error, this.bot.msg_error_generic);
 }
 
 /**
@@ -392,31 +392,6 @@ DonorsChooseBotController.prototype.respondWithSuccess = function(member, projec
       self.endChat(member, thirdMessage, customFields);
     });
   }, 2 * delay);
-}
-
-/**
- * Posts MoCo profile_update to save msgTxt to member profile and send as SMS.
- * @param {object} member
- * @param {number} optInPath - Should contain {{slothbot_response}} as Liquid
- * @param {string} msgTxt - Value to save to our slothboth_response Custom Field
- * @param {object} [profileFields] - Key/values to save as MoCo Custom Fields
- */
-function sendSMS(member, optInPath, msgTxt, profileFields) {
-  if (typeof optInPath === 'undefined') {
-    logger.error('dc.sendSMS undefined optInPath user:%s msgText:%s', member, msgTxt);
-    return;
-  }
-  var mobileNumber = helpers.getNormalizedPhone(member.phone);
-  var msgTxt = msgTxt.replace('{{postal_code}}', member.profile_postal_code);
-
-  if (typeof profileFields === 'undefined') {
-    profileFields = {gambit_chatbot_response: msgTxt};
-  }
-  else {
-    profileFields.gambit_chatbot_response = msgTxt;
-  }
-
-  mobilecommons.profile_update(mobileNumber, optInPath, profileFields);
 }
 
 /**

--- a/api/controllers/SlothBotController.js
+++ b/api/controllers/SlothBotController.js
@@ -25,7 +25,7 @@ SlothBotController.prototype.chatbot = function(request, response) {
   reply += 'You just told me:\n\n' + incomingMsg;
 
   // @todo Move hardcoded value into environment variable.
-  mobilecommons.profile_update(phone, 210045, {gambit_chatbot_response: reply}); 
+  mobilecommons.chatbot(request.body, 210045, reply);
 }
 
 module.exports = SlothBotController;

--- a/lib/mobilecommons.js
+++ b/lib/mobilecommons.js
@@ -5,6 +5,7 @@
 var RequestRetry = require('node-request-retry');
 var logger = rootRequire('lib/logger');
 var emitter = rootRequire('lib/eventEmitter');
+var helpers = rootRequire('lib/helpers');
 var _ = require('underscore');
 
 
@@ -226,3 +227,32 @@ exports.optout = function(args) {
   requestRetry.setRetryConditions([400, 408, 500]);
   requestRetry.post(url, payload, callback);
 };
+
+/**
+ * Posts to a chatbot optInPath to send msgTxt to given member.
+ * @param {object} member
+ * @param {number} optInPath - Id of Opt-in path, needs to contain 
+ *     {{gambit_chatbot_response}} in Liquid to render our msgTxt
+ * @param {string} msgTxt - Message to send to our member
+ * @param {object} [profileFields] - Additional Key/value object to save as 
+ *     Mobile Commons Custom Fields on our member's profile.
+ */
+exports.chatbot = function(member, optInPath, msgTxt, profileFields) {
+  if (typeof optInPath === 'undefined') {
+    logger.error('dc.sendSMS undefined optInPath user:%s msgText:%s', member, msgTxt);
+    return;
+  }
+  var mobileNumber = helpers.getNormalizedPhone(member.phone);
+  // Check for any Liquid tokens to substitute.
+  // Currently only supporting postal_code.
+  var msgTxt = msgTxt.replace('{{postal_code}}', member.profile_postal_code);
+
+  if (typeof profileFields === 'undefined') {
+    profileFields = {gambit_chatbot_response: msgTxt};
+  }
+  else {
+    profileFields.gambit_chatbot_response = msgTxt;
+  }
+
+  this.profile_update(mobileNumber, optInPath, profileFields);
+}


### PR DESCRIPTION
#### What's this PR do?
* Moves the `/api/controllers/DonorsChooseBotController.sendSMS` function into our `/lib/mobilecommons` class as a new `chatbot` function to DRY setting the `gambit_chatbot_response` Mobile Commons Custom Field value used for chatbot Mobile Commons campaigns.
* Updates `/api/controllers/SlothBotController` accordingly to DRY

#### How should this be reviewed?
Test that our staging DonorsChooseBot and SlothBot Mobile Commons Campaigns are operational upon deploy to staging. 

#### Any background context you want to provide?
Will use this to begin prototyping a DS Campaign Bot to eventually deprecate our `api/legacy` endpoints.

#### Related tickets
#463 

#### Checklist
- [x] Tested on staging.


