### PR TITLE
Adds CampaignBot support for multiple DS Campaigns

### DIFF
--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -520,7 +520,7 @@ CampaignBotController.prototype.getCompletedMenuMsg = function() {
  */
 CampaignBotController.prototype.sendMessage = function(req, res, msgTxt) {
 
-  if (req.query.start && this.signup.draft_reportback_submission) {
+  if (req.query.start && this.signup && this.signup.draft_reportback_submission) {
     var continueMsg = 'Picking up where you left off on ' + this.campaign.title;
     msgTxt = continueMsg + '...\n\n' + msgTxt;
   }
@@ -529,14 +529,15 @@ CampaignBotController.prototype.sendMessage = function(req, res, msgTxt) {
     msgTxt = '@stg: ' + msgTxt;
   }
 
-  var oip = this.mobileCommonsConfig.oip_chat;
+  var optInPath = this.mobileCommonsConfig.oip_chat;
 
-  if (!oip) {
-    logger.error('no oip');
+  if (!optInPath) {
+    logger.error("CampaignBot:%s no oip_chat found.", this.campaign._id);
     res.sendStatus(500);
+    return;
   }
 
-  mobilecommons.chatbot({phone: this.user.mobile}, oip, msgTxt);
+  mobilecommons.chatbot({phone: this.user.mobile}, optInPath, msgTxt);
   res.send();
 
 }

--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -19,6 +19,9 @@ var CMD_REPORTBACK = (process.env.GAMBIT_CMD_REPORTBACK || 'P');
  */
 function CampaignBotController(campaignId) {
   this.campaign = app.getConfig(app.ConfigName.CAMPAIGNS, campaignId);
+  var mocoId = this.campaign.current_mobilecommons_campaign;
+  var mobileCommonsConfigName = app.ConfigName.CHATBOT_MOBILECOMMONS_CAMPAIGNS;
+  this.mobileCommonsConfig = app.getConfig(mobileCommonsConfigName, mocoId);
 };
 
 /**
@@ -29,7 +32,7 @@ function CampaignBotController(campaignId) {
 CampaignBotController.prototype.chatbot = function(req, res) {
   var self = this;
 
-  if (!self.campaign) {
+  if (!self.campaign || !self.mobileCommonsConfig) {
     res.sendStatus(500);
     return;
   }
@@ -518,7 +521,14 @@ CampaignBotController.prototype.sendMessage = function(req, res, msgTxt) {
     msgTxt = '@stg: ' + msgTxt;
   }
 
-  mobilecommons.chatbot({phone: this.user.mobile}, 213849, msgTxt);
+  var oip = this.mobileCommonsConfig.oip_chat;
+
+  if (!oip) {
+    logger.error('no oip');
+    res.sendStatus(500);
+  }
+
+  mobilecommons.chatbot({phone: this.user.mobile}, oip, msgTxt);
   res.send();
 
 }

--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -18,10 +18,18 @@ var CMD_REPORTBACK = (process.env.GAMBIT_CMD_REPORTBACK || 'P');
  * @param {integer} campaignId - our DS Campaign ID
  */
 function CampaignBotController(campaignId) {
+
   this.campaign = app.getConfig(app.ConfigName.CAMPAIGNS, campaignId);
-  var mocoId = this.campaign.current_mobilecommons_campaign;
-  var mobileCommonsConfigName = app.ConfigName.CHATBOT_MOBILECOMMONS_CAMPAIGNS;
-  this.mobileCommonsConfig = app.getConfig(mobileCommonsConfigName, mocoId);
+
+  var mobileCommonsCampaign = this.campaign.staging_mobilecommons_campaign;
+
+  if (process.env.NODE_ENV === 'production') {
+    mobileCommonsCampaign = this.campaign.current_mobilecommons_campaign;
+  }
+
+  var configName = app.ConfigName.CHATBOT_MOBILECOMMONS_CAMPAIGNS;
+  this.mobileCommonsConfig = app.getConfig(configName, mobileCommonsCampaign);
+
 };
 
 /**

--- a/api/models/campaign/Campaign.js
+++ b/api/models/campaign/Campaign.js
@@ -11,7 +11,12 @@ var schema = new mongoose.Schema({
 
   rb_noun: String,
 
-  rb_verb: String
+  rb_verb: String,
+
+  // We're using Mobile Commons campaigns like Phoenix Campaign Runs.
+  // We create a new Mobile Commons campaign when the DS Campaign's 
+  // Signup and Quantity totals need start at 0 again for this year/month's run.
+  current_mobilecommons_campaign: Number
 
 })
 

--- a/api/models/campaign/Campaign.js
+++ b/api/models/campaign/Campaign.js
@@ -16,7 +16,10 @@ var schema = new mongoose.Schema({
   // We're using Mobile Commons campaigns like Phoenix Campaign Runs.
   // We create a new Mobile Commons campaign when the DS Campaign's 
   // Signup and Quantity totals need start at 0 again for this year/month's run.
-  current_mobilecommons_campaign: Number
+  current_mobilecommons_campaign: Number,
+
+  // Internal Mobile Commons campaign to use for Gambit staging / development.
+  staging_mobilecommons_campaign: Number
 
 })
 

--- a/lib/mobilecommons.js
+++ b/lib/mobilecommons.js
@@ -239,7 +239,8 @@ exports.optout = function(args) {
  */
 exports.chatbot = function(member, optInPath, msgTxt, profileFields) {
   if (typeof optInPath === 'undefined') {
-    logger.error('dc.sendSMS undefined optInPath user:%s msgText:%s', member, msgTxt);
+    logger.error('mobilecommons.chatbot undefined optInPath user:%s msgText:%s', 
+      member, msgTxt);
     return;
   }
   var mobileNumber = helpers.getNormalizedPhone(member.phone);


### PR DESCRIPTION
#### What's this PR do?
Removes hardcoded CampaignBot Mobile Commons `chatbot` opt-in path, supporting multiple DS Campaigns via creating mData's to post to the relevant`/v1/chatbot?bot_type=campaign&campaign=:id` endpoints.

* Adds a `current_mobilecommons_campaign` and `staging_mobilecommons_campaign` to our Campaign model. Loads the Chatbot Mobile Commons Campaign based on value set, and opts member into the `oip_chat` Opt-in path to display our saved `gambit_chatbot_response` custom field value in Mobile Commons.

Also fixes bug on first signup introduced in #619 

#### How should this be reviewed?

Test reportback conversations against Campaigns 2070 and 2299, which I've configured in our DB:

- POST `/v1/chatbot?bot_type=campaign&campaign=2070&start`
- POST `/v1/chatbot?bot_type=campaign&campaign=2070`
- POST `/v1/chatbot?bot_type=campaign&campaign=2299&start`
- POST `/v1/chatbot?bot_type=campaign&campaign=2299`

#### Any background context you want to provide?

Yup, here are the steps for how to set up a CampaignBot for a DS campaign called Y with DS Campaign ID 123:

**Mobile Commons:**

- Clone a "CampaignBot: X"  Mobile Commons Campaign as "CampaignBot: Y"

- Clone 2 mData's: ("CampaignBot: start X", "CampaignBot: chat X") for CampaignBot Y

    - Edit the `campaign` parameter passed in each CampaignBot Y mData's to post to Campaign Y's DS Campaign ID 123, e.g. `/v1/chatbot?bot_type=campaign&campaign=123&start`


- Edit each of CampaignBot Y's two Opt-in Path Conversations to post to the CampaignBot Y start/chat mData's (instead of posting to CampaignBot X, from when we cloned)

**Config database**
- Create a new document in `campaigns` with `_id` set to 123, the DS Campaign ID, and configure the following properties:
    - `title`*
    - `rb_noun`*
    - `rb_verb`* 
    - `current_mobilecommons_campaign` -- Mobile Commons Campaign ID to be used for the current production run of Campaign Y)
    - `staging_mobilecommons_campaign` -- Mobile Commons Campaign ID for development/staging purposes only
   
Properties marked with a * will one day be populated/synced via Phoenix API request

- Create a new document in `chatbot_mobilecommons_campaigns` with `_id` set to the Mobile Commons Campaign ID of our "CampaignBot Y" Mobile Commons Campaign (the :campaign_id in https://secure.mcommons.com/campaigns/:campaign_id). 
    - Set its `oip_chat` to the opt-in path ID of the "Chat" opt-in path in the CampaignBot Y Mobile Commons Campaign, e.g. https://secure.mcommons.com/campaigns/:campaign_id/opt_in_paths/:optin_path_id

Heroku:
- Restart all dynos to refresh `config` database

#### Relevant tickets
#606, #619

#### Checklist
- [x] Tested on staging.
