### PR TITLE
Adds createUserAndPostSignup function

### DIFF
--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -10,7 +10,7 @@ var reportbackSubmissions = require('../models/campaign/ReportbackSubmission')(c
 var signups = require('../models/campaign/Signup')(connOps);
 var users = require('../models/User')(connOps);
 
-var CMD_REPORTBACK = 'next';
+var CMD_REPORTBACK = (process.env.GAMBIT_CMD_REPORTBACK || 'p');
 
 /**
  * CampaignBotController


### PR DESCRIPTION
#### What's this PR do?
Still nothing user-facing, leftover function from #614 moving handling creating a User into a `createUserAndPostSignup` function.

* Adds a `GAMBIT_CMD_REPORTBACK` config variable to avoid hardcoding the Start Reportback command.
* Renames `users`, `signups`, and `reportbackSubmissions` variables with a `db` prefix.

#### How should this be reviewed?
* Need to manually delete your user in the `users` collection
* Start and complete, repeat campaign

#### Any background context you want to provide?

* This branch also adds comments about how a User's `campaigns` hash table property is meant to store the Signup status for a given Campaign's current run. We'll need to add logic to query for Campaign start/end dates and verify if our Signup `created_at` date is current (if not, we'll need to create a new Signup)

* Not posting anything to Phoenix API yet. It does seem worth looking into posting to [Northstar](https://github.com/dosomething/northstar-js) instead. Refs #462 

#### Relevant tickets
#606, #610

#### Checklist
- [x] Tested on staging.

