### PR TITLE
Starts on CampaignBot + ReportbackSubmissions

### DIFF
--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -51,14 +51,14 @@ CampaignBotController.prototype.onFindCampaign = function(err, res, body) {
 
   var rbInfo = campaign.reportback_info;
   var msgTxt;
-  if (this.request.query.start) {
-    msgTxt = '@flynn: You\'re signed up for ' + campaign.title + '.\n\n';
+  if (this.request.query.start || !this.request.body.args) {
+    msgTxt = '@stg: You\'re signed up for ' + campaign.title + '.\n\n';
     msgTxt += 'When completed, text back the total number of ' + rbInfo.noun;
     msgTxt += ' you have ' + rbInfo.verb + ' so far.';
   }
   else {
     var incomingMsg = parseInt(this.request.body.args);
-    msgTxt = '@flynn: Got you down for ' + incomingMsg;
+    msgTxt = '@stg: Got you down for ' + incomingMsg;
     msgTxt += ' ' + rbInfo.noun + ' ' + rbInfo.verb + '.';
     var created = Date.now();
     var submission = {

--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -1,0 +1,27 @@
+"use strict";
+
+var mobilecommons = rootRequire('lib/mobilecommons');
+var logger = rootRequire('lib/logger');
+
+/**
+ * CampaignBotController
+ * @constructor
+ */
+function CampaignBotController() {};
+
+/**
+ * Chatbot endpoint for DS Campaign Signup and Reportback.
+ * @param {object} request - Express request
+ * @param {object} response - Express response
+ */
+CampaignBotController.prototype.chatbot = function(request, response) {
+  var member = request.body;
+  var incomingMsg = request.body.args;
+  response.send();
+
+  var reply = '@flynn: Hi';
+
+  mobilecommons.chatbot(member, 213849, reply);
+}
+
+module.exports = CampaignBotController;

--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -26,7 +26,7 @@ CampaignBotController.prototype.chatbot = function(request, response) {
     return;
   }
   var context = {
-    member: member,
+    request: request,
     response: response
   };
   phoenix.campaignGet(this.campaignId, onFindCampaign.bind(context));
@@ -36,7 +36,7 @@ CampaignBotController.prototype.chatbot = function(request, response) {
  * Callback for successful loading of Campaign from Phoenix API.
  */
 function onFindCampaign(err, res, body) {
-  var member = this.member;
+  var member = this.request.body;
 
   var phoenixResponse = JSON.parse(body);
   var campaign = phoenixResponse.data;
@@ -45,9 +45,20 @@ function onFindCampaign(err, res, body) {
     return;
   }
   this.response.send();
-  var msgTxt = '@flynn: You signed up for ' + campaign.title;
+
   var rbInfo = campaign.reportback_info;
-  msgTxt += '\n\nHow many ' + rbInfo.noun + ' have you ' + rbInfo.verb + '?';
+  var msgTxt;
+  if (this.request.query.start) {
+    msgTxt = '@flynn: You\'re signed up for ' + campaign.title + '.\n\n';
+    msgTxt += 'When completed, text back the total number of ' + rbInfo.noun;
+    msgTxt += ' you have ' + rbInfo.verb + ' so far.';
+  }
+  else {
+    var incomingMsg = this.request.body.args;
+    msgTxt = '@flynn: Got you down for ' + incomingMsg;
+    msgTxt += ' ' + rbInfo.noun + ' ' + rbInfo.verb + '.';
+  }
+
   mobilecommons.chatbot(member, 213849, msgTxt);
 }
 

--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -60,16 +60,14 @@ CampaignBotController.prototype.onFindCampaign = function(err, res, body) {
     var incomingMsg = parseInt(this.request.body.args);
     msgTxt = '@stg: Got you down for ' + incomingMsg;
     msgTxt += ' ' + rbInfo.noun + ' ' + rbInfo.verb + '.';
-    var created = Date.now();
     var submission = {
-      _id: created,
-      created_at: created,
       campaign: parseInt(campaign.id),
       mobile: member.phone,
       quantity: incomingMsg
     }
     reportbackSubmissions.create(submission).then(function(doc) {
-      logger.debug('CampaignBot.reportbackSubmissions created:%s', submission);
+      logger.debug('campaignBot created reportbackSubmission._id:%s for:%s', 
+        doc['_id'], submission);
     });
   }
 

--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -46,6 +46,8 @@ function onFindCampaign(err, res, body) {
   }
   this.response.send();
   var msgTxt = '@flynn: You signed up for ' + campaign.title;
+  var rbInfo = campaign.reportback_info;
+  msgTxt += '\n\nHow many ' + rbInfo.noun + ' have you ' + rbInfo.verb + '?';
   mobilecommons.chatbot(member, 213849, msgTxt);
 }
 

--- a/api/models/ReportbackSubmission.js
+++ b/api/models/ReportbackSubmission.js
@@ -5,9 +5,7 @@ var mongoose = require('mongoose');
 
 var schema = new mongoose.Schema({
 
-  _id: Number,
-
-  created_at: Number,
+  created_at: {type: Date, default: Date.now},
 
   mobile: {type: String, index: true},
 

--- a/api/models/ReportbackSubmission.js
+++ b/api/models/ReportbackSubmission.js
@@ -1,0 +1,22 @@
+/**
+ * Stores each upsert submission posted to DS Reportback API.
+ */
+var mongoose = require('mongoose');
+
+var schema = new mongoose.Schema({
+
+  _id: Number,
+
+  created_at: Number,
+
+  mobile: {type: String, index: true},
+
+  campaign: {type: Number, index: true},
+
+  quantity: Number
+
+})
+
+module.exports = function(connection) {
+  return connection.model('reportback_submissions', schema);
+};

--- a/api/router.js
+++ b/api/router.js
@@ -4,6 +4,7 @@ var router = express.Router();
 var logger = rootRequire('lib/logger');
 var campaignRouter = require('./legacy/ds-routing');
 var reportbackRouter = require('./legacy/reportback');
+var CampaignBot = require('./controllers/CampaignBotController');
 var DonorsChooseBot = require('./controllers/DonorsChooseBotController');
 var Slothbot = require('./controllers/SlothBotController');
 
@@ -30,6 +31,9 @@ router.post('/v1/chatbot', function(request, response) {
 
   var controller;
   switch (request.query.bot_type) {
+    case 'campaign':
+      controller = new CampaignBot();
+      break;
     case 'donorschoose':
       controller = new DonorsChooseBot();
       break;

--- a/api/router.js
+++ b/api/router.js
@@ -32,7 +32,7 @@ router.post('/v1/chatbot', function(request, response) {
   var controller;
   switch (request.query.bot_type) {
     case 'campaign':
-      controller = new CampaignBot();
+      controller = new CampaignBot(request.query.campaign);
       break;
     case 'donorschoose':
       controller = new DonorsChooseBot();

--- a/documentation/endpoints/chatbot.md
+++ b/documentation/endpoints/chatbot.md
@@ -6,11 +6,18 @@ Currently hard-wired for usage in our Mobile Commons account to chat over SMS.
 POST /v1/chatbot
 ```
 
+**Headers**
+
+Name | Type | Description
+--- | --- | ---
+`x-gambit-api-key` | `string` | **Required.** Used to authenticate POST requests.
+
 **Parameters**
 
 Name | Type | Description
 --- | --- | ---
-`bot_type` | `string` | Type of bot to chat with, `donorschoose` or `slothbot`. Default: `slothbot`
+`bot_type` | `string` | Type of bot to chat with, `campaign`, `donorschoose` or `slothbot`. Default: `slothbot`
+`campaign` | `integer` | Required when `bot_type=campaign`, used to load Campaign from Phoenix API
 `start` | `boolean` | If set, the bot will begin a new conversation. Default: `false`
 
 **Input**

--- a/lib/mobilecommons.js
+++ b/lib/mobilecommons.js
@@ -245,7 +245,9 @@ exports.chatbot = function(member, optInPath, msgTxt, profileFields) {
   var mobileNumber = helpers.getNormalizedPhone(member.phone);
   // Check for any Liquid tokens to substitute.
   // Currently only supporting postal_code.
-  var msgTxt = msgTxt.replace('{{postal_code}}', member.profile_postal_code);
+  if (member.profile_postal_code) {
+    msgTxt = msgTxt.replace('{{postal_code}}', member.profile_postal_code);
+  }
 
   if (typeof profileFields === 'undefined') {
     profileFields = {gambit_chatbot_response: msgTxt};

--- a/lib/phoenix.js
+++ b/lib/phoenix.js
@@ -18,8 +18,8 @@ else {
 }
 
 module.exports = function() {
-  if (typeof global.dscontentapi === 'undefined') {
-    global.dscontentapi = {};
+  if (typeof global.phoenix === 'undefined') {
+    global.phoenix = {};
   }
 
   return {
@@ -107,8 +107,8 @@ function userGet(userData, callback) {
     method: 'GET',
     headers: {
       'Accept': 'application/json',
-      'Cookie': global.dscontentapi.session_name + '=' + global.dscontentapi.sessid,
-      'X-CSRF-Token': global.dscontentapi.token
+      'Cookie': global.phoenix.session_name + '=' + global.phoenix.sessid,
+      'X-CSRF-Token': global.phoenix.token
     }
   };
 
@@ -170,9 +170,9 @@ function onUserLogin(err, response, body) {
     logger.error(err);
   }
   else if (response && response.statusCode == 200) {
-    global.dscontentapi.sessid = body.sessid;
-    global.dscontentapi.session_name = body.session_name;
-    global.dscontentapi.token = body.token;
+    global.phoenix.sessid = body.sessid;
+    global.phoenix.session_name = body.session_name;
+    global.phoenix.token = body.token;
   }
   else {
     logger.error('Failed to authenticate to DS content API');
@@ -193,8 +193,8 @@ function userLogout(callback) {
     headers: {
       'Content-Type': 'application/json',
       'Accept': 'application/json',
-      'Cookie': global.dscontentapi.session_name + '=' + global.dscontentapi.sessid,
-      'X-CSRF-Token': global.dscontentapi.token
+      'Cookie': global.phoenix.session_name + '=' + global.phoenix.sessid,
+      'X-CSRF-Token': global.phoenix.token
     }
   };
 
@@ -226,7 +226,7 @@ function authToken(callback) {
     headers: {
       'Content-Type': 'application/json',
       'Accept': 'application/json',
-      'Cookie': global.dscontentapi.session_name + '=' + global.dscontentapi.sessid
+      'Cookie': global.phoenix.session_name + '=' + global.phoenix.sessid
     }
   };
 
@@ -244,10 +244,10 @@ function onAuthToken(err, response, body) {
   }
   else {
     if (typeof body === 'string') {
-      global.dscontentapi.token = JSON.parse(body).token;
+      global.phoenix.token = JSON.parse(body).token;
     }
     else if (typeof body === 'object') {
-      global.dscontentapi.token = body.token;
+      global.phoenix.token = body.token;
     }
   }
 
@@ -305,8 +305,8 @@ function campaignsReportback(rbData, callback) {
     headers: {
       'Content-Type': 'application/json',
       'Accept': 'application/json',
-      'Cookie': global.dscontentapi.session_name + '=' + global.dscontentapi.sessid,
-      'X-CSRF-Token': global.dscontentapi.token
+      'Cookie': global.phoenix.session_name + '=' + global.phoenix.sessid,
+      'X-CSRF-Token': global.phoenix.token
     },
     body: body,
     json: true
@@ -319,7 +319,7 @@ function campaignsReportback(rbData, callback) {
 
   // If we're in a test env, just log, emit an event, and call the callback function with test values. 
   if (process.env.NODE_ENV == 'test') {
-    logger.info('dscontentapi.campaignsReportback test: ', body.uid, ' | ', body.caption, ' | ', body.quantity, ' | ', body.why_participated, ' | ', body.file_url);
+    logger.info('phoenix.campaignsReportback test: ', body.uid, ' | ', body.caption, ' | ', body.quantity, ' | ', body.why_participated, ' | ', body.file_url);
     emitter.emit(emitter.events.reportbackSubmit, options);
     return callback(null, [TEST_RBID], [TEST_RBID]);
   }
@@ -369,14 +369,13 @@ function onCampaignsReportback(err, response, body) {
  * @param {function} [callback]
  */
 function campaignGet(campaignId, callback) {
-  logger.debug('phoenix.campaignGet:%d', campaignId);
   var options = {
     url: BASE_URL + '/campaigns/' + campaignId,
     method: 'GET',
     headers: {
       'Accept': 'application/json',
-      'Cookie': global.dscontentapi.session_name + '=' + global.dscontentapi.sessid,
-      'X-CSRF-Token': global.dscontentapi.token
+      'Cookie': global.phoenix.session_name + '=' + global.phoenix.sessid,
+      'X-CSRF-Token': global.phoenix.token
     }
   };
 

--- a/lib/phoenix.js
+++ b/lib/phoenix.js
@@ -23,6 +23,7 @@ module.exports = function() {
   }
 
   return {
+    campaignGet: campaignGet,
     userCreate: userCreate,
     userGet: userGet,
     userLogin: userLogin,
@@ -357,6 +358,43 @@ function onCampaignsReportback(err, response, body) {
     err = 'Invalid body received from report back response';
   }
 
+  if (typeof this.customCallback === 'function') {
+    this.customCallback(err, response, body);
+  }
+}
+
+/**
+ * Get campaign.
+ * @param {integer} campaignId - DS Campaign ID to query for
+ * @param {function} [callback]
+ */
+function campaignGet(campaignId, callback) {
+  logger.debug('phoenix.campaignGet:%d', campaignId);
+  var options = {
+    url: BASE_URL + '/campaigns/' + campaignId,
+    method: 'GET',
+    headers: {
+      'Accept': 'application/json',
+      'Cookie': global.dscontentapi.session_name + '=' + global.dscontentapi.sessid,
+      'X-CSRF-Token': global.dscontentapi.token
+    }
+  };
+
+  var _callback = onCampaignGet;
+  if (typeof callback === 'function') {
+    _callback = onCampaignGet.bind({customCallback: callback});
+  }
+  logger.log('debug', 'phoenix.campaignGet GET:%s', options.url);
+  request(options, _callback)
+}
+
+function onCampaignGet(err, response, body) {
+  if (err) {
+    logger.error('phoenix.onCampaignGet error:', err);
+  }
+  else {
+    logger.verbose('phoenix.onCampaignGet body:', JSON.stringify(body));
+  }
   if (typeof this.customCallback === 'function') {
     this.customCallback(err, response, body);
   }


### PR DESCRIPTION
#### What's this PR do?
Groundwork for #606, opening now to merge to keep this pull request readable. 

* Adds new `function campaignGet(campaignId, callback)` to `/lib/phoenix.js`. Also renames `global.dscontentapi` to `global.phoenix`

* Adds new `/api/controllers/CampaignBotController` to be used when `bot_type=campaign&campaign=:campaign_id` is passed to our chatbot endpoint, loading the Campaign from Phoenix

    * If `&start=true`. displays signup message for Campaign Title

    * Else write whatever our member texts back as `quantity` to a new `reportback_submissions` collection in our operations database (`mdata_responder`)

#### How should this be reviewed?
Post locally to `/v1/chatbot?bot_type=campaign&campaign=2070` to load Bumble Bands campaign from API, confirm a `reportback_submission` document is created upon including numeric `args` when excluding `start` from query string.

I'll be setting up a staging campaign to verify nothing breaks on staging as well.

#### Any background context you want to provide?
* Looking to add a `submitted_at` to the `ReportbackSubmission` model to track all submissions posted to the Phoenix API. Current `legacy/reportback` code deletes document from `reportbacks` collection upon successful submission to Phoenix API 

* Also looking to add a `User` model to track the current `ReportbackSubmission` per campaign a member may be completing.

#### Relevant tickets
#606 

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Tested on staging.
