### PR TITLE
Pull CampaignBot message content from Gambit-Jr campaignbots API

### DIFF
--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -570,6 +570,11 @@ CampaignBotController.prototype.getCompletedMenuMsg = function() {
  * @param {string} msgTxt
  */
 CampaignBotController.prototype.sendMessage = function(req, res, msgTxt) {
+  msgTxt = msgTxt.replace(/<br>/gi, '\n');
+  msgTxt = msgTxt.replace(/{{title}}/gi, this.campaign.title);
+  msgTxt = msgTxt.replace(/{{quantity}}/gi, this.signup.total_quantity_submitted);
+  msgTxt = msgTxt.replace(/{{rb_noun}}/gi, this.campaign.rb_noun);
+  msgTxt = msgTxt.replace(/{{rb_verb}}/gi, this.campaign.rb_verb);
 
   if (req.query.start && this.signup && this.signup.draft_reportback_submission) {
     var continueMsg = 'Picking up where you left off on ' + this.campaign.title;

--- a/api/controllers/DonorsChooseBotController.js
+++ b/api/controllers/DonorsChooseBotController.js
@@ -401,56 +401,6 @@ function getDonationCount(member) {
 }
 
 /**
- * Queries Gambit Jr. API to sync donorschoose_bots config documents.
- * @param {object} req - Express request
- * @param {object} res - Express response
- */
-DonorsChooseBotController.prototype.syncBotConfigs = function(req, res) {
-  var self = this;
-
-  var url = 'http://dev-gambit-jr.pantheonsite.io/wp-json/wp/v2/donorschoose_bots/';
-  requestHttp.get(url, function(error, response, body) {
-    if (error) {
-      res.status(500);
-      return;
-    }
-    var bots = JSON.parse(body);
-    var propertyNames = [
-      'msg_ask_email',
-      'msg_ask_first_name',
-      'msg_ask_zip',
-      'msg_donation_success',
-      'msg_error_generic',
-      'msg_invalid_email',
-      'msg_invalid_first_name',
-      'msg_invalid_zip',
-      'msg_project_link',
-      'msg_max_donations_reached',
-      'msg_search_start',
-      'msg_search_no_results'
-    ];
-    var bot, configDoc, propertyName;
-    for (var i = 0; i < bots.length; i++) {
-      bot = bots[i];
-      configDoc = app.getConfig(app.ConfigName.DONORSCHOOSE_BOTS, bot.id);
-      if (!configDoc) {
-        logger.log('info', 'dc.syncBotConfigs doc not found for id:%s', bot.id);
-        continue;
-      }
-      for (var j = 0; j < propertyNames.length; j++) {
-        propertyName = propertyNames[j];
-        configDoc[propertyName] = bot[propertyName];
-      }
-      configDoc.name = bot.title;
-      configDoc.refreshed_at = Date.now();
-      configDoc.save();
-      logger.log('info', 'dc.syncBotConfigs success for id:%s', bot.id);
-    }
-    res.send();
-  });
-}
-
-/**
  * The following two functions are for handling Mongoose Promise chain errors.
  */
 function promiseErrorCallback(message, member) {

--- a/api/controllers/DonorsChooseBotController.js
+++ b/api/controllers/DonorsChooseBotController.js
@@ -10,7 +10,7 @@ var donorsChooseApiPassword = process.env.DONORSCHOOSE_API_PASSWORD;
 
 var DONATION_AMOUNT = (process.env.DONORSCHOOSE_DONATION_AMOUNT || 10);
 var DONATION_COUNT_FIELDNAME = 'ss2016_donation_count';
-var DONORSCHOOSE_BOT_ID = process.env.DONORSCHOOSE_BOT_ID;
+var DONORSCHOOSEBOT_ID = process.env.DONORSCHOOSEBOT_ID;
 var MAX_DONATIONS_ALLOWED = (process.env.DONORSCHOOSE_MAX_DONATIONS_ALLOWED || 5);
 var MOCO_CAMPAIGN_ID = process.env.DONORSCHOOSE_MOCO_CAMPAIGN_ID;
 
@@ -30,7 +30,7 @@ var donationModel = require('../models/donation/DonorsChooseDonation')(connOps);
  */
 function DonorsChooseBotController() {
   this.mocoCampaign = app.getConfig(app.ConfigName.CHATBOT_MOBILECOMMONS_CAMPAIGNS, MOCO_CAMPAIGN_ID);
-  this.bot = app.getConfig(app.ConfigName.DONORSCHOOSE_BOTS, DONORSCHOOSE_BOT_ID);
+  this.bot = app.getConfig(app.ConfigName.DONORSCHOOSEBOTS, DONORSCHOOSEBOT_ID);
 };
 
 /**
@@ -337,7 +337,7 @@ DonorsChooseBotController.prototype.postDonation = function(member, project) {
         profile_first_name: member.profile_first_name,
         profile_postal_code: member.profile_postal_code,
         mobilecommons_campaign_id: MOCO_CAMPAIGN_ID,
-        donorschoose_bot_id: DONORSCHOOSE_BOT_ID,
+        donorschoosebot_id: DONORSCHOOSEBOT_ID,
         donation_id: donation.donationId,
         donation_amount: DONATION_AMOUNT,
         proposal_id: project.id,

--- a/api/models/campaign/CampaignBot.js
+++ b/api/models/campaign/CampaignBot.js
@@ -1,0 +1,25 @@
+/**
+ * Model for Gambit Jr. API campaignbot. 
+ * Each document contains content to use for each message sent in
+ * a DS Campaign conversation.
+ */
+var mongoose = require('mongoose');
+
+var schema = new mongoose.Schema({
+  // Corresponds to the campaignbot ID in Gambit Jr. API.
+  _id: Number,
+  msg_menu_signedup: String,
+  msg_ask_supports_mms: String,
+  msg_no_supports_mms: String,
+  msg_ask_quantity: String,
+  msg_invalid_quantity: String,
+  msg_ask_photo: String,
+  msg_no_photo_sent: String,
+  msg_ask_caption: String,
+  msg_ask_why_participated: String,
+  msg_menu_completed: String
+});
+
+module.exports = function(connection) {
+  return connection.model(app.ConfigName.CAMPAIGNBOTS, schema, 'campaignbots');
+};

--- a/api/models/donation/DonorsChooseBot.js
+++ b/api/models/donation/DonorsChooseBot.js
@@ -1,10 +1,7 @@
 /**
- * Model for Gambit Jr. API donorschoose_bot. 
- * Each document contains content to use for each message sent in
- * DonorsChoose donation endgame flow.
- *
- * We keep a cache of each donorschoose_bot to avoid making
- * more network connections to the Gambir Jr. API
+ * Model for Gambit Jr. API DonorsChooseBot. 
+ * Each document contains copy to use for each message sent in DonorsChooseBot
+ * Chatbot conversations.
  */
 var mongoose = require('mongoose');
 
@@ -28,5 +25,5 @@ var schema = new mongoose.Schema({
 });
 
 module.exports = function(connection) {
-  return connection.model(app.ConfigName.DONORSCHOOSE_BOTS, schema, 'donorschoose_bots');
+  return connection.model(app.ConfigName.DONORSCHOOSEBOTS, schema, 'donorschoosebots');
 };

--- a/api/router.js
+++ b/api/router.js
@@ -7,6 +7,7 @@ var reportbackRouter = require('./legacy/reportback');
 var CampaignBot = require('./controllers/CampaignBotController');
 var DonorsChooseBot = require('./controllers/DonorsChooseBotController');
 var Slothbot = require('./controllers/SlothBotController');
+var gambitJunior = rootRequire('lib/gambit-junior');
 
 app.use('/', router);
 
@@ -55,7 +56,6 @@ router.post('/v1/chatbot', function(request, response) {
 
 router.post('/v1/chatbot/sync', function(request, response) {
 
-  var controller = new DonorsChooseBot();
-  controller.syncBotConfigs(request, response);
+  gambitJunior.syncBotConfigs(request, response, request.query.bot_type);
 
 });

--- a/api/router.js
+++ b/api/router.js
@@ -40,10 +40,15 @@ router.post('/v1/chatbot', function(request, response) {
   var controller;
 
   switch (request.query.bot_type) {
-    case 'campaign':
+    case 'campaignbot':
       controller = new CampaignBot(request.query.campaign);
       break;
+    // @todo Remove this safety check, deprecating donorschoose bot_type value.
+    // Using donorschoosebot instead.
     case 'donorschoose':
+      controller = new DonorsChooseBot();
+      break;
+    case 'donorschoosebot':
       controller = new DonorsChooseBot();
       break;
     default:

--- a/config/smsConfigsLoader.js
+++ b/config/smsConfigsLoader.js
@@ -3,6 +3,7 @@
  */
 app.ConfigName = {
   CAMPAIGN_TRANSITIONS: 'start_campaign_transition',
+  CAMPAIGNBOTS: 'campaignbots',
   CAMPAIGNS: 'campaigns',
   CHATBOT_MOBILECOMMONS_CAMPAIGNS: 'chatbot_mobilecommons_campaigns',
   DONORSCHOOSE_BOTS: 'donorschoose_bots',
@@ -14,6 +15,7 @@ var conn = require('./connectionConfig');
 var configModelArray = [
   rootRequire('api/models/ChatbotMobileCommonsCampaign')(conn),
   rootRequire('api/models/campaign/Campaign')(conn),
+  rootRequire('api/models/campaign/CampaignBot')(conn),
   rootRequire('api/models/donation/DonorsChooseBot')(conn),
   rootRequire('api/legacy/ds-routing/config/startCampaignTransitionsConfigModel')(conn),
   rootRequire('api/legacy/ds-routing/config/yesNoPathsConfigModel')(conn),

--- a/config/smsConfigsLoader.js
+++ b/config/smsConfigsLoader.js
@@ -6,7 +6,7 @@ app.ConfigName = {
   CAMPAIGNBOTS: 'campaignbots',
   CAMPAIGNS: 'campaigns',
   CHATBOT_MOBILECOMMONS_CAMPAIGNS: 'chatbot_mobilecommons_campaigns',
-  DONORSCHOOSE_BOTS: 'donorschoose_bots',
+  DONORSCHOOSEBOTS: 'donorschoosebots',
   REPORTBACK: 'reportback',
   YES_NO_PATHS: 'yes_no_path'
 };

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -8,7 +8,7 @@ This is __Gambit__, a DoSomething.org chatbot API for use with Mobile Commons.
 #### Chatbot
 Endpoint                                       | Functionality                                           
 ---------------------------------------------- | --------------------------------------------------------
-`POST /v1/chatbot` | [Chat](endpoints/chatbot.md)
+`POST /v1/chatbot` | [Chat](endpoints/chatbot.md#chat)
 `POST /v1/chatbot/sync` | [Sync chatbot content](endpoints/chatbot.md#sync)
 
 

--- a/documentation/endpoints/chatbot.md
+++ b/documentation/endpoints/chatbot.md
@@ -1,10 +1,12 @@
 # Chatbot
 
-Currently hard-wired for usage in our Mobile Commons account to chat over SMS.
+## Chat
 
 ```
 POST /v1/chatbot
 ```
+Receives requests from MobileCommons Chatbot mData's and sends User a response 
+over SMS (via posting to Mobile Commons API to send relevant message to User).
 
 **Headers**
 
@@ -32,3 +34,24 @@ Name | Type | Description
 `profile_postal_code` | `string` | 
 `profile_ss2016_donation_count` | `string` | Used by `donorschoose` bots to limit # of donations. This parameter name can be changed by `DONORSCHOOSE_DONATION_FIELDNAME`
 
+
+## Sync
+
+```
+POST /v1/chatbot/chat
+```
+Queries Gambit-Jr. API to update the corresponding Mongo `config` collection 
+documents with the latest content for the given `bot_type`.
+
+
+**Headers**
+
+Name | Type | Description
+--- | --- | ---
+`x-gambit-api-key` | `string` | **Required.** Used to authenticate POST requests.
+
+**Parameters**
+
+Name | Type | Description
+--- | --- | ---
+`bot_type` | `string` | Type of bot to sync: `campaignbot` , `donorschoosebot` 

--- a/documentation/endpoints/chatbot.md
+++ b/documentation/endpoints/chatbot.md
@@ -18,7 +18,8 @@ Name | Type | Description
 
 Name | Type | Description
 --- | --- | ---
-`bot_type` | `string` | Type of bot to chat with, `campaign`, `donorschoose` or `slothbot`. Default: `slothbot`
+`bot_type` | `string` | Type of bot to chat with, expected values: `campaignbot`, 
+`donorschoosebot` or `slothbot`. Defaults to `slothbot`
 `campaign` | `integer` | Required when `bot_type=campaign`, used to load Campaign from Phoenix API
 `start` | `boolean` | If set, the bot will begin a new conversation. Default: `false`
 
@@ -54,4 +55,5 @@ Name | Type | Description
 
 Name | Type | Description
 --- | --- | ---
-`bot_type` | `string` | Type of bot to sync: `campaignbot` , `donorschoosebot` 
+`bot_type` | `string` | Type of bot to sync, expected values: `campaignbot` or 
+`donorschoosebot` 

--- a/lib/gambit-junior.js
+++ b/lib/gambit-junior.js
@@ -3,20 +3,34 @@
 var requestHttp = require('request');
 var logger = rootRequire('lib/logger');
 
-const donorsChooseBotProperties = [
-  'msg_ask_email',
-  'msg_ask_first_name',
-  'msg_ask_zip',
-  'msg_donation_success',
-  'msg_error_generic',
-  'msg_invalid_email',
-  'msg_invalid_first_name',
-  'msg_invalid_zip',
-  'msg_project_link',
-  'msg_max_donations_reached',
-  'msg_search_start',
-  'msg_search_no_results'
-];
+const botProperties = {
+  campaignbot: [
+    'msg_ask_caption',
+    'msg_ask_photo',
+    'msg_ask_quantity',
+    'msg_ask_supports_mms',
+    'msg_ask_why_participated',
+    'msg_invalid_quantity',
+    'msg_menu_completed',
+    'msg_menu_signedup',
+    'msg_no_photo_sent',
+    'msg_no_supports_mms'
+  ],
+  donorschoosebot: [
+    'msg_ask_email',
+    'msg_ask_first_name',
+    'msg_ask_zip',
+    'msg_donation_success',
+    'msg_error_generic',
+    'msg_invalid_email',
+    'msg_invalid_first_name',
+    'msg_invalid_zip',
+    'msg_project_link',
+    'msg_max_donations_reached',
+    'msg_search_start',
+    'msg_search_no_results'
+  ]
+};
 
 /**
  * Query Gambit Jr. API to sync config collection for given bot type
@@ -28,21 +42,33 @@ module.exports.syncBotConfigs = function(req, res, type) {
   var url = 'http://dev-gambit-jr.pantheonsite.io/wp-json/wp/v2/' + type + 's';
   logger.debug('gambit-junior url:%s', url);
 
-  // @todo Add campaignBotProperties and check for botType
-  var propertyNames = donorsChooseBotProperties;
+  // @todo Remove underscore from donorschoose_bots to avoid needing configName
+  // variable, just pass type plural to our app.getConfig() function later
+  var configName = app.ConfigName.CAMPAIGNBOTS;
+  if (type === 'donorschoosebot') {
+    configName = app.ConfigName.DONORSCHOOSE_BOTS;
+  }
+
+  var propertyNames = botProperties[type];
+  if (!propertyNames) {
+    logger.error('gambit-junior no botProperties defined for type:%s', type);
+    res.status(500);
+    return;
+  }
 
   requestHttp.get(url, function(error, response, body) {
     if (error) {
       res.status(500);
       return;
     }
+
     var bots = JSON.parse(body);
     logger.verbose(bots);
     var bot, configDoc, propertyName;
+
     for (var i = 0; i < bots.length; i++) {
       bot = bots[i];
-      // @todo configName must be a variable
-      configDoc = app.getConfig(app.ConfigName.DONORSCHOOSE_BOTS, bot.id);
+      configDoc = app.getConfig(configName, bot.id);
       if (!configDoc) {
         logger.log('info', 'gambit-junior no config for bot_id:%s', bot.id);
         continue;
@@ -56,6 +82,8 @@ module.exports.syncBotConfigs = function(req, res, type) {
       configDoc.save();
       logger.log('info', 'gambit-junior sync success bot_id:%s', bot.id);
     }
+
     res.send();
+
   });
 }

--- a/lib/gambit-junior.js
+++ b/lib/gambit-junior.js
@@ -39,15 +39,9 @@ const botProperties = {
  * @param {string} type - Chatbot type. expected: donorschoosebot | campaignbot
  */
 module.exports.syncBotConfigs = function(req, res, type) {
-  var url = 'http://dev-gambit-jr.pantheonsite.io/wp-json/wp/v2/' + type + 's';
+  var endpoint = type + 's';
+  var url = 'http://dev-gambit-jr.pantheonsite.io/wp-json/wp/v2/' + endpoint;
   logger.debug('gambit-junior url:%s', url);
-
-  // @todo Remove underscore from donorschoose_bots to avoid needing configName
-  // variable, just pass type plural to our app.getConfig() function later
-  var configName = app.ConfigName.CAMPAIGNBOTS;
-  if (type === 'donorschoosebot') {
-    configName = app.ConfigName.DONORSCHOOSE_BOTS;
-  }
 
   var propertyNames = botProperties[type];
   if (!propertyNames) {
@@ -68,7 +62,7 @@ module.exports.syncBotConfigs = function(req, res, type) {
 
     for (var i = 0; i < bots.length; i++) {
       bot = bots[i];
-      configDoc = app.getConfig(configName, bot.id);
+      configDoc = app.getConfig(endpoint, bot.id);
       if (!configDoc) {
         logger.log('info', 'gambit-junior no config for bot_id:%s', bot.id);
         continue;

--- a/lib/gambit-junior.js
+++ b/lib/gambit-junior.js
@@ -1,0 +1,61 @@
+"use strict"
+
+var requestHttp = require('request');
+var logger = rootRequire('lib/logger');
+
+const donorsChooseBotProperties = [
+  'msg_ask_email',
+  'msg_ask_first_name',
+  'msg_ask_zip',
+  'msg_donation_success',
+  'msg_error_generic',
+  'msg_invalid_email',
+  'msg_invalid_first_name',
+  'msg_invalid_zip',
+  'msg_project_link',
+  'msg_max_donations_reached',
+  'msg_search_start',
+  'msg_search_no_results'
+];
+
+/**
+ * Query Gambit Jr. API to sync config collection for given bot type
+ * @param {object} req - Express request
+ * @param {object} res - Express response
+ * @param {string} type - Chatbot type. expected: donorschoosebot | campaignbot
+ */
+module.exports.syncBotConfigs = function(req, res, type) {
+  var url = 'http://dev-gambit-jr.pantheonsite.io/wp-json/wp/v2/' + type + 's';
+  logger.debug('gambit-junior url:%s', url);
+
+  // @todo Add campaignBotProperties and check for botType
+  var propertyNames = donorsChooseBotProperties;
+
+  requestHttp.get(url, function(error, response, body) {
+    if (error) {
+      res.status(500);
+      return;
+    }
+    var bots = JSON.parse(body);
+    logger.verbose(bots);
+    var bot, configDoc, propertyName;
+    for (var i = 0; i < bots.length; i++) {
+      bot = bots[i];
+      // @todo configName must be a variable
+      configDoc = app.getConfig(app.ConfigName.DONORSCHOOSE_BOTS, bot.id);
+      if (!configDoc) {
+        logger.log('info', 'gambit-junior no config for bot_id:%s', bot.id);
+        continue;
+      }
+      for (var j = 0; j < propertyNames.length; j++) {
+        propertyName = propertyNames[j];
+        configDoc[propertyName] = bot[propertyName];
+      }
+      configDoc.name = bot.title;
+      configDoc.refreshed_at = Date.now();
+      configDoc.save();
+      logger.log('info', 'gambit-junior sync success bot_id:%s', bot.id);
+    }
+    res.send();
+  });
+}


### PR DESCRIPTION
#### What's this PR do?
Loads CampaignBot message content from the Gambit-Jr. API instead of hardcoding.

* Adds `/api/models/campaign/CampaignBot.js` to model a CampaignBot returned from new `/campaignbots/` endpoint in Gambit-Jr API : http://dev-gambit-jr.pantheonsite.io/wp-json/wp/v2/campaignbots

* Adds a `CampaignBot` property called `bot` to the `CampaignBotController`.  Sends the relevant bot property as the message to our User, instead of using hardcoded copy in helper functions 

* Removes deprecated helper functions

* Adds a `/lib/gambitJunior` helper class to DRY syncing our Bot configs with Gambit-Jr API

#### How should this be reviewed?
Test full CampaignBot conversation flow, including sending invalid quantity / not submitting photo.
Verify that nothing breaks, and messages sent are aligned with [CampaignBot 41's configuration](http://dev-gambit-jr.pantheonsite.io/wp-json/wp/v2/campaignbots/41)

#### Any background context you want to provide?

Screenshot of the Gambit-Jr admin Campaignbot webform:

<img width="1133" alt="screen shot 2016-09-14 at 4 16 48 pm" src="https://cloud.githubusercontent.com/assets/1236811/18533308/cc0ddac0-7a96-11e6-9da0-edf44336ca6a.png">

#### Relevant tickets
#606, https://trello.com/c/bJgcc4F1

#### Todos
* [ ] Add a `msg_continue_draft` message to refactor last hardcoded message

* [ ] Currently hardcoding one CampaignBot for now to use for every DS Campaign. We'll need to add support so we can override with a different Bot based on DS Campaign (e.g. create a Shawn Mendes bot for Notes From Shawn)

#### Could dos
* Add support for a `{{campaign_url}}` to prompt user to complete Campaign on web. Bonus task could be to use a Magic Link so they're logged in upon clicking.

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Tested on staging.

cc @sergii-tkachenko 
