### PR TITLE
Splits chatReportback into start and continue functions, adds loadsSignup

### DIFF
--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -92,12 +92,10 @@ CampaignBotController.prototype.chatbot = function(request, response) {
 CampaignBotController.prototype.loadSignup = function(signupId) {
   var self = this;
 
-  // Load and store our User's Signup for this Campaign.
   signups.findOne({ '_id': signupId }, function (err, signupDoc) {
 
     if (err) {
       logger.error(err);
-      res.sendStatus(500);
     }
 
     if (!signupDoc) {
@@ -111,26 +109,15 @@ CampaignBotController.prototype.loadSignup = function(signupId) {
     self.signup = signupDoc;
     logger.debug('self.signup:%s', self.signup._id.toString());
 
-    // Within check for supports MMS, we call startReportbackSubmission if yes
     if (!self.supportsMMS()) {
       return;
     }
-
-    // @todo: Check if Campaign start keyword was sent, send new Continue Menu
-    // instead of ask next RB question immediately without informing user of
-    // current reportbackSubmission status and what we have collected so far
 
     if (self.signup.draft_reportback_submission) {
       self.continueReportbackSubmission();
       return;
     }
 
-    if (!self.signup.total_quantity_submitted) {
-      self.continueReportbackSubmission();
-      return;        
-    }
-
-    // When User has completed and wants to submit another RB Submission
     if (self.incomingMsg === CMD_REPORTBACK) {
       self.startReportbackSubmission();
       return;
@@ -147,7 +134,6 @@ CampaignBotController.prototype.loadSignup = function(signupId) {
 CampaignBotController.prototype.continueReportbackSubmission = function() {
   var self = this;
 
-  // Check if our User is in the middle of a draft Reportback Submission.
   reportbackSubmissions.findOne(
     { '_id': self.signup.draft_reportback_submission },
     function (err, reportbackSubmissionDoc) {
@@ -156,6 +142,9 @@ CampaignBotController.prototype.continueReportbackSubmission = function() {
       logger.error(err);
       return;
     }
+
+    // @todo: Inspect our incoming message to determine if User is attemping
+    // continue Campaign conversation by texting in the Campaign Signup keyword
 
     // Store reference to our draft document to save data in collect functions.
     self.reportbackSubmission = reportbackSubmissionDoc;

--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -78,55 +78,67 @@ CampaignBotController.prototype.chatbot = function(request, response) {
       return;
     }
 
-    // Load and store our User's Signup for this Campaign.
-    signups.findOne({ '_id': signupId }, function (err, signupDoc) {
-
-      if (err) {
-        logger.error(err);
-      }
-
-      if (!signupDoc) {
-        // Edge case where our cached Signup ID in user.campaigns not found
-        // Could potentially lookup campaign/user in Signups to check for any
-        // Signup document to use, but for now let's log and assume wont happen.
-        logger.error('no signupDoc found for _id:%s', signupId);
-        return;
-      }
-
-      self.signup = signupDoc;
-      logger.debug('self.signup:%s', self.signup._id.toString());
-
-      // Within check for supports MMS, we call startReportbackSubmission if yes
-      if (!self.supportsMMS()) {
-        return;
-      }
-
-      // @todo: Check if Campaign start keyword was sent, send new Continue Menu
-      // instead of ask next RB question immediately without informing user of
-      // current reportbackSubmission status and what we have collected so far
-
-      if (self.signup.draft_reportback_submission) {
-        self.continueReportbackSubmission();
-        return;
-      }
-
-      if (!self.signup.total_quantity_submitted) {
-        self.continueReportbackSubmission();
-        return;        
-      }
-
-      // When User has completed and wants to submit another RB Submission
-      if (self.incomingMsg === CMD_REPORTBACK) {
-        self.startReportbackSubmission();
-        return;
-      }
-
-      self.sendCompletedMenuMsg();
-
-    });
+    self.loadSignup(signupId);
 
   });
   
+}
+
+/**
+ * Loads and sets a controller.signup property for given Signup Id
+ * Sends chatbot response per current user's sent message and campaign progress.
+ * @param {string} signupId
+ */
+CampaignBotController.prototype.loadSignup = function(signupId) {
+  var self = this;
+
+  // Load and store our User's Signup for this Campaign.
+  signups.findOne({ '_id': signupId }, function (err, signupDoc) {
+
+    if (err) {
+      logger.error(err);
+      res.sendStatus(500);
+    }
+
+    if (!signupDoc) {
+      // Edge case where our cached Signup ID in user.campaigns not found
+      // Could potentially lookup campaign/user in Signups to check for any
+      // Signup document to use, but for now let's log and assume wont happen.
+      logger.error('no signupDoc found for _id:%s', signupId);
+      return;
+    }
+
+    self.signup = signupDoc;
+    logger.debug('self.signup:%s', self.signup._id.toString());
+
+    // Within check for supports MMS, we call startReportbackSubmission if yes
+    if (!self.supportsMMS()) {
+      return;
+    }
+
+    // @todo: Check if Campaign start keyword was sent, send new Continue Menu
+    // instead of ask next RB question immediately without informing user of
+    // current reportbackSubmission status and what we have collected so far
+
+    if (self.signup.draft_reportback_submission) {
+      self.continueReportbackSubmission();
+      return;
+    }
+
+    if (!self.signup.total_quantity_submitted) {
+      self.continueReportbackSubmission();
+      return;        
+    }
+
+    // When User has completed and wants to submit another RB Submission
+    if (self.incomingMsg === CMD_REPORTBACK) {
+      self.startReportbackSubmission();
+      return;
+    }
+
+    self.sendCompletedMenuMsg();
+
+  });
 }
 
 /**


### PR DESCRIPTION
#### What's this PR do?
Nothing user-facing, cleans up code readability:
* `chatReportback(isNewSubmission)` refactored as `startReportbackSubmission()` and `continueReportbackSubmission()`
* Moves signups query logic out of `chatbot` and into separate `loadSignup(signupId)` function

#### How should this be reviewed?
Verify reportback conversation still works per #613

#### Any background context you want to provide?
Next up:
* [ ] Collect image and caption
* [ ] Only collect `why_participated` for the first Reportback Submission, don't need to collect again on repeat

#### Relevant tickets
#606 

#### Checklist
- [x] Tested on staging.
