### PR TITLE
Post separate User Registration source value

### DIFF
--- a/app/models/User.js
+++ b/app/models/User.js
@@ -75,7 +75,7 @@ userSchema.statics.post = function (data) {
   const model = this;
 
   const scope = data;
-  scope.source = process.env.DS_API_POST_SOURCE;
+  scope.source = process.env.DS_API_USER_REGISTRATION_SOURCE || 'sms';
   scope.password = helpers.generatePassword(data.mobile);
   const emailDomain = process.env.DS_API_DEFAULT_USER_EMAIL || 'mobile.import';
   scope.email = `${data.mobile}@${emailDomain}`;


### PR DESCRIPTION
#### What's this PR do?
Sets a different env variable to keep User registration source as `sms` -- per legacy `reportback` endpoint

#### How should this be reviewed?
Find someone who doesn't have a DS Mobile Commons Profile, or post a dummy number to Thor like I do

#### Relevant tickets
Fixes #694 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.

