### PR TITLE
CampaignBot sendMessage cleanup

### DIFF
--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -239,13 +239,14 @@ CampaignBotController.prototype.startReportbackSubmission = function(req, res) {
 CampaignBotController.prototype.collectQuantity = function(req, res, promptUser) {
   var self = this;
 
+  var askQuantityMsg = self.getAskQuantityMessage();
   if (promptUser) {
-    return self.sendMessage(req, res, self.getAskQuantityMessage());
+    return self.sendMessage(req, res, askQuantityMsg);
   }
 
   var quantity = req.incoming_message;
   if (helpers.hasLetters(quantity) || !parseInt(quantity)) {
-    return self.sendMessage(req, res, 'Please provide a valid number.');
+    return self.sendMessage(req, res, 'Invalid valid number sent.\n\n' + askQuantityMsg);
   }
 
   self.reportbackSubmission.quantity = parseInt(quantity);
@@ -493,7 +494,7 @@ CampaignBotController.prototype.getStartMenuMsg = function() {
 
 CampaignBotController.prototype.getCompletedMenuMsg = function() {
   var action = this.campaign.rb_noun + ' ' + this.campaign.rb_verb;
-  var msgTxt = '@stg:\n\n*' + this.campaign.title + '*\n';
+  var msgTxt = '\n\n*' + this.campaign.title + '*\n';
   msgTxt += 'We\'ve got you down for ' + this.signup.total_quantity_submitted;
   msgTxt += ' ' + action + '.\n\n---\n';
   msgTxt += 'To add more ' + action + ', text ' + CMD_REPORTBACK.toUpperCase();

--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -163,31 +163,22 @@ CampaignBotController.prototype.continueReportbackSubmission = function(req, res
     // Store reference to our draft document to save data in collect functions.
     self.reportbackSubmission = reportbackSubmissionDoc;
 
-    // @todo Move this check into sendMessage(req, res, msgTxt)
     var promptUser = (req.query.start || false);
-    if (promptUser) {
-      var msg = '@stg: Picking up where we left off on ' + self.campaign.title;
-      self.sendMessage(msg + '...');
-    }
 
     if (!self.reportbackSubmission.quantity) {
-      self.collectQuantity(req, res, promptUser);
-      return;
+      return self.collectQuantity(req, res, promptUser);
     }
 
     if (!self.reportbackSubmission.image_url) {
-      self.collectPhoto(req, res, promptUser);
-      return;
+      return self.collectPhoto(req, res, promptUser);
     }
 
     if (!self.reportbackSubmission.caption) {
-      self.collectCaption(req, res, promptUser);
-      return;
+      return self.collectCaption(req, res, promptUser);
     }
 
     if (!self.reportbackSubmission.why_participated) {
-      self.collectWhyParticipated(req, res, promptUser);
-      return;
+      return self.collectWhyParticipated(req, res, promptUser);
     }
 
     // @todo Could be edge case where error on submit here
@@ -434,6 +425,8 @@ CampaignBotController.prototype.supportsMMS = function(req, res) {
 
 /**
  * Creates a Signup for our Campaign and current User, continues conversation.
+ * @param {object} req - Express request
+ * @param {object} res - Express response
  */
 CampaignBotController.prototype.postSignup = function(req, res) {
   logger.debug('postSignup');
@@ -510,12 +503,20 @@ CampaignBotController.prototype.getCompletedMenuMsg = function() {
   return msgTxt;
 }
 
-
+/**
+ * Sends mobilecommons.chatbot response with given msgTxt
+ * @param {object} req - Express request
+ * @param {object} res - Express response
+ * @param {string} msgTxt
+ */
 CampaignBotController.prototype.sendMessage = function(req, res, msgTxt) {
-  var mobileCommonsProfile = {
-    phone: this.user.mobile
-  };
-  mobilecommons.chatbot(mobileCommonsProfile, 213849, msgTxt);
+  if (req.query.start && this.signup.draft_reportback_submission) {
+    var continueMsg = 'Picking up where you left off on ' + this.campaign.title;
+    msgTxt = continueMsg + '...\n\n' + msgTxt;
+  }
+
+  mobilecommons.chatbot({phone: this.user.mobile}, 213849, msgTxt);
+
 }
 
 module.exports = CampaignBotController;

--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -248,7 +248,7 @@ CampaignBotController.prototype.collectQuantity = function(req, res, promptUser)
 
   var quantity = req.incoming_message;
   if (helpers.hasLetters(quantity) || !parseInt(quantity)) {
-    return self.sendMessage(req, res, '@stg: Please provide a valid number.');
+    return self.sendMessage(req, res, 'Please provide a valid number.');
   }
 
   self.reportbackSubmission.quantity = parseInt(quantity);
@@ -402,12 +402,12 @@ CampaignBotController.prototype.supportsMMS = function(req, res) {
   // @see loadSignup()
   var incomingCommand = helpers.getFirstWord(req.incoming_message);
   if (incomingCommand && incomingCommand.toUpperCase() === CMD_REPORTBACK) {
-    self.sendMessage(req, res, '@stg: Can you send photos from your phone?');
+    self.sendMessage(req, res, 'Can you send photos from your phone?');
     return false;
   }
   
   if (!helpers.isYesResponse(req.incoming_message)) {
-    self.sendMessage(req, res, '@stg: Sorry, you must submit a photo to complete.');
+    self.sendMessage(req, res, 'Sorry, you must submit a photo to complete.');
     return false;
   }
 
@@ -464,7 +464,7 @@ CampaignBotController.prototype.postSignup = function(req, res) {
  * @todo Deprecate these via Gambit Jr. CampaignBot content configs.
  */
 CampaignBotController.prototype.getAskQuantityMessage = function() {
-  var msgTxt = '@stg: What`s the total number of ' + this.campaign.rb_noun;
+  var msgTxt = 'What`s the total number of ' + this.campaign.rb_noun;
   msgTxt += ' you ' + this.campaign.rb_verb + '?';
   msgTxt += '\n\nPlease text the exact number back.';
   return msgTxt;
@@ -472,23 +472,23 @@ CampaignBotController.prototype.getAskQuantityMessage = function() {
 
 CampaignBotController.prototype.getAskPhotoMessage = function() {
   var action = this.campaign.rb_noun + ' ' + this.campaign.rb_verb;
-  var msgTxt = '@stg: Send your best photo of you and all ';
+  var msgTxt = 'Send your best photo of you and all ';
   msgTxt += this.reportbackSubmission.quantity + ' ' + action + '.';
   return msgTxt;
 }
 
 CampaignBotController.prototype.getAskCaptionMessage = function() {
-  var msgTxt = '@stg: Text back a caption to use for your photo.';
+  var msgTxt = 'Text back a caption to use for your photo.';
   return msgTxt;
 }
 
 CampaignBotController.prototype.getAskWhyParticipatedMessage = function() {
-  var msgTxt = '@stg: Why did you participate in ' + this.campaign.title + '?';
+  var msgTxt = 'Why did you participate in ' + this.campaign.title + '?';
   return msgTxt;
 }
 
 CampaignBotController.prototype.getStartMenuMsg = function() {
-  var msgTxt = '@stg: You\'re signed up for ' + this.campaign.title + '.\n\n';
+  var msgTxt = 'You\'re signed up for ' + this.campaign.title + '.\n\n';
   msgTxt += 'When you have ' + this.campaign.rb_verb + ' some ';
   msgTxt += this.campaign.rb_noun + ', text back ' + CMD_REPORTBACK.toUpperCase();
   return msgTxt;
@@ -513,6 +513,9 @@ CampaignBotController.prototype.sendMessage = function(req, res, msgTxt) {
   if (req.query.start && this.signup.draft_reportback_submission) {
     var continueMsg = 'Picking up where you left off on ' + this.campaign.title;
     msgTxt = continueMsg + '...\n\n' + msgTxt;
+  }
+  if (process.env.NODE_ENV !== 'production') {
+    msgTxt = '@stg: ' + msgTxt;
   }
 
   mobilecommons.chatbot({phone: this.user.mobile}, 213849, msgTxt);

--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -279,7 +279,7 @@ CampaignBotController.prototype.collectPhoto = function(req, res, promptUser) {
   }
 
   if (!req.incoming_image_url) {
-    self.sendAskPhotoMessage(req, res, 'No photo sent.\n\n' + askPhotoMsg);
+    self.sendMessage(req, res, 'No photo sent.\n\n' + askPhotoMsg);
     return;
   }
 

--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -199,6 +199,8 @@ CampaignBotController.prototype.continueReportbackSubmission = function(req, res
 
 /**
  * Creates new ReportbackSubmission, saves to Signup.draft_reportback_submission
+ * @param {object} req - Express request
+ * @param {object} res - Express response
  */
 CampaignBotController.prototype.startReportbackSubmission = function(req, res) {
   var self = this;
@@ -242,6 +244,8 @@ CampaignBotController.prototype.startReportbackSubmission = function(req, res) {
 /**
  * Handles conversation for saving quantity to our current reportbackSubmission.
  * Creates new reportbackSubmission document if none exists.
+ * @param {object} req - Express request
+ * @param {object} res - Express response
  * @param {boolean} promptUser - Whether to lead off conversation with user.
  */
 CampaignBotController.prototype.collectQuantity = function(req, res, promptUser) {
@@ -305,6 +309,8 @@ CampaignBotController.prototype.collectPhoto = function(req, res, promptUser) {
 
 /**
  * Handles conversation for saving caption to our current reportbackSubmission.
+ * @param {object} req - Express request
+ * @param {object} res - Express response
  * @param {boolean} promptUser
  */
 CampaignBotController.prototype.collectCaption = function(req, res, promptUser) {
@@ -337,7 +343,9 @@ CampaignBotController.prototype.collectCaption = function(req, res, promptUser) 
 
 /**
  * Handles conversation for saving why_participated to reportbackSubmission.
- * @param {boolean} promptUser - Whether to lead off conversation with user.
+ * @param {object} req - Express request
+ * @param {object} res - Express response
+ * @param {boolean} promptUser
  */
 CampaignBotController.prototype.collectWhyParticipated = function(req, res, promptUser) {
   var self = this;
@@ -393,6 +401,8 @@ CampaignBotController.prototype.postReportback = function() {
 
 /**
  * Handles conversation to save our current User's supportsMMS property.
+ * @param {object} req - Express request
+ * @param {object} res - Express response
  */
 CampaignBotController.prototype.supportsMMS = function(req, res) {
   var self = this;

--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -34,9 +34,6 @@ CampaignBotController.prototype.chatbot = function(req, res) {
     return;
   }
 
-  // @todo: Move into the completion handlers by passing into functions.
-  res.send();
-
   dbUsers.findOne({ '_id': req.user_id }, function (err, userDoc) {
 
     if (err) {
@@ -510,15 +507,18 @@ CampaignBotController.prototype.getCompletedMenuMsg = function() {
  * @param {string} msgTxt
  */
 CampaignBotController.prototype.sendMessage = function(req, res, msgTxt) {
+
   if (req.query.start && this.signup.draft_reportback_submission) {
     var continueMsg = 'Picking up where you left off on ' + this.campaign.title;
     msgTxt = continueMsg + '...\n\n' + msgTxt;
   }
+
   if (process.env.NODE_ENV !== 'production') {
     msgTxt = '@stg: ' + msgTxt;
   }
 
   mobilecommons.chatbot({phone: this.user.mobile}, 213849, msgTxt);
+  res.send();
 
 }
 


### PR DESCRIPTION
#### What's this PR do?
Refactors `CampaignBotController` functions to pass the Express request and response down to the `sendMessage(req, res, msgTxt)` function (refs #618) and [SO thread on scoping data in Express](http://stackoverflow.com/questions/20710023/how-to-scope-data-in-express-node-controller/20710437#20710437).
* Removes `self.incomingMsg` in favor of always inspecting `req.incoming_message`
* Removes hardcoded `@stg:` prefix from messages and appends in `sendMessage(req, res, msgTxt)` if our `NODE_ENV` is not production
* Calls `response.send()` upon successfully sending a message (instead of immediately upon finding a Campaign)
* Adds "Picking up where we left off" continue message logic into `sendMessage` to send a single message instead of 2 (where often the Picking up message would send after the Ask message, since we weren't using timeouts)


#### How should this be reviewed?
Test signing up and reporting back multiple times to the staging CampaignBot.

#### Any background context you want to provide?
Cleanup code in prep for starting on adding DS API integration.

Tasks left:
* [ ] Create `handleError` method to call `res.sendStatus(500)`, could potentially opt user into a `oip_failed` Opt In path that doesn't listen for responses but ask them to text in Campaign keyword again
* [ ] Set up a 2nd CampaignBot and verify campaign state is preserved between switching back and forth mid-reportback

#### Relevant tickets
#606

#### Checklist
- [x] Tested on staging.
