### PR TITLE
Adds User and Campaign models

### DIFF
--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -90,8 +90,14 @@ CampaignBotController.prototype.chatReportback = function(user, userReplyMsg) {
     }
 
     user.supports_mms = true;
-    user.save();
-    sendMessage(user, '@stg: How many nouns did you verb?');
+    user.save(function (err) {
+      if (err) {
+        return handleError(err);
+      } 
+      sendMessage(user, '@stg: How many nouns did you verb?');
+    });
+    return;
+
 
   }
 

--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -78,28 +78,8 @@ CampaignBotController.prototype.chatReportback = function(user, userReplyMsg) {
   logger.verbose('reportback %s', user);
   var self = this;
 
-  if (!user.supports_mms) {
-
-    if (!userReplyMsg) {
-      sendMessage(user, '@stg: Can you send photos from your phone?');
-      return;
-    }
-    
-    if (!helpers.isYesResponse(userReplyMsg)) {
-      sendMessage(user, '@stg: Sorry, you must submit a photo to complete.');
-      return;
-    }
-
-    user.supports_mms = true;
-    user.save(function (err) {
-      if (err) {
-        return handleError(err);
-      } 
-      sendMessage(user, '@stg: How many nouns did you verb?');
-    });
+  if (!self.supportsMMS(user, userReplyMsg)) {
     return;
-
-
   }
 
   var quantity = parseInt(userReplyMsg);
@@ -120,6 +100,34 @@ CampaignBotController.prototype.chatReportback = function(user, userReplyMsg) {
   });
 
 }
+
+CampaignBotController.prototype.supportsMMS = function(user, userMsg) {
+
+  if (user.supports_mms) {
+    return true;
+  }
+
+  if (!userMsg) {
+    sendMessage(user, '@stg: Can you send photos from your phone?');
+    return false;
+  }
+  
+  if (!helpers.isYesResponse(userMsg)) {
+    sendMessage(user, '@stg: Sorry, you must submit a photo to complete.');
+    return false;
+  }
+
+  user.supports_mms = true;
+  user.save(function(err) {
+    if (err) {
+      // @todo
+      // return handleError(err);
+    }
+    sendMessage(user, '@stg: How many nouns did you verb?');
+    return true;
+  });
+
+};
 
 
 CampaignBotController.prototype.sendSignupSuccessMsg = function(user) {

--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -130,11 +130,17 @@ CampaignBotController.prototype.supportsMMS = function() {
       // @todo
       // return handleError(err);
     }
-    self.sendMessage('@stg: How many nouns did you verb?');
+    self.askQuantity();
     return true;
   });
 
 };
+
+CampaignBotController.prototype.askQuantity = function() {
+  var msgTxt = '@stg: how many ' + this.campaign.rb_noun + ' have you ';
+  msgTxt += this.campaign.rb_verb + '?\n\nPls txt the exact number.';
+  this.sendMessage(msgTxt);
+}
 
 
 CampaignBotController.prototype.sendSignupSuccessMsg = function() {

--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -56,29 +56,35 @@ CampaignBotController.prototype.chatbot = function(request, response) {
     }
 
     logger.debug('campaignBot found user:%s', user._id);
-    if (request.query.start || !request.body.args)  {
+    var userReplyMsg = helpers.getFirstWord(request.body.args);
+    if (request.query.start || !userReplyMsg)  {
       self.sendSignupSuccessMsg(user);
       return;
     }
 
-    self.reportback(user, request.body.args);
-
+    if (userReplyMsg === 'done') {
+      self.chatReportback(user, null);
+    }
+    else {
+      self.chatReportback(user, userReplyMsg);
+    }
+    
   });
   
 }
 
