### PR TITLE
CampaignBot support to send confirmation messages for external signups

### DIFF
--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -23,34 +23,6 @@ class CampaignBotController {
   }
 
   /**
-   * Upserts model for given Northstar Signup.
-   */
-  cacheSignup(northstarSignup) {
-    logger.debug(`cacheSignup id:${northstarSignup.id}`);
-
-    const data = {
-      _id: Number(northstarSignup.id),
-      user: northstarSignup.user,
-      campaign: northstarSignup.campaign,
-      // Delete existing draft submission in case we're updating existing
-      // Signup model (e.g. if we're handling a clear cache command)
-      draft_reportback_submission: null,
-    };
-    // Only set if this was called from postSignup(req).
-    if (northstarSignup.keyword) {
-      data.keyword = northstarSignup.keyword;
-    }
-    if (northstarSignup.reportback) {
-      data.reportback = Number(northstarSignup.reportback.id);
-      data.total_quantity_submitted = northstarSignup.reportback.quantity;
-    }
-
-    return app.locals.db.signups
-      .findOneAndUpdate({ _id: northstarSignup.id }, data, { upsert: true, new: true })
-      .exec();
-  }
-
-  /**
    * Upserts model for given Northstar User.
    */
   cacheUser(northstarUser) {
@@ -222,7 +194,7 @@ class CampaignBotController {
       const currentSignup = signups[0];
       this.debug(req, `currentSignup.id:${currentSignup.id}`);
 
-      return this.cacheSignup(currentSignup);
+      return app.locals.db.signups.store(currentSignup);
     })
     .then((signupDoc) => {
       if (!signupDoc) {

--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -332,7 +332,7 @@ class CampaignBotController {
 
     // Check if Northstar User exists for mobile number.
     return app.locals.db.users
-      .get('mobile', req.body.phone)
+      .lookup('mobile', req.body.phone)
       .then((user) => {
         if (!user) {
           return this.postUser(req);

--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -217,28 +217,6 @@ class CampaignBotController {
   }
 
   /**
-   * Gets User from DS API if exists for given type/id, else creates new User.
-   * @param {object} req
-   * @return {object} - User model
-   */
-  getUser(type, id) {
-    logger.debug(`getUser type:${type} id:${id}`);
-
-    return app.locals.clients.northstar.Users
-      .get(type, id)
-      .then((user) => {
-        logger.debug('northstar.Users.get success');
-
-        return this.cacheUser(user);
-      })
-      .catch(() => {
-        logger.debug(`could not getUser type:${type} id:${id}`);
-
-        return null;
-      });
-  }
-
-  /**
    * Returns whether current user has submitted a Reportback for the current campaign.
    * @param {object} req
    * @return {bool}
@@ -337,7 +315,7 @@ class CampaignBotController {
           if (!user) {
             this.debug(req, `no doc for user:${userID}`);
 
-            return this.getUser('id', userID);
+            return app.locals.db.users.get('id', userID);
           }
           this.debug(req, `found doc for user:${userID}`);
 
@@ -352,8 +330,8 @@ class CampaignBotController {
     }
 
     // Check if Northstar User exists for mobile number.
-    return this
-      .getUser('mobile', req.body.phone)
+    return app.locals.db.users
+      .get('mobile', req.body.phone)
       .then((user) => {
         if (!user) {
           return this.postUser(req);

--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -174,6 +174,7 @@ class CampaignBotController {
    * Gets Signup from DS API if exists for given user, else creates new Signup.
    * @param {object} req - Express request, expects loaded user and campaign.
    * @return {object} - Signup model
+   * TODO: Split this out into Signup/User methods.
    */
   getCurrentSignup(req) {
     this.debug(req, 'getCurrentSignup');
@@ -194,7 +195,7 @@ class CampaignBotController {
       const currentSignup = signups[0];
       this.debug(req, `currentSignup.id:${currentSignup.id}`);
 
-      return app.locals.db.signups.store(currentSignup);
+      return app.locals.db.signups.storeNorthstarSignup(currentSignup);
     })
     .then((signupDoc) => {
       if (!signupDoc) {
@@ -535,7 +536,7 @@ class CampaignBotController {
     msg = msg.replace(/{{cmd_reportback}}/i, process.env.GAMBIT_CMD_REPORTBACK);
     msg = msg.replace(/{{cmd_member_support}}/i, process.env.GAMBIT_CMD_MEMBER_SUPPORT);
 
-    if (campaign.keywords) {
+    if (campaign.keywords.length) {
       let keyword = campaign.keywords[0].toUpperCase();
       if (req.signup && req.signup.keyword) {
         keyword = req.signup.keyword.toUpperCase();

--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -537,19 +537,6 @@ class CampaignBotController {
     return msg;
   }
 
-  /**
-   * Updates the given User model's current_campaign property to given campaignId.
-   */
-  setCurrentCampaign(user, campaignId) {
-    if (campaignId === user.current_campaign) {
-      return true;
-    }
-
-    return app.locals.db.users
-      .findByIdAndUpdate(user._id, { current_campaign: campaignId })
-      .exec();
-  }
-
 }
 
 module.exports = CampaignBotController;

--- a/api/models/Signup.js
+++ b/api/models/Signup.js
@@ -42,12 +42,12 @@ module.exports = function (connection) {
 /**
  * Query DS API for given Signup id and store.
  */
-signupSchema.statics.getById = Promise.method(function(id) {
+signupSchema.statics.getById = Promise.method((id) => {
   app.locals.logger.debug(`Signup.getById:${id}`);
 
   return app.locals.clients.northstar.Signups.get(id)
     .then(northstarSignup => {
-      logger.debug(northstarSignup);
+      logger.debug(`northstar.Signups.get:${id} success`);
 
       return signupSchema.statics.store(northstarSignup);
     });
@@ -56,8 +56,8 @@ signupSchema.statics.getById = Promise.method(function(id) {
 /**
  * Parse given Northstar Signup and return Signup model.
  */
-signupSchema.statics.store = Promise.method(function(northstarSignup) {
-  logger.debug(`cacheSignup id:${northstarSignup.id}`);
+signupSchema.statics.store = Promise.method((northstarSignup) => {
+  logger.debug(`Signup.store id:${northstarSignup.id}`);
 
   const data = {
     _id: Number(northstarSignup.id),

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -1,11 +1,17 @@
 'use strict';
 
 /**
- * Models a DS User.
+ * Imports.
  */
 const mongoose = require('mongoose');
+const Promise = require('bluebird');
 
-const schema = new mongoose.Schema({
+const logger = app.locals.logger;
+
+/**
+ * Schema.
+ */
+const userSchema = new mongoose.Schema({
 
   _id: { type: String, index: true },
   // TODO: Not sure we need this index
@@ -22,5 +28,52 @@ const schema = new mongoose.Schema({
 });
 
 module.exports = function (connection) {
-  return connection.model('users', schema);
+  return connection.model('users', userSchema);
 };
+
+/**
+ * Statics.
+ */
+
+/**
+ * Query DS API for given User type/id and store.
+ */
+userSchema.statics.get = Promise.method((type, id) => {
+  logger.debug(`User.get type:${type} id:${id}`);
+
+  return app.locals.clients.northstar.Users
+    .get(type, id)
+    .then((northstarUser) => {
+      logger.debug('northstar.Users.get success');
+
+      return userSchema.statics.store(northstarUser);
+    })
+    .catch(() => {
+      logger.debug(`could not getUser type:${type} id:${id}`);
+
+      return null;
+    });
+});
+
+/**
+ * Parse given Northstar User and return User model.
+ */
+userSchema.statics.store = Promise.method((northstarUser) => {
+  logger.debug(`User.store id:${northstarUser.id}`);
+
+  const data = {
+    _id: northstarUser.id,
+    mobile: northstarUser.mobile,
+    first_name: northstarUser.firstName,
+    email: northstarUser.email,
+    phoenix_id: northstarUser.drupalID,
+    role: northstarUser.role,
+    campaigns: {},
+  };
+
+  return app.locals.db.users
+    .findOneAndUpdate({ _id: data._id }, data, {
+      upsert: true,
+      new: true,
+    });
+});

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -46,16 +46,16 @@ function parseNorthstarUser(northstarUser) {
 /**
  * Query DS API for given User type/id and store.
  */
-userSchema.statics.get = function (type, id) {
+userSchema.statics.lookup = function (type, id) {
   const model = this;
 
   return new Promise((resolve, reject) => {
-    logger.debug(`User.get type:${type} id:${id}`);
+    logger.debug(`User.lookup type:${type} id:${id}`);
 
     return app.locals.clients.northstar.Users
       .get(type, id)
       .then((northstarUser) => {
-        logger.debug('northstar.Users.get success');
+        logger.debug('northstar.Users.lookup success');
         const data = parseNorthstarUser(northstarUser);
 
         return model

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -63,7 +63,33 @@ userSchema.statics.lookup = function (type, id) {
           .exec()
           .then(user => resolve(user))
           .catch(error => reject(error));
-      });
+      })
+      .catch((error) => reject(error));
+  });
+};
+
+/**
+ * Post user to DS API.
+ */
+userSchema.statics.post = function (newUser) {
+  const model = this;
+
+  return new Promise((resolve, reject) => {
+    logger.debug(`User.post data:${JSON.stringify(newUser)}`);
+
+    return app.locals.clients.northstar.Users
+      .create(newUser)
+      .then((northstarUser) => {
+        logger.info(`northstar.Users created user:${northstarUser.id}`);
+        const data = parseNorthstarUser(northstarUser);
+
+        return model
+          .findOneAndUpdate({ _id: data._id }, data, { upsert: true, new: true })
+          .exec()
+          .then(user => resolve(user))
+          .catch(error => reject(error));
+      })
+      .catch(error => reject(error));
   });
 };
 

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -94,9 +94,9 @@ userSchema.statics.post = function (newUser) {
 };
 
 /**
- * Set given signup campaign to user current_campaign, stores to campaigns hash map.
+ * Set given signup on user's campaigns hash map, sets signup.campaign to user.current_campaign.
  */
-userSchema.methods.setCurrentSignup = function (signup) {
+userSchema.methods.setCurrentCampaign = function (signup) {
   const user = this;
 
   return new Promise((resolve, reject) => {

--- a/config/router-chatbot.js
+++ b/config/router-chatbot.js
@@ -116,7 +116,7 @@ router.post('/', (req, res) => {
     return app.locals.db.signups
       .getById(signupID)
       .then((signup) => {
-        logger.debug(signup);
+        logger.debug(`signup.user:${signup.user}`);
 
         return res.send(signup);
       });

--- a/config/router-chatbot.js
+++ b/config/router-chatbot.js
@@ -102,6 +102,8 @@ router.post('/', (req, res) => {
       .lookupByID(signupID)
       .then((signup) => {
         currentSignup = signup;
+        // TODO: Check if currentSignup.campaign is defined in CAMPAIGNBOT_CAMPAIGNS.
+        // If it's not, send Express response to alert, and exit.
 
         return app.locals.db.users.lookup('id', currentSignup.user);
       })

--- a/config/router-chatbot.js
+++ b/config/router-chatbot.js
@@ -101,7 +101,7 @@ router.post('/', (req, res) => {
       .then((signup) => {
         currentSignup = signup;
 
-        return app.locals.db.users.get('id', currentSignup.user);
+        return app.locals.db.users.lookup('id', currentSignup.user);
       })
       .then((user) => {
         if (!user) {

--- a/config/router-chatbot.js
+++ b/config/router-chatbot.js
@@ -84,6 +84,9 @@ router.post('/', (req, res) => {
 
   let campaignID;
 
+  /**
+   * Check for Mobile Commons Keyword Signup from incoming mData request.
+   */
   if (req.body.keyword) {
     scope.keyword = req.body.keyword.toLowerCase();
     logger.debug(`keyword:${scope.keyword}`);
@@ -95,6 +98,22 @@ router.post('/', (req, res) => {
 
       return res.sendStatus(500);
     }
+  }
+
+  /**
+   * Check for external Signup from incoming Quicksilver request.
+   */
+  if (req.body.signup) {
+    const signupID = Number(req.body.signup);
+    logger.debug(`signupID:${signupID}`);
+
+    return app.locals.db.signups
+      .getById(signupID)
+      .then((signup) => {
+        logger.debug(signup);
+
+        return res.send(signup);
+      });
   }
 
   const controller = app.locals.controllers.campaignBot;

--- a/config/router-chatbot.js
+++ b/config/router-chatbot.js
@@ -52,6 +52,12 @@ function sendSmsResponse(req, msg) {
  */
 router.post('/', (req, res) => {
   const scope = req;
+  const controller = app.locals.controllers.campaignBot;
+  if (!controller) {
+    logger.error('app.locals.controllers.campaignBot undefined');
+
+    return res.sendStatus(500);
+  }
 
   scope.incoming_message = req.body.args;
   scope.incoming_image_url = req.body.mms_image_url;
@@ -114,13 +120,6 @@ router.post('/', (req, res) => {
 
         return res.send(signup);
       });
-  }
-
-  const controller = app.locals.controllers.campaignBot;
-  if (!controller) {
-    logger.error('app.locals.controllers.campaignBot undefined');
-
-    return res.sendStatus(500);
   }
 
   return controller

--- a/config/router-chatbot.js
+++ b/config/router-chatbot.js
@@ -108,7 +108,7 @@ router.post('/', (req, res) => {
           return res.status(500).status('Cannot find user for signup');
         }
 
-        return user.setCurrentSignup(currentSignup);
+        return user.setCurrentCampaign(currentSignup);
       })
       .then((user) => {
         scope.user = user;
@@ -223,7 +223,7 @@ router.post('/', (req, res) => {
     })
     .then(msg => {
       controller.debug(scope, `sendMessage:${msg}`);
-      controller.setCurrentCampaign(scope.user, scope.campaign._id);
+      scope.user.setCurrentCampaign(scope.signup);
       sendToMobileCommons(scope, msg);
 
       return res.send(gambitResponse(msg));

--- a/documentation/endpoints/chatbot.md
+++ b/documentation/endpoints/chatbot.md
@@ -3,7 +3,6 @@
 ```
 POST /v1/chatbot
 ```
-Currently only implemented in [Mobile Commons](https://github.com/DoSomething/gambit/wiki/Chatbot#networking).
 
 **Headers**
 
@@ -15,18 +14,32 @@ Name | Type | Description
 
 Name | Type | Description
 --- | --- | ---
-`bot_type` | `string` | Can set to `donorschoosebot`, otherwise defaults to `campaignbot`.
+`bot_type` | `string` | Defaults to `campaignbot`, accepts `donorschoosebot`
 `start` | `boolean` | If set, the bot will begin a new DonorsChoose conversation if `bot_type=donorschoose`. Default: `false`
 
 **Input**
 
+***Mobile Commons***
+
+Params from incoming [Mobile Commons](https://github.com/DoSomething/gambit/wiki/Chatbot#networking) mData requests.
+
 Name | Type | Description
 --- | --- | ---
 `phone` | `string` | **Required.** Our member's mobile number.
-`args` | `string` | An incoming message the member has sent.
-`keyword` | `string` | If set, it's the [Mobile Commons keyword](https://github.com/DoSomething/gambit/wiki/Chatbot#mdata) that the sender's incoming message triggered.
+`args` | `string` | Incoming message the member has sent.
+`keyword` | `string` | [Mobile Commons keyword](https://github.com/DoSomething/gambit/wiki/Chatbot#mdata) that the triggered incoming Mobile Commons mData request.
+`mms_image_url` | `string` | URL of incoming image member as has sent.
 `profile_first_name` | `string` | 
 `profile_email` | `string` | 
 `profile_northstar_id` | `string` | 
 `profile_postal_code` | `string` | 
 `profile_ss2016_donation_count` | `string` | Used by `donorschoose` bots to limit # of donations. This parameter name can be changed by `DONORSCHOOSE_DONATION_FIELDNAME`
+
+***Quicksilver***
+
+Params from incoming [Quicksilver](https://github.com/DoSomething/gambit/wiki/Chatbot#quicksilver) requests.
+
+Name | Type | Description
+--- | --- | ---
+`signup_id` | `number` | DS Signup ID to update Gambit cache for
+`signup_source` | `string` | Required if `signup_id` is set

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@dosomething/northstar-js": "git://github.com/DoSomething/northstar-js.git",
     "@dosomething/phoenix-js": "git://github.com/DoSomething/phoenix-js.git",
+    "bluebird": "^3.4.6",
     "body-parser": "^1.9.2",
     "connect-multiparty": "1.1.0",
     "count-von-count": "^1.0.0",


### PR DESCRIPTION
#### What's this PR do?

* Adds support to send Signup confirmation messages from CampaignBot for external (non Gambit) Signups:

    * Clients like Quicksilver should post to the `chatbot` endpoint and pass the `signup_id` and its `signup_source`

    * If the incoming `signup_source` is equal to the Gambit `DS_API_POST_SOURCE`, we don't send the confirmation message (we'll have already sent it to the User after they signed up through Gambit)

* Refactors `CampaignBotController` methods like `getUser` and `cacheSignup` as [Mongoose static and instance methods](http://mongoosejs.com/docs/guide.html#methods) in the relevant model classes

    * Adds Bluebird to promisify the new static/instance methods 

#### How should this be reviewed?
code 👀 
staging 📲 

#### Relevant tickets
#642 

#### Checklist
- [x] Tested on staging.