### PR TITLE
Better support for continuing unfinished Reportback Submissions

### DIFF
--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -161,25 +161,28 @@ CampaignBotController.prototype.continueReportbackSubmission = function(req, res
       return;
     }
 
-    // @todo: Inspect our incoming message to determine if User is attemping
-    // continue Campaign conversation by texting in the Campaign Signup keyword
-
     // Store reference to our draft document to save data in collect functions.
     self.reportbackSubmission = reportbackSubmissionDoc;
 
+    var promptUser = (req.query.start || false);
+
+    if (promptUser) {
+      var msg = '@stg: Picking up where we left off on ' + self.campaign.title;
+      self.sendMessage(msg + '...');
+    }
 
     if (!self.reportbackSubmission.quantity) {
-      self.collectQuantity();
+      self.collectQuantity(promptUser);
       return;
     }
 
     if (!self.reportbackSubmission.caption) {
-      self.collectCaption();
+      self.collectCaption(promptUser);
       return;
     }
 
     if (!self.reportbackSubmission.why_participated) {
-      self.collectWhyParticipated();
+      self.collectWhyParticipated(promptUser);
       return;
     }
 
@@ -432,7 +435,7 @@ CampaignBotController.prototype.sendAskQuantityMessage = function() {
 }
 
 CampaignBotController.prototype.sendAskCaptionMessage = function() {
-  var msgTxt = '@stg: Got it! Text back a caption to use.';
+  var msgTxt = '@stg: Text back a caption to use for your photo.';
   this.sendMessage(msgTxt);
 }
 


### PR DESCRIPTION
#### What's this PR do?
Adds a check for a `start` query param within `continueReportbackSubmission`. If it exists:
* Send a "Picking up where we left off..." message to the user
* Send additional message asking the **next question** for collecting Reportback info

#### How should this be reviewed?
* Clear out your User's `campaigns` property in the `users` Mongo collection to clean slate Campaign Activity
* Text in Campaign's Mobile Commons keyword to load CampaignBot and create new Signup
* Begin a Reportback by texting in our `CMD_REPORTBACK`
* Text in the Campaign's Mobile Commons keyword again to continue conversation
* Confirm you're sent the "Picking up where we left off" message, and then asked for Quantity
* Respond with quantity, and then repeat texting in keyword again to confirm asked for Caption
* etc

#### Any background context you want to provide?
We set the `start` query string parameter from the "DSCampaignBot: start" mData, whereas the "DSCampaignBot: chat" mData does not include it all in the query.

The **next question** text is bolded above in reference to Slothbot integration? :puppet:

#### Relevant tickets
#606, #463 

#### Checklist
- [x] Tested on staging.