-CampaignBotController.prototype.reportback = function(user, incomingMsg) {
+CampaignBotController.prototype.chatReportback = function(user, userReplyMsg) {
   logger.verbose('reportback %s', user);
   var self = this;
 
   if (!user.supports_mms) {
 
-    if (!incomingMsg) {
+    if (!userReplyMsg) {
       sendMessage(user, '@stg: Can you send photos from your phone?');
       return;
     }
     
-    if (!helpers.isYesResponse(incomingMsg)) {
+    if (!helpers.isYesResponse(userReplyMsg)) {
       sendMessage(user, '@stg: Sorry, you must submit a photo to complete.');
       return;
     }
@@ -89,7 +95,7 @@ CampaignBotController.prototype.reportback = function(user, incomingMsg) {
 
   }
 
-  var quantity = parseInt(incomingMsg);
+  var quantity = parseInt(userReplyMsg);
   if (!quantity) {
     sendMessage(user, '@stg: Please provide a valid number.');
     return;
@@ -111,8 +117,8 @@ CampaignBotController.prototype.reportback = function(user, incomingMsg) {
 
 CampaignBotController.prototype.sendSignupSuccessMsg = function(user) {
   var msgTxt = '@stg: You\'re signed up for ' + this.campaign.title + '.\n\n';
-  msgTxt += 'When completed, text back the total number of ' + this.campaign.rb_noun;
-  msgTxt += ' you have ' + this.campaign.rb_verb + ' so far.';
+  msgTxt += 'When you have ' + this.campaign.rb_verb + ' some ';
+  msgTxt += this.campaign.rb_noun + ', text back DONE.';
   sendMessage(user, msgTxt);
 }
 

--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -8,6 +8,7 @@ var helpers = rootRequire('lib/helpers');
 var connOps = rootRequire('config/connectionOperations');
 var reportbackSubmissions = require('../models/ReportbackSubmission')(connOps);
 var users = require('../models/User')(connOps);
+var START_RB_COMMAND = 'next';
 
 /**
  * CampaignBotController
@@ -62,7 +63,7 @@ CampaignBotController.prototype.chatbot = function(request, response) {
       return;
     }
 
-    if (userReplyMsg === 'done') {
+    if (userReplyMsg.toLowerCase() === START_RB_COMMAND) {
       self.chatReportback(user, null);
     }
     else {
@@ -124,7 +125,7 @@ CampaignBotController.prototype.chatReportback = function(user, userReplyMsg) {
 CampaignBotController.prototype.sendSignupSuccessMsg = function(user) {
   var msgTxt = '@stg: You\'re signed up for ' + this.campaign.title + '.\n\n';
   msgTxt += 'When you have ' + this.campaign.rb_verb + ' some ';
-  msgTxt += this.campaign.rb_noun + ', text back DONE.';
+  msgTxt += this.campaign.rb_noun + ', text back ' + START_RB_COMMAND.toUpperCase();
   sendMessage(user, msgTxt);
 }
 

--- a/api/models/Campaign.js
+++ b/api/models/Campaign.js
@@ -1,0 +1,20 @@
+/**
+ * Models a DS Campaign.
+ */
+var mongoose = require('mongoose');
+
+var schema = new mongoose.Schema({
+
+  _id: {type: Number, index: true},
+
+  title: String,
+
+  rb_noun: String,
+
+  rb_verb: String
+
+})
+
+module.exports = function(connection) {
+  return connection.model('campaigns', schema);
+};

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -1,0 +1,19 @@
+/**
+ * Models a DS Member.
+ */
+var mongoose = require('mongoose');
+
+var schema = new mongoose.Schema({
+
+  // Storing mobile as _id for now, but this should eventually be Northstar ID.
+  _id: {type: String, index: true},
+
+  mobile: {type: String, index: true},
+
+  first_name: String
+
+})
+
+module.exports = function(connection) {
+  return connection.model('users', schema);
+};

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -5,14 +5,13 @@ var mongoose = require('mongoose');
 
 var schema = new mongoose.Schema({
 
-  // Storing mobile as _id for now, but this should eventually be Northstar ID.
   _id: {type: String, index: true},
 
   mobile: {type: String, index: true},
 
   first_name: String,
 
-  supports_mms: Boolean
+  supports_mms: {type: Boolean, default: false}
 
 })
 

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -10,7 +10,9 @@ var schema = new mongoose.Schema({
 
   mobile: {type: String, index: true},
 
-  first_name: String
+  first_name: String,
+
+  supports_mms: Boolean
 
 })
 

--- a/api/router.js
+++ b/api/router.js
@@ -29,7 +29,12 @@ router.use('/reportback', reportbackRouter);
 
 router.post('/v1/chatbot', function(request, response) {
 
+  // Store relevant info from incoming Mobile Commons requests.
+  request.incoming_message = request.body.args;
+  request.user_id = request.body.phone;
+
   var controller;
+
   switch (request.query.bot_type) {
     case 'campaign':
       controller = new CampaignBot(request.query.campaign);

--- a/api/router.js
+++ b/api/router.js
@@ -31,6 +31,8 @@ router.post('/v1/chatbot', function(request, response) {
 
   // Store relevant info from incoming Mobile Commons requests.
   request.incoming_message = request.body.args;
+  // We're using phone for now, Mobile Commons profile ID could make sense.
+  // Or potentially finding/creating our current user here to store Northstar ID
   request.user_id = request.body.phone;
 
   var controller;

--- a/config/smsConfigsLoader.js
+++ b/config/smsConfigsLoader.js
@@ -3,6 +3,7 @@
  */
 app.ConfigName = {
   CAMPAIGN_TRANSITIONS: 'start_campaign_transition',
+  CAMPAIGNS: 'campaigns',
   CHATBOT_MOBILECOMMONS_CAMPAIGNS: 'chatbot_mobilecommons_campaigns',
   DONORSCHOOSE_BOTS: 'donorschoose_bots',
   REPORTBACK: 'reportback',
@@ -11,6 +12,7 @@ app.ConfigName = {
 
 var conn = require('./connectionConfig');
 var configModelArray = [
+  rootRequire('api/models/Campaign')(conn),
   rootRequire('api/models/ChatbotMobileCommonsCampaign')(conn),
   rootRequire('api/models/DonorsChooseBot')(conn),
   rootRequire('api/legacy/ds-routing/config/startCampaignTransitionsConfigModel')(conn),


### PR DESCRIPTION
#### What's this PR do?
* Adds a`campaigns` collection to `configs` database to cache Campaigns from Phoenix API. Right now this is manually imported for development, but we'll eventually want to build ways to programatically refresh

* Refactors CampaignBotController  to load its Campaign from the relevant `app.config` instead of querying Phoenix API in every Gambit `chatbot?bot_type=campaign` API request (see #609)

* Adds `user_id` and `incoming_request` properties to our Express request in `router.js` to DRY code in SlothBotControllers and DonorsChooseDotControllers in upcoming pull requests

* Adds a `users` collection to our `mdata-responder` operations database as groundwork for storing a User's campaign activity. Upon posting to the Campaignbot chatbot request, we either create a new user document if one doesn't exist, or fetch the user from `users` to do things like:

* Begins work on storing whether our user `supports_mms`, to avoid asking it again in the future (another todo for future pull request)


#### How should this be reviewed?

Pull down branch and POST `/v1/chatbot?bot_type=campaign&campaign=2070` with relevant query parameters and verify nothing breaks. This isn't meant to be fully functional flow yet, but merging now to keep this pull request readable.

#### Any background context you want to provide?
![bumble](https://cloud.githubusercontent.com/assets/1236811/18150908/62cf3880-6f9f-11e6-802c-48bfc7d15f55.png)


#### Relevant tickets
#606 


#### Checklist
- [x] Tested on staging.