### PR TITLE
Stores Northstar ID for User _id, adds handleError and loggerPrefix helper functions

### DIFF
--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -586,7 +586,7 @@ CampaignBotController.prototype.handleError = function(req, res, error) {
  * @return {string}
  */
 CampaignBotController.prototype.loggerPrefix = function(req) {
-  return 'campaign:' + req.query.campaign + ' user:' + req.user_id;
+  return 'campaignBot.campaign:' + req.query.campaign + ' user:' + req.user_id;
 }
 
 module.exports = CampaignBotController;

--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -94,13 +94,13 @@ CampaignBotController.prototype.createUserAndPostSignup = function(req, res) {
   dbUsers.create({
 
     _id: req.user_id,
-    mobile: req.user_id,
+    mobile: req.user_mobile,
     campaigns: {}
 
   }).then(function(newUserDoc) {
 
     self.user = newUserDoc;
-    logger.debug('%s created user:%', self.loggerPrefix(req), newUserDoc['_id']);
+    logger.debug('%s created', self.loggerPrefix(req));
 
     self.postSignup(req, res);
 

--- a/api/router.js
+++ b/api/router.js
@@ -32,9 +32,9 @@ router.post('/v1/chatbot', function(request, response) {
   // Store relevant info from incoming Mobile Commons requests.
   request.incoming_message = request.body.args;
   request.incoming_image_url = request.body.mms_image_url;
-  // We're using phone for now, Mobile Commons profile ID could make sense.
-  // Or potentially finding/creating our current user here to store Northstar ID
-  request.user_id = request.body.phone;
+  // @todo Handle when Northstar ID doesn't exist
+  request.user_id = request.body.profile_northstar_id;
+  request.user_mobile = request.body.phone;
 
   var controller;
 

--- a/config/smsConfigsLoader.js
+++ b/config/smsConfigsLoader.js
@@ -71,7 +71,8 @@ function onRetrievedConfig() {
  *   Config document.
  */
 app.getConfig = function(modelName, documentId, key) {
-  logger.debug('smsConfigsLoader.getConfig for modelName:' + modelName + ' documentId:' + documentId + ' key:' + key);
+  logger.verbose('smsConfigsLoader.getConfig modelName:%s documentId:%s',
+    modelName, documentId);
 
   var keyMatches;
   var idMatches;


### PR DESCRIPTION
#### What's this PR do?
* DRY debug logging with a `loggerPrefix(req) function
* DRY error handling with a `CampaignBotController.handleError(req, res, error)` function
* Set our local User id to `profile_northstar_id` with a big `todo` for when a member joins DoSomething via SMS and we don't have a Northstar ID yet

#### How should this be reviewed?
Chat with the 2 staging CampaignBots and verify app logs look 👍 

#### Any background context you want to provide?
Sample `debug` logging:
````
4:04:51 PM web.1 |  info: Express server listening on port 5000 in thor mode...
4:04:56 PM web.1 |  debug: campaign:2070 user:5547be89469c64ec7d8b518d incoming_message:40
4:04:56 PM web.1 |  debug: campaign:2070 user:5547be89469c64ec7d8b518d loaded user:5547be89469c64ec7d8b518d
4:04:56 PM web.1 |  debug: campaign:2070 user:5547be89469c64ec7d8b518d loaded signup:57d09b505a5be8da0feb6739
4:04:56 PM web.1 |  debug: campaign:2070 user:5547be89469c64ec7d8b518d continueReportbackSubmission
4:04:56 PM web.1 |  debug: mobilecommons.profile_update for user:[removed] oip:213849 customFields:{"gambit_chatbot_response":"@stg: No photo sent.\n\nSend your best photo of you and all 40 bumble bands created."}
4:05:13 PM web.1 |  debug: campaign:2070 user:5547be89469c64ec7d8b518d incoming_message:40
4:05:13 PM web.1 |  debug: campaign:2070 user:5547be89469c64ec7d8b518d incoming_image_url:https://i.ytimg.com/vi/8rhge-os-18/maxresdefault.jpg
4:05:13 PM web.1 |  debug: campaign:2070 user:5547be89469c64ec7d8b518d loaded user:5547be89469c64ec7d8b518d
4:05:13 PM web.1 |  debug: campaign:2070 user:5547be89469c64ec7d8b518d loaded signup:57d09b505a5be8da0feb6739
4:05:13 PM web.1 |  debug: campaign:2070 user:5547be89469c64ec7d8b518d continueReportbackSubmission
4:05:13 PM web.1 |  debug: mobilecommons.profile_update for user:[removed] oip:213849 customFields:{"gambit_chatbot_response":"@stg: Text back a caption to use for your photo."}
4:05:24 PM web.1 |  debug: campaign:2299 user:5547be89469c64ec7d8b518d incoming_message:undefined
4:05:24 PM web.1 |  debug: campaign:2299 user:5547be89469c64ec7d8b518d loaded user:5547be89469c64ec7d8b518d
4:05:24 PM web.1 |  debug: campaign:2299 user:5547be89469c64ec7d8b518d loaded signup:57d09b9b5a5be8da0feb6756
4:05:24 PM web.1 |  debug: mobilecommons.profile_update for user:[removed] oip:214465 customFields:{"gambit_chatbot_response":"@stg: \n\n*Two Books Blue Books*\nWe've got you down for undefined books collected.\n\n---\nTo add more books collected, text P"}
````

todo:
* [ ] Log Mobile Commons `profile_id` instead of `phone` in our `mobilecommons.js` debug calls
* [ ] Add debug logging (or verbose) for successful Reportback Submission / Signup Draft updates

#### Relevant tickets
#606 
#### Checklist
- [x] Tested on staging.
