### PR TITLE
Creates mobile commons groups & saves to DB

### DIFF
--- a/api/models/Campaign.js
+++ b/api/models/Campaign.js
@@ -71,7 +71,7 @@ schema.methods.createMobileCommonsGroups = function () {
   .then(() => mobilecommons.createGroup(`${prefix} status=completed`))
   .then(completedGroup => setMobileCommonsGroup(campaign, 'completed', completedGroup))
   .then(() => campaign.save())
-  .catch(err => logger.error(err););
+  .catch(err => logger.error(err));
 }
 
 module.exports = function (connection) {

--- a/api/models/Campaign.js
+++ b/api/models/Campaign.js
@@ -71,7 +71,7 @@ schema.methods.createMobileCommonsGroups = function () {
   .then(completedGroup => setMobileCommonsGroup(campaign, 'completed', completedGroup))
   .then(() => campaign.save())
   .catch(err => logger.error(err));
-}
+};
 
 module.exports = function (connection) {
   return connection.model('campaigns', schema);

--- a/api/models/Campaign.js
+++ b/api/models/Campaign.js
@@ -46,7 +46,6 @@ const schema = new mongoose.Schema({
 function setMobileCommonsGroup(campaign, status, group) {
   const scope = campaign;
   const parsedGroup = JSON.parse(parser.toJson(group));
-
   // If the group name is available...
   if (parsedGroup.response.success === 'true') {
 
@@ -72,7 +71,7 @@ schema.methods.createMobileCommonsGroups = function () {
   .then(() => mobilecommons.createGroup(`${prefix} status=completed`))
   .then(completedGroup => setMobileCommonsGroup(campaign, 'completed', completedGroup))
   .then(() => campaign.save())
-  .catch(err => logger.error(err));
+  .catch(err => logger.error(err););
 }
 
 module.exports = function (connection) {

--- a/api/models/Campaign.js
+++ b/api/models/Campaign.js
@@ -43,7 +43,8 @@ const schema = new mongoose.Schema({
 
 });
 
-function setMobileCommonsGroup(status, group) {
+function setMobileCommonsGroup(campaign, status, group) {
+  const scope = campaign;
   const parsedGroup = JSON.parse(parser.toJson(group));
 
   // If the group name is available...
@@ -51,7 +52,7 @@ function setMobileCommonsGroup(status, group) {
 
     // Save newly created group id to this campaign.
     const groupId = parsedGroup.response.group.id;
-    this.mobile_commons_groups[status] = groupId;
+    scope.mobile_commons_groups[status] = groupId;
   }
 }
 
@@ -67,9 +68,9 @@ schema.methods.createMobileCommonsGroups = function () {
 
   // Create mobile commons group with custom name based on this campaign
   mobilecommons.createGroup(`${prefix} status=doing`)
-  .then(doingGroup => setMobileCommonsGroup('doing', doingGroup).bind(campaign))
+  .then(doingGroup => setMobileCommonsGroup(campaign, 'doing', doingGroup))
   .then(() => mobilecommons.createGroup(`${prefix} status=completed`))
-  .then(completedGroup => setMobileCommonsGroup('completed', completedGroup).bind(campaign))
+  .then(completedGroup => setMobileCommonsGroup(campaign, 'completed', completedGroup))
   .then(() => campaign.save())
   .catch(err => logger.error(err));
 }

--- a/api/models/Campaign.js
+++ b/api/models/Campaign.js
@@ -36,21 +36,28 @@ const schema = new mongoose.Schema({
   msg_no_photo_sent: String,
 
   // Mobile Commons Specific Fields.
-  mobile_commons_groups: {
+  mobilecommons_groups: {
     doing: Number,
     completed: Number,
   },
 
 });
 
-function setMobileCommonsGroup(campaign, status, group) {
+/**
+ * For a given campaign, update its mobile commons group id,
+ * based on the mobile commons response.
+ * @param {Campaign} campaign    Campaign model to update.
+ * @param {string} status        Either completed or doing.
+ * @param {string} groupResponse XML string from mobile commons API.
+ */
+function setMobileCommonsGroup(campaign, status, groupResponse) {
   const scope = campaign;
-  const parsedGroup = JSON.parse(parser.toJson(group));
+  const parsedGroup = JSON.parse(parser.toJson(groupResponse));
   // If the group name is available...
   if (parsedGroup.response.success === 'true') {
     // Save newly created group id to this campaign.
     const groupId = parsedGroup.response.group.id;
-    scope.mobile_commons_groups[status] = groupId;
+    scope.mobilecommons_groups[status] = groupId;
   }
 }
 

--- a/api/models/Campaign.js
+++ b/api/models/Campaign.js
@@ -48,7 +48,6 @@ function setMobileCommonsGroup(campaign, status, group) {
   const parsedGroup = JSON.parse(parser.toJson(group));
   // If the group name is available...
   if (parsedGroup.response.success === 'true') {
-
     // Save newly created group id to this campaign.
     const groupId = parsedGroup.response.group.id;
     scope.mobile_commons_groups[status] = groupId;

--- a/api/models/Campaign.js
+++ b/api/models/Campaign.js
@@ -12,6 +12,7 @@ const schema = new mongoose.Schema({
 
   // Properties cached from DS API.
   title: String,
+  run_id: Number,
   msg_rb_confirmation: String,
   rb_noun: String,
   rb_verb: String,
@@ -32,8 +33,8 @@ const schema = new mongoose.Schema({
 
   // Mobile Commons Specific Fields.
   mobileCommonsGroups: {
-    doing: String,
-    completed: String,
+    doing: Number,
+    completed: Number,
   },
 
 });

--- a/api/models/Campaign.js
+++ b/api/models/Campaign.js
@@ -12,7 +12,7 @@ const schema = new mongoose.Schema({
 
   // Properties cached from DS API.
   title: String,
-  run_id: Number,
+  current_run: Number,
   msg_rb_confirmation: String,
   rb_noun: String,
   rb_verb: String,
@@ -32,7 +32,7 @@ const schema = new mongoose.Schema({
   msg_no_photo_sent: String,
 
   // Mobile Commons Specific Fields.
-  mobileCommonsGroups: {
+  mobile_commons_groups: {
     doing: Number,
     completed: Number,
   },

--- a/api/models/Campaign.js
+++ b/api/models/Campaign.js
@@ -30,6 +30,12 @@ const schema = new mongoose.Schema({
   msg_menu_signedup: String,
   msg_no_photo_sent: String,
 
+  // Mobile Commons Specific Fields.
+  mobileCommonsGroups: {
+    doing: String,
+    completed: String,
+  },
+
 });
 
 module.exports = function (connection) {

--- a/config/locals.js
+++ b/config/locals.js
@@ -55,7 +55,7 @@ function createMobileCommonsGroupsForCampaign(campaignModel) {
       doing: '',
       completed: '',
     };
-    campaignModel.mobileCommonsGroups = campaignModel.mobileCommonsGroups;
+    campaignModel.mobileCommonsGroups = groups;
   }
 
   // Create mobile commons groups & store ID on campaign model.

--- a/config/locals.js
+++ b/config/locals.js
@@ -4,7 +4,6 @@
  * Imports.
  */
 const gambitJunior = rootRequire('lib/junior');
-const mobilecommons = rootRequire('lib/mobilecommons');
 
 const logger = app.locals.logger;
 

--- a/config/locals.js
+++ b/config/locals.js
@@ -61,17 +61,17 @@ function createMobileCommonsGroupsForCampaign(campaignModel) {
   // Create mobile commons groups & store ID on campaign model.
   mobilecommons.createGroup(`${prefix} status=doing`)
   .then(doingGroup => {
-    doingGroup = JSON.parse(parser.toJson(doingGroup));
-    if (doingGroup.response.success === 'true') {
-      const groupId = doingGroup.response.group.id;
+    const parsedGroup = JSON.parse(parser.toJson(doingGroup));
+    if (parsedGroup.response.success === 'true') {
+      const groupId = parsedGroup.response.group.id;
       campaignModel.mobileCommonsGroups.doing = groupId;
     }
   })
   .then(() => mobilecommons.createGroup(`${prefix} status=completed`))
   .then(completedGroup => {
-    completedGroup = JSON.parse(parser.toJson(completedGroup));
-    if (completedGroup.response.success === 'true') {
-      const groupId = completedGroup.response.group.id;
+    const parsedGroup = JSON.parse(parser.toJson(completedGroup));
+    if (parsedGroup.response.success === 'true') {
+      const groupId = parsedGroup.response.group.id;
       campaignModel.mobileCommonsGroups.completed = groupId;
     }
   })

--- a/config/locals.js
+++ b/config/locals.js
@@ -32,6 +32,7 @@ function cacheCampaign(phoenixCampaign) {
     status: phoenixCampaign.status,
     tagline: phoenixCampaign.tagline,
     title: phoenixCampaign.title,
+    run_id: phoenixCampaign.currentCampaignRun.id,
     msg_rb_confirmation: phoenixCampaign.reportbackInfo.confirmationMessage,
     rb_noun: phoenixCampaign.reportbackInfo.noun,
     rb_verb: phoenixCampaign.reportbackInfo.verb,
@@ -48,7 +49,7 @@ function cacheCampaign(phoenixCampaign) {
  */
 function createMobileCommonsGroupsForCampaign(campaignModel) {
   const campaignScope = campaignModel;
-  const prefix = `env=${process.env.NODE_ENV} campaign_id=${campaignModel._id}`;
+  const prefix = `env=${process.env.NODE_ENV} campaign_id=${campaignModel._id} run_id=${campaignModel.run_id}`;
 
   // Migrate old campaign models.
   if (!campaignModel.mobileCommonsGroups.doing || !campaignModel.mobileCommonsGroups.completed) {

--- a/config/locals.js
+++ b/config/locals.js
@@ -32,7 +32,7 @@ function cacheCampaign(phoenixCampaign) {
     status: phoenixCampaign.status,
     tagline: phoenixCampaign.tagline,
     title: phoenixCampaign.title,
-    run_id: phoenixCampaign.currentCampaignRun.id,
+    current_run: phoenixCampaign.currentCampaignRun.id,
     msg_rb_confirmation: phoenixCampaign.reportbackInfo.confirmationMessage,
     rb_noun: phoenixCampaign.reportbackInfo.noun,
     rb_verb: phoenixCampaign.reportbackInfo.verb,
@@ -51,16 +51,7 @@ function createMobileCommonsGroupsForCampaign(campaignModel) {
   const campaignScope = campaignModel;
   const prefix = `env=${process.env.NODE_ENV}
                   campaign_id=${campaignModel._id}
-                  run_id=${campaignModel.run_id}`;
-
-  // Migrate old campaign models.
-  if (!campaignModel.mobileCommonsGroups.doing || !campaignModel.mobileCommonsGroups.completed) {
-    const groups = {
-      doing: '',
-      completed: '',
-    };
-    campaignScope.mobileCommonsGroups = groups;
-  }
+                  run_id=${campaignModel.current_run}`;
 
   // Create mobile commons groups & store ID on campaign model.
   mobilecommons.createGroup(`${prefix} status=doing`)
@@ -68,7 +59,7 @@ function createMobileCommonsGroupsForCampaign(campaignModel) {
     const parsedGroup = JSON.parse(parser.toJson(doingGroup));
     if (parsedGroup.response.success === 'true') {
       const groupId = parsedGroup.response.group.id;
-      campaignScope.mobileCommonsGroups.doing = groupId;
+      campaignScope.mobile_commons_groups.doing = groupId;
     }
   })
   .then(() => mobilecommons.createGroup(`${prefix} status=completed`))
@@ -76,7 +67,7 @@ function createMobileCommonsGroupsForCampaign(campaignModel) {
     const parsedGroup = JSON.parse(parser.toJson(completedGroup));
     if (parsedGroup.response.success === 'true') {
       const groupId = parsedGroup.response.group.id;
-      campaignScope.mobileCommonsGroups.completed = groupId;
+      campaignScope.mobile_commons_groups.completed = groupId;
     }
   })
   .then(() => campaignScope.save())

--- a/config/locals.js
+++ b/config/locals.js
@@ -51,10 +51,11 @@ function createMobileCommonsGroupsForCampaign(campaignModel) {
 
   // Migrate old campaign models.
   if (!campaignModel.mobileCommonsGroups.doing || !campaignModel.mobileCommonsGroups.completed) {
-    campaignModel.mobileCommonsGroups = {
+    const groups = {
       doing: '',
       completed: '',
-    }
+    };
+    campaignModel.mobileCommonsGroups = campaignModel.mobileCommonsGroups;
   }
 
   // Create mobile commons groups & store ID on campaign model.
@@ -62,18 +63,20 @@ function createMobileCommonsGroupsForCampaign(campaignModel) {
   .then(doingGroup => {
     doingGroup = JSON.parse(parser.toJson(doingGroup));
     if (doingGroup.response.success === 'true') {
-      campaignModel.mobileCommonsGroups.doing = doingGroup.response.group.id;
+      const groupId = doingGroup.response.group.id;
+      campaignModel.mobileCommonsGroups.doing = groupId;
     }
   })
   .then(() => mobilecommons.createGroup(`${prefix} status=completed`))
   .then(completedGroup => {
     completedGroup = JSON.parse(parser.toJson(completedGroup));
     if (completedGroup.response.success === 'true') {
-      campaignModel.mobileCommonsGroups.completed = completedGroup.response.group.id;
+      const groupId = completedGroup.response.group.id;
+      campaignModel.mobileCommonsGroups.completed = groupId;
     }
   })
   .then(() => campaignModel.save())
-  .catch(err => console.log(err));
+  .catch(err => logger.error(err));
 }
 
 /**

--- a/config/locals.js
+++ b/config/locals.js
@@ -49,7 +49,9 @@ function cacheCampaign(phoenixCampaign) {
  */
 function createMobileCommonsGroupsForCampaign(campaignModel) {
   const campaignScope = campaignModel;
-  const prefix = `env=${process.env.NODE_ENV} campaign_id=${campaignModel._id} run_id=${campaignModel.run_id}`;
+  const prefix = `env=${process.env.NODE_ENV}
+                  campaign_id=${campaignModel._id}
+                  run_id=${campaignModel.run_id}`;
 
   // Migrate old campaign models.
   if (!campaignModel.mobileCommonsGroups.doing || !campaignModel.mobileCommonsGroups.completed) {

--- a/config/locals.js
+++ b/config/locals.js
@@ -47,6 +47,7 @@ function cacheCampaign(phoenixCampaign) {
  * @see https://github.com/DoSomething/gambit/issues/673
  */
 function createMobileCommonsGroupsForCampaign(campaignModel) {
+  const campaignScope = campaignModel;
   const prefix = `env=${process.env.NODE_ENV} campaign_id=${campaignModel._id}`;
 
   // Migrate old campaign models.
@@ -55,7 +56,7 @@ function createMobileCommonsGroupsForCampaign(campaignModel) {
       doing: '',
       completed: '',
     };
-    campaignModel.mobileCommonsGroups = groups;
+    campaignScope.mobileCommonsGroups = groups;
   }
 
   // Create mobile commons groups & store ID on campaign model.
@@ -64,7 +65,7 @@ function createMobileCommonsGroupsForCampaign(campaignModel) {
     const parsedGroup = JSON.parse(parser.toJson(doingGroup));
     if (parsedGroup.response.success === 'true') {
       const groupId = parsedGroup.response.group.id;
-      campaignModel.mobileCommonsGroups.doing = groupId;
+      campaignScope.mobileCommonsGroups.doing = groupId;
     }
   })
   .then(() => mobilecommons.createGroup(`${prefix} status=completed`))
@@ -72,10 +73,10 @@ function createMobileCommonsGroupsForCampaign(campaignModel) {
     const parsedGroup = JSON.parse(parser.toJson(completedGroup));
     if (parsedGroup.response.success === 'true') {
       const groupId = parsedGroup.response.group.id;
-      campaignModel.mobileCommonsGroups.completed = groupId;
+      campaignScope.mobileCommonsGroups.completed = groupId;
     }
   })
-  .then(() => campaignModel.save())
+  .then(() => campaignScope.save())
   .catch(err => logger.error(err));
 }
 

--- a/lib/mobilecommons.js
+++ b/lib/mobilecommons.js
@@ -2,7 +2,7 @@
  * Helper methods to interface with the Mobile Commons API.
  */
 
-const request = require('request');
+const request = require('request-promise-native');
 const RequestRetry = require('node-request-retry');
 const helpers = rootRequire('lib/helpers');
 const _ = require('underscore');
@@ -66,7 +66,7 @@ exports.profile_update = function(phone, optInPathId, customFields) {
     else if (response && response.statusCode != 200) {
       logger.error('mobilecommons.profile_update for user:'
         + phone + ' | form data: ' + JSON.stringify(postData.form)
-        + '| with code: ' + response.statusCode 
+        + '| with code: ' + response.statusCode
         + ' | body: ' + body + ' | stack: ' + trace);
     }
   };
@@ -77,9 +77,9 @@ exports.profile_update = function(phone, optInPathId, customFields) {
 };
 
 /**
- * Opt-in mobile numbers into specified Mobile Commons paths. Can take custom 
- * key-value pairs in the args input in order to update custom profile fields 
- * of the alphPhone user. 
+ * Opt-in mobile numbers into specified Mobile Commons paths. Can take custom
+ * key-value pairs in the args input in order to update custom profile fields
+ * of the alphPhone user.
  */
 exports.optin = function(args) {
   logger.log('debug', 'mobilecommons.optin:%s', JSON.stringify(args));
@@ -103,7 +103,7 @@ exports.optin = function(args) {
   if (alphaPhone == null || alphaOptin <= 0) {
     return;
   }
-    
+
   payload = {
     form: {
       opt_in_path: alphaOptin,
@@ -124,7 +124,7 @@ exports.optin = function(args) {
     }
   }
 
-  // If a custom field exists in args, add it to the payload. 
+  // If a custom field exists in args, add it to the payload.
   keys = Object.keys(args);
   for (i = 0; i < keys.length; i++) {
     if (! _.contains(standardKeys, keys[i])) {
@@ -215,15 +215,15 @@ exports.optout = function(args) {
 /**
  * Posts to a chatbot optInPath to send msgTxt to given member.
  * @param {object} member
- * @param {number} optInPath - Id of Opt-in path, needs to contain 
+ * @param {number} optInPath - Id of Opt-in path, needs to contain
  *     {{gambit_chatbot_response}} in Liquid to render our msgTxt
  * @param {string} msgTxt - Message to send to our member
- * @param {object} [profileFields] - Additional Key/value object to save as 
+ * @param {object} [profileFields] - Additional Key/value object to save as
  *     Mobile Commons Custom Fields on our member's profile.
  */
 exports.chatbot = function(member, optInPath, msgTxt, profileFields) {
   if (typeof optInPath === 'undefined') {
-    logger.error('mobilecommons.chatbot undefined optInPath user:%s msgText:%s', 
+    logger.error('mobilecommons.chatbot undefined optInPath user:%s msgText:%s',
       member, msgTxt);
     return;
   }
@@ -261,8 +261,6 @@ exports.createGroup = function (groupName) {
       logger.error(err);
       return;
     }
-    // We get an invalid name error back if name exists (which we'll usually get).
-    logger.debug(body);
 
     return body;
   });

--- a/lib/mobilecommons.js
+++ b/lib/mobilecommons.js
@@ -2,13 +2,20 @@
  * Helper methods to interface with the Mobile Commons API.
  */
 
-var RequestRetry = require('node-request-retry');
-var helpers = rootRequire('lib/helpers');
-var _ = require('underscore');
+const request = require('request');
+const RequestRetry = require('node-request-retry');
+const helpers = rootRequire('lib/helpers');
+const _ = require('underscore');
 const logger = app.locals.logger;
 
 // Modifying the default Request library's request object.
 RequestRetry.setDefaults({timeout: 120000});
+
+const uri = 'https://secure.mcommons.com/api';
+const auth = {
+  user: process.env.MOBILECOMMONS_AUTH_EMAIL,
+  pass: process.env.MOBILECOMMONS_AUTH_PASS,
+};
 
 /**
 * Mobile Commons profile_update API. Can be used to subscribe the user to an
@@ -236,3 +243,27 @@ exports.chatbot = function(member, optInPath, msgTxt, profileFields) {
 
   this.profile_update(mobileNumber, optInPath, profileFields);
 }
+
+/**
+ * Create new Mobile Commons Group with given groupName.
+ */
+exports.createGroup = function (groupName) {
+  logger.debug(`mobilecommons.createGroup ${groupName}`);
+
+  const data = {
+    auth,
+    form: { name: groupName },
+  };
+  const url = `${uri}/create_group`;
+
+  return request.post(url, data, (err, res, body) => {
+    if (err) {
+      logger.error(err);
+      return;
+    }
+    // We get an invalid name error back if name exists (which we'll usually get).
+    logger.debug(body);
+
+    return body;
+  });
+};

--- a/package.json
+++ b/package.json
@@ -42,11 +42,13 @@
     "path": "~0.4.9",
     "q": "^1.0.1",
     "request": "2.34.x",
+    "request-promise-native": "^1.0.3",
     "stathat": "0.0.8",
     "superagent": "^2.3.0",
     "underscore": "^1.8.3",
     "winston": "0.8.x",
-    "winston-mongodb": "0.5.x"
+    "winston-mongodb": "0.5.x",
+    "xml2json": "^0.10.0"
   },
   "devDependencies": {
     "@dosomething/eslint-config": "^1.1.1",


### PR DESCRIPTION
#### What's this PR do?
- Adds some new packages
- Adds new fields to campaign model
- Creates mobile commons groups per campaign
- Saves ID's to model

#### How should this be reviewed?
LOL this is fun. So when testing in Mobile Commons, you cannot simple "delete" a group. You have to rename the group to some random string, then delete it. MoCo reserves the string in namespace even after you delete it.

#### Any background context you want to provide?
Part 2 of this will be exposing this data

#### Relevant tickets
Fixes #

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
