### PR TITLE
CampaignBot router + refactor

### DIFF
--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -142,7 +142,7 @@ class CampaignBotController {
       .then(() => {
         this.debug(req, `saved signup:${this.signup._id.toString()}`);
 
-        return this.collectQuantity(req, res, true);
+        return req.reportbackSubmission;
       });
   }
 
@@ -195,10 +195,7 @@ class CampaignBotController {
   /**
    * Get the message to send back to user based on req and ReportbackSubmission.
    */
-  getMessageForReportbackSubmission(req, isNew) {
-    if (isNew) {
-
-    }
+  continueReportbackSubmission(req) {
     const ask = (req.query.start || false);
     const properties = [
       'quantity',
@@ -289,15 +286,6 @@ class CampaignBotController {
   }
 
   /**
-   * Returns reportback submission and sends message to user.
-   */
-  loadReportbackSubmission(id) {
-    return dbRbSubmissions
-      .findById(id)
-      .exec();
-  }
-
-  /**
    * Returns signup from cache if exists for id, else get/create from DS API.
    */
   loadSignup(id) {
@@ -311,10 +299,7 @@ class CampaignBotController {
           return this.getSignup();
         }
 
-        // @todo Load ReportbackSubmission and attach to signup? 
-        // There's prob a mongoose function to load draft_reportback_submission.
-
-          // @todo Validate signupDoc dates against current Campaign run dates.
+        // @todo Validate signupDoc dates against current Campaign run dates.
         return signup;        
       });
   }

--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -17,12 +17,12 @@ const CMD_REPORTBACK = (process.env.GAMBIT_CMD_REPORTBACK || 'P');
  */
 class CampaignBotController {
 
-  constructor(campaignBotId) {
-    this.bot = app.getConfig(app.ConfigName.CAMPAIGNBOTS, campaignBotId);
-    logger.info(`CampaignBotController loaded campaignBot:${campaignBotId}`);
+  constructor(botId) {
+    this.bot = app.getConfig(app.ConfigName.CAMPAIGNBOTS, botId);
+    logger.info(`CampaignBotController loaded campaignBot:${botId}`);
 
     if (!this.bot) {
-      return this.error(req, 'bot config not found');
+      return this.error(req, `CampaignBot not found for id:${botId}`);
     }
   }
 
@@ -38,7 +38,7 @@ class CampaignBotController {
         user: req.user_id, 
       })
       .then(reportbackSubmission => {
-        this.debug(req, `created submission:${reportbackSubmission._id.toString()}`)
+        this.debug(req, `created :${reportbackSubmission._id.toString()}`);
         req.signup.draft_reportback_submission = reportbackSubmission._id;
 
         return req.signup.save();
@@ -364,34 +364,6 @@ class CampaignBotController {
 
     return msgTxt;
   }
-
-  supportsMMS(req, res) {
-    this.debug(req, 'supportsMMS');
-
-    if (this.user.supports_mms === true) {
-      return true;
-    }
-
-    // @todo DRY this logic.
-    // @see loadSignup()
-    const incomingCommand = helpers.getFirstWord(req.incoming_message);
-    if (incomingCommand && incomingCommand.toUpperCase() === CMD_REPORTBACK) {
-      this.sendMessage(req, res, this.bot.msg_ask_supports_mms);
-      return false;
-    }
-    
-    if (!helpers.isYesResponse(req.incoming_message)) {
-      this.sendMessage(req, res, this.bot.msg_no_supports_mms);
-      return false;
-    }
-
-    this.user.supports_mms = true;
-    return this.user
-      .save()
-      .then(() => {
-        return this.createReportbackSubmission(req, res);
-      });
-  };
 
 };
 

--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -215,6 +215,7 @@ class CampaignBotController {
    */
   getCurrentSignup(req) {
     this.debug(req, 'getCurrentSignup');
+    let signup;
 
     return app.locals.clients.northstar.Signups.index({
       campaigns: req.campaign_id,
@@ -242,19 +243,18 @@ class CampaignBotController {
         data.reportback = parseInt(currentSignup.reportback.id);
         data.total_quantity_submitted = currentSignup.reportback.quantity;
       }
-      this.debug(req, `data:${JSON.stringify(data)}`);
+
       return app.locals.db.signups.create(data);
     })
     .then(signupDoc => {
       this.debug(req, `created signupDoc:${signupDoc._id.toString()}`);
-
+      signup = signupDoc;
       req.user.campaigns[req.campaign_id] = signupDoc._id;
       req.user.markModified('campaigns');
       return req.user.save();
     })
     .then(() => {
-      console.log(signupDoc);
-      return signupDoc;
+      return signup;
     });
   }
 

--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -216,7 +216,7 @@ class CampaignBotController {
   getCurrentSignup(req) {
     this.debug(req, 'getCurrentSignup');
 
-    return app.locals.northstarClient.Signups.index({
+    return app.locals.clients.northstar.Signups.index({
       campaigns: req.campaign_id,
       user: req.user_id,
     })
@@ -262,7 +262,7 @@ class CampaignBotController {
    * Queries DS API to find existing user, else creates new user.
    */
   getUser(id) {
-    return app.locals.northstarClient.Users
+    return app.locals.clients.northstar.Users
       .get('id', id)
       .then(user => {
         if (!user) {
@@ -345,7 +345,7 @@ class CampaignBotController {
       postData.why_participated = submission.why_participated;
     }
 
-    return app.locals.phoenixClient.Campaigns
+    return app.locals.clients.phoenix.Campaigns
       .reportback(req.campaign_id, postData)
       .then(reportbackId => {
         return this.postReportbackSuccess(req, reportbackId);
@@ -390,7 +390,7 @@ class CampaignBotController {
   postSignup(user, campaignId) {
     this.debug(req, 'postSignup');
 
-    return app.locals.phoenixClient.Campaigns
+    return app.locals.clients.phoenix.Campaigns
       .signup(campaignId, {
         source: process.env.DS_API_POST_SOURCE,
         uid: user.phoenix_id,

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -24,5 +24,5 @@ var schema = new mongoose.Schema({
 })
 
 module.exports = function(connection) {
-  return connection.model('Users', schema);
+  return connection.model('users', schema);
 };

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -24,5 +24,5 @@ var schema = new mongoose.Schema({
 })
 
 module.exports = function(connection) {
-  return connection.model('users', schema);
+  return connection.model('Users', schema);
 };

--- a/api/models/campaign/ReportbackSubmission.js
+++ b/api/models/campaign/ReportbackSubmission.js
@@ -13,7 +13,7 @@ var schema = new mongoose.Schema({
 
   caption: String,
 
-  image_url: String,
+  photo: String,
 
   quantity: Number,
 

--- a/api/models/campaign/Signup.js
+++ b/api/models/campaign/Signup.js
@@ -1,7 +1,11 @@
 /**
  * Models a DS Signup.
  */
-var mongoose = require('mongoose');
+
+ /**
+  * Imports.
+  */
+const mongoose = require('mongoose');
 
 var schema = new mongoose.Schema({
 
@@ -15,7 +19,10 @@ var schema = new mongoose.Schema({
 
   // If user is in the middle of a Reportback Submission, we store its ID 
   // for easy lookup.
-  draft_reportback_submission: {type: String, ref: 'ReportbackSubmission'},
+  draft_reportback_submission: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'reportback_submissions'
+  },
 
   reportback: Number,
 
@@ -31,5 +38,5 @@ var schema = new mongoose.Schema({
 })
 
 module.exports = function(connection) {
-  return connection.model('signups', schema);
+  return connection.model('Signups', schema);
 };

--- a/api/models/campaign/Signup.js
+++ b/api/models/campaign/Signup.js
@@ -38,5 +38,5 @@ var schema = new mongoose.Schema({
 })
 
 module.exports = function(connection) {
-  return connection.model('Signups', schema);
+  return connection.model('signups', schema);
 };

--- a/api/models/campaign/Signup.js
+++ b/api/models/campaign/Signup.js
@@ -13,11 +13,11 @@ var schema = new mongoose.Schema({
 
   created_at: {type: Date, default: Date.now},
 
-  reportback: Number,
-
   // If user is in the middle of a Reportback Submission, we store its ID 
   // for easy lookup.
-  draft_reportback_submission: String,
+  draft_reportback_submission: {type: String, ref: 'ReportbackSubmission'},
+
+  reportback: Number,
 
   // Last quantity submitted by the user.
   // We'll want to update this number from DS API once we're querying for

--- a/api/router.js
+++ b/api/router.js
@@ -1,15 +1,18 @@
-var express = require('express')
-var router = express.Router();
+"use strict";
 
-var logger = rootRequire('lib/logger');
+const express = require('express')
+const router = express.Router();
+
+const logger = rootRequire('lib/logger');
 const mobilecommons = rootRequire('lib/mobilecommons');
+const gambitJunior = rootRequire('lib/gambit-junior');
 
-var campaignRouter = require('./legacy/ds-routing');
-var reportbackRouter = require('./legacy/reportback');
+const campaignRouter = require('./legacy/ds-routing');
+const reportbackRouter = require('./legacy/reportback');
 
-var DonorsChooseBot = require('./controllers/DonorsChooseBotController');
-var Slothbot = require('./controllers/SlothBotController');
-var gambitJunior = rootRequire('lib/gambit-junior');
+const DonorsChooseBot = require('./controllers/DonorsChooseBotController');
+const Slothbot = require('./controllers/SlothBotController');
+
 
 app.use('/', router);
 
@@ -88,6 +91,8 @@ function campaignBot(req, res) {
     req.mobilecommons_campaign
   );
 
+  let msgTxt;
+
   return controller
     .loadUser(req.user_id)
     .then(user => {
@@ -116,10 +121,14 @@ function campaignBot(req, res) {
       }
 
       if (signup.total_quantity_submitted) {
-        return controller.getMessage(req, controller.bot.msg_menu_completed);
+        msgTxt = controller.bot.msg_menu_completed;
+
+        return controller.renderResponseMessage(req, msgTxt);
       }
 
-      return controller.getMessage(req, controller.bot.msg_menu_signedup);
+      msgTxt = controller.bot.msg_menu_signedup;
+
+      return controller.renderResponseMessage(req, msgTxt);
     })
     .then(msg => {
       controller.debug(req, `sendMessage:${msg}`);

--- a/api/router.js
+++ b/api/router.js
@@ -99,11 +99,11 @@ function campaignBot(req, res) {
       controller.debug(req, `loaded user:${user._id}`);
 
       req.user = user;
-      const currentSignup = user.campaigns[req.campaign_id];
+      const signupId = user.campaigns[req.campaign_id];
 
-      if (currentSignup) {
-        controller.debug(req, `loadSignup:${currentSignup}`);
-        return controller.loadSignup(currentSignup);
+      if (signupId) {
+        controller.debug(req, `loadSignup:${signupId}`);
+        return controller.loadCurrentSignup(req, signupId);
       }
 
       return controller.getCurrentSignup(req);

--- a/api/router.js
+++ b/api/router.js
@@ -6,7 +6,7 @@ const mobilecommons = rootRequire('lib/mobilecommons');
 
 var campaignRouter = require('./legacy/ds-routing');
 var reportbackRouter = require('./legacy/reportback');
-var CampaignBot = require('./controllers/CampaignBotController');
+
 var DonorsChooseBot = require('./controllers/DonorsChooseBotController');
 var Slothbot = require('./controllers/SlothBotController');
 var gambitJunior = rootRequire('lib/gambit-junior');
@@ -73,7 +73,7 @@ router.post('/v1/chatbot/sync', function(request, response) {
  */
 function campaignBot(req, res) {
   req.campaign_id = req.query.campaign;
-  const controller = new CampaignBot(req, res);
+  const controller = app.locals.campaignBotController;
 
   req.campaign = app.getConfig(
     app.ConfigName.CAMPAIGNS,
@@ -126,5 +126,6 @@ function campaignBot(req, res) {
     })
     .catch(err => {
       controller.error(req, res, err);
+      return res.sendStatus(500);
     });
 }

--- a/api/router.js
+++ b/api/router.js
@@ -95,14 +95,17 @@ function campaignBot(req, res) {
 
       req.user = user;
       const currentSignup = user.campaigns[req.campaign_id];
+      controller.debug(req, `currentSignup:${currentSignup}`);
+
       if (currentSignup) {
+        controller.debug(req, `loadSignup:${currentSignup}`);
         return controller.loadSignup(currentSignup);
       }
 
-      return controller.getCurrentSignup(user, req.campaign_id);
+      return controller.getCurrentSignup(req);
     })
     .then(signup => {
-      controller.debug(req, `loaded signup:${signup._id}`);
+      controller.debug(req, `loaded signup:${signup._id.toString()}`);
       req.signup = signup;
 
       if (signup.draft_reportback_submission) {
@@ -120,6 +123,7 @@ function campaignBot(req, res) {
       return controller.getMessage(req, controller.bot.msg_menu_signedup);
     })
     .then(msg => {
+      controller.debug(req, `sendMessage:${msg}`);
       mobilecommons.chatbot(req.body, req.mobilecommons_config.oip_chat, msg);
 
       return res.send({message: msg});  

--- a/api/router.js
+++ b/api/router.js
@@ -95,7 +95,6 @@ function campaignBot(req, res) {
 
       req.user = user;
       const currentSignup = user.campaigns[req.campaign_id];
-      controller.debug(req, `currentSignup:${currentSignup}`);
 
       if (currentSignup) {
         controller.debug(req, `loadSignup:${currentSignup}`);

--- a/config/connectionConfig.js
+++ b/config/connectionConfig.js
@@ -1,13 +1,15 @@
-var mongoose = require('mongoose');
+const mongoose = require('mongoose');
+const dbUri = process.env.CONFIG_DB_URI || 'mongodb://localhost/config';
 
 var connectionConfig;
 
 if (!connectionConfig || !connectionConfig.readyState) {
-  module.exports = connectionConfig = mongoose.createConnection(app.get('config-database-uri'));
-} else {
-  module.exports = connectionConfig
+  module.exports = connectionConfig = mongoose.createConnection(dbUri);
+} 
+else {
+  module.exports = connectionConfig;
 }
 
 connectionConfig.on('connected', function() { 
-  console.log('Mongoose connected to connectionConfig with status code: ' + connectionConfig.readyState);
+  console.log(`connectionConfig readyState:${connectionConfig.readyState}`);
 });

--- a/config/connectionOperations.js
+++ b/config/connectionOperations.js
@@ -1,14 +1,16 @@
-var mongoose = require('mongoose');
+const mongoose = require('mongoose');
 mongoose.Promise = global.Promise;
+const dbUri = process.env.DB_URI || 'mongodb://localhost/ds-mdata-responder';
 
 var connectionOperations;
 
 if (!connectionOperations || !connectionOperations.readyState) {
-  module.exports = connectionOperations = mongoose.createConnection(app.get('operations-database-uri'));
-} else {
-  module.exports = connectionOperations
+  module.exports = connectionOperations = mongoose.createConnection(dbUri);
+} 
+else {
+  module.exports = connectionOperations;
 }
 
 connectionOperations.on('connected', function() {  
-  console.log('Mongoose connected to connectionOperations with status code: ' + connectionOperations.readyState);
+  console.log(`connectionOperations readyState:${connectionOperations.readyState}`);
 });

--- a/config/index.js
+++ b/config/index.js
@@ -32,14 +32,6 @@ module.exports = function() {
   // Set the database URI this app will use to retrieve SMS config files.
   app.set('config-database-uri', process.env.CONFIG_DB_URI || 'mongodb://localhost/config')
 
-  // @TODO: Find a better way of passing the host URL to SGSoloController.createSoloGame()
-  // Specify app host URL. 
-  if (process.env.NODE_ENV == 'production') {
-    app.hostName = 'ds-mdata-responder.herokuapp.com';
-  } else {
-    app.hostName = 'localhost:' + app.get('port');
-  }
-
   /**
    * Global stathat reporting wrapper function
    *
@@ -57,5 +49,12 @@ module.exports = function() {
       count,
       function(status, json) {}
     );
+  };
+
+  const conn = rootRequire('config/connectionOperations');
+  app.locals.db = {
+    reportbackSubmissions: rootRequire('api/models/campaign/ReportbackSubmission')(conn),
+    signups: rootRequire('api/models/campaign/Signup')(conn),
+    users: rootRequire('api/models/User')(conn),
   };
 }

--- a/config/index.js
+++ b/config/index.js
@@ -1,17 +1,16 @@
-var path = require('path')
-  , express = require('express')
-  , fs = require('fs')
-  , root_dirname = path.dirname(path.dirname(__dirname))
-  , mongoose = require('mongoose')
-  , stathat = require('stathat')
-  , errorHandler = require('errorhandler')
-  , bodyParser = require('body-parser')
-  ;
+/**
+ * Imports.
+ */
+const express = require('express');
+const path = require('path');
+const root_dirname = path.dirname(path.dirname(__dirname));
+const stathat = require('stathat');
+const errorHandler = require('errorhandler');
+const bodyParser = require('body-parser');
+const NorthstarClient = require('@dosomething/northstar-js');
+const PhoenixClient = require('@dosomething/phoenix-js');
 
 module.exports = function() {
-
-  // Set port variable
-  app.set('port', process.env.PORT || 4711);
 
   // Parses request body and populates request.body
   app.use(bodyParser.json());
@@ -25,12 +24,6 @@ module.exports = function() {
 
   // Add static path
   app.use(express.static(path.join(root_dirname, 'public')));
-
-  // Set the database URI this app will use for SMS operations.
-  app.set('operations-database-uri', process.env.DB_URI || 'mongodb://localhost/ds-mdata-responder');
-
-  // Set the database URI this app will use to retrieve SMS config files.
-  app.set('config-database-uri', process.env.CONFIG_DB_URI || 'mongodb://localhost/config')
 
   /**
    * Global stathat reporting wrapper function
@@ -57,4 +50,16 @@ module.exports = function() {
     signups: rootRequire('api/models/campaign/Signup')(conn),
     users: rootRequire('api/models/User')(conn),
   };
+
+  app.locals.clients = {};
+  app.locals.clients.northstar = new NorthstarClient({
+    baseURI: process.env.DS_NORTHSTAR_API_BASEURI,
+    apiKey: process.env.DS_NORTHSTAR_API_KEY,
+  });
+  app.locals.clients.phoenix = new PhoenixClient({
+    baseURI: process.env.DS_PHOENIX_API_BASEURI,
+    username: process.env.DS_PHOENIX_API_USERNAME,
+    password: process.env.DS_PHOENIX_API_PASSWORD,
+  });
+
 }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,3 +1,8 @@
+/**
+ * Imports.
+ */
+const logger = rootRequire('lib/logger');
+
 module.exports = {
   isValidState : isValidState,
   isValidZip : isValidZip,

--- a/server.js
+++ b/server.js
@@ -9,8 +9,6 @@ const express = require('express');
 const http = require('http');
 const logger = rootRequire('lib/logger');
 const phoenix = rootRequire('lib/phoenix')();
-const NorthstarClient = require('@dosomething/northstar-js');
-const PhoenixClient = require('@dosomething/phoenix-js');
 
 // Default is 5. Increasing # of concurrent sockets per host.
 http.globalAgent.maxSockets = 100;
@@ -31,17 +29,6 @@ app = express();
 
 const appConfig = require('./config')(); 
 const smsConfigsLoader = require('./config/smsConfigsLoader');
-
-app.locals.northstarClient = new NorthstarClient({
-  baseURI: process.env.DS_NORTHSTAR_API_BASEURI,
-  apiKey: process.env.DS_NORTHSTAR_API_KEY,
-});
-
-app.locals.phoenixClient = new PhoenixClient({
-  baseURI: process.env.DS_PHOENIX_API_BASEURI,
-  username: process.env.DS_PHOENIX_API_USERNAME,
-  password: process.env.DS_PHOENIX_API_PASSWORD,
-});
 
 const router = require('./api/router');
 

--- a/server.js
+++ b/server.js
@@ -29,8 +29,7 @@ phoenix.userLogin(
  */
 app = express();
 
-const appConfig = require('./config')();
-const router = require('./api/router');
+const appConfig = require('./config')(); 
 const smsConfigsLoader = require('./config/smsConfigsLoader');
 
 app.locals.northstarClient = new NorthstarClient({
@@ -44,9 +43,15 @@ app.locals.phoenixClient = new PhoenixClient({
   password: process.env.DS_PHOENIX_API_PASSWORD,
 });
 
+const router = require('./api/router');
+
+const CampaignBotController = rootRequire('api/controllers/CampaignBotController');
+
 // Retrieves all SMS config files before starting server.
 smsConfigsLoader(() => {
   const port = (process.env.PORT || 5000);
+  // @todo We'll need to loop through all campaignBots and store as array.
+  app.locals.campaignBotController = new CampaignBotController(41);
   app.listen(port, () => {
     logger.info(`Gambit is listening, port:${port} env:${process.env.NODE_ENV}.`);
   });


### PR DESCRIPTION
#### What's this PR do?
To the end user, all this PR does sync an existing Signup from Northstar if you've already signed up for the DS Campaign XYZ, but it's your first time texting into the CampaignBot for XYZ.

It also refactors the monolithic `CampaignBotController.constructor` callback hell into smaller functions, and moves handling our Express response into `router.js` per @deadlybutter's suggestion in https://github.com/DoSomething/gambit/pull/631#discussion_r80523908

Plus:
* Refactor functions like `collectQuantity` and `collectPhoto` into a `collectReportbackProperty(req, property, ask)` function
* Adds a `getCurrentSignup` req to call Northstar JS Signups.index and check for existence of Signup. TODO -- Check for `Signup.campaignRun.current` right now it's hardcoded to just use first Signup returned
* Cleans up `/config/index.js` -- saves our User, Signup, and ReportbackSubmission models to `app.locals.db`, refactor Northstar and Phoenix clients to `app.locals.clients`
* Stores the current User and Signup in our Express request object instead of defining on `CampaignBotController` - refs https://github.com/DoSomething/gambit/pull/631/files#r80523498
* Creates `CampaignBotController` once in `server.js` to avoid unnecessarily creating/destroying -- refs https://github.com/DoSomething/gambit/pull/631/files#r80525317

#### How should this be reviewed?
Testing as an end user is one way... reviewing code is a whole lot trickier since this refactors the entire `CampaignBotController` class. I jumped off the deep end on this one, but it should make writing unit tests for these smaller functions a whole lot easier in the future.

End user testing needs a full test of all available routes (including legacy) -- since we're making some changes into main files like `server.js`, `router.js`, etc

Code review could start from the `campaignBot(req, res)` function in `router.js` and check out `CampaignBotController` classes accordingly.

#### Any background context you want to provide?

* Planning to move `/api/router.js` into `/config/router.js` - was going to give that a shot in this branch but it breaks the routes nested in `/api/legacy/`

* Removes check for `user.supports_mms` for now. This seems like something we may not need to store at all -- could be handled in our `msg_no_photo_sent` copy.

* It's so tempting to refactor the `DonorsChooseBotController` too.

#### Relevant tickets
#606

#### Checklist
- [x] Tested on staging.

cc @sergii-tkachenko 