### PR TITLE
Repeat Reportback support

### DIFF
--- a/api/models/campaign/ReportbackSubmission.js
+++ b/api/models/campaign/ReportbackSubmission.js
@@ -13,7 +13,9 @@ var schema = new mongoose.Schema({
 
   quantity: Number,
 
-  why_participated: String
+  why_participated: String,
+
+  submitted_at: Date
 
 })
 

--- a/api/models/campaign/Signup.js
+++ b/api/models/campaign/Signup.js
@@ -14,7 +14,18 @@ var schema = new mongoose.Schema({
 
   created_at: {type: Date, default: Date.now},
 
-  reportback_submission: String
+  // If user is in the middle of a Reportback Submission, we store its ID 
+  // for easy lookup.
+  draft_reportback_submission: String,
+
+  // Last quantity submitted by the user.
+  // We'll want to update this number from DS API once we're querying for
+  // any existing or updates to Reportbacks for this Signup.
+  total_quantity_submitted: Number,
+
+  // Corresponds to the submitted_at of User's most recent ReportbackSubmission.
+  // Set this value as last import date if we start querying for updates.
+  updated_at: Date
 
 })
 


### PR DESCRIPTION
#### What's this PR do?
Picks up where #611 left off and adds support for additional Reportback Submissions after the first. Still not posting anything to API yet -- just storing data in the Gambit DB for prototyping.

* Renames the Signup`reportback_submission` property as `draft_reportback_submission` 

* Adds a `submitted_at` Date property to Reportback Submissions to store the time saved to `reportback_submissions` DB and posted to Phoenix API. We are not deleting `reportback_submissions` documents -- which is slight departure from how our `/api/legacy/reportback` controller [deletes documents from the `reportbacks` collection upon successful post to the Phoenix API](https://github.com/DoSomething/gambit/blob/0eee555eb58472bfbca293007610662082f834b0/api/legacy/reportback/index.js#L447).

* Adds a `total_quantity_submitted` to the Signup, and writes the quantity from our completed Reportback Submission draft. Once the draft document is saved with a `submitted_at` after collecting all data (future todo - actually post to API), we unset the Signup's `draft_reportback_submission` -- simplifying logic for determining if conversation should be about collecting Reportback data

* Refactors `CampaignBotController.sendReportbackSuccessMsg(quantity)` as `CampaignBotController.sendCompletedMenu()` to be called after submitting a successful Reportback, and to field any other requests from the User at all besides `CMD_REPORTBACK`. This state will eventually get built out to support other "commands" to ask Support Questions, review the Campaign details, or find another Campaign to complete.

* Adds a `startReportbackSubmission` method to create a new Reportback Submission document and save its ID to the Signup `draft_reportback_submission` property. This was previously done within `collectQuantity`, but creating upon texting in a `CMD_REPORTBACK` command when no draft is started helps keep our general `chatbot` logic more readable.


#### How should this be reviewed?
POST to `/v1/chatbot?bot_type=campaign&campaign=2070` with relevant `args` to verify new Reportback Submissions are created, and the user's Signup data is updated accordingly per each step.


#### Relevant tickets
#606 

#### Checklist
- [x] Tested on staging.
