### PR TITLE
Adds support for olderThan DonorsChoose query param

### DIFF
--- a/api/controllers/DonorsChooseBotController.js
+++ b/api/controllers/DonorsChooseBotController.js
@@ -174,7 +174,9 @@ DonorsChooseBotController.prototype.findProjectAndRespond = function(member, ema
 
   var phone = member.phone;
   var zip = member.profile_postal_code;
-  var apiUrl = donorschoose.getProposalsQueryUrl(zip, DONATION_AMOUNT);
+  var olderThan = process.env.DONORSCHOOSE_PROPOSALS_OLDERTHAN;
+
+  var apiUrl = donorschoose.getProposalsQueryUrl(zip, DONATION_AMOUNT, olderThan);
   logger.log('debug', 'dc.findProject user:%s request:%s', phone, apiUrl);
   apiUrl += '&APIKey=' + donorsChooseApiKey;
 

--- a/lib/donorschoose.js
+++ b/lib/donorschoose.js
@@ -43,9 +43,10 @@ module.exports.getDonationsPostUrl = function() {
  * Returns DonorsChoose API url to query for first Project found by given zip.
  * @param {string} zip
  * @param {integer} minCostToComplete
+ * @param {integer} olderThan
  * @return {string}
  */
-module.exports.getProposalsQueryUrl = function(zip, minCostToComplete) {
+module.exports.getProposalsQueryUrl = function(zip, minCostToComplete, olderThan) {
   var url = proposalsHost + 'common/json_feed.html';
   // Currently hardcoded for STEM.
   url += '?subject4=-4'; 
@@ -53,5 +54,8 @@ module.exports.getProposalsQueryUrl = function(zip, minCostToComplete) {
   url += '&costToCompleteRange=' + minCostToComplete + '+TO+10000'; 
   url += '&max=1';
   url += '&zip=' + zip;
+  if (olderThan) {
+    url += '&olderThan=' + olderThan;
+  }
   return url;
 }


### PR DESCRIPTION
#### What's this PR do?
* Adds new `olderThan` parameter to `getProposalsQueryUrl` function
* Passes  `process.env.DONORSCHOOSE_PROPOSALS_OLDERTHAN` to filter by

#### How should this be reviewed?
* Set local `DONORSCHOOSE_PROPOSALS_OLDERTHAN` to 1472688000000 and run DonorsChooseBot to confirm donation works
* Unset and test again to confirm donation works

#### Relevant tickets
Fixes #625 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [x] Tested on staging.

cc @sergii-tkachenko 