### PR TITLE
Groups api

### DIFF
--- a/app/models/Campaign.js
+++ b/app/models/Campaign.js
@@ -96,17 +96,19 @@ campaignSchema.methods.createMobileCommonsGroups = function () {
   const campaignRunId = this.current_run;
 
   function parseApiRes(res) {
-    if (res._id) {
-      // If a group is in the response, save the data for this env.
-      const env = process.env.NODE_ENV;
-      const hasEnv = env in res.mobilecommons_groups;
-      return {
-        doing: hasEnv ? res.mobilecommons_groups[env].doing : '',
-        completed: hasEnv ? res.mobilecommons_groups[env].completed : '',
-      };
+    if (!res._id) {
+      return false;
     }
 
-    return false;
+    const env = process.env.NODE_ENV;
+    if (!res.mobilecommons_groups[env]) {
+      return false;
+    }
+
+    return {
+      doing: res.mobilecommons_groups[env].doing,
+      completed: res.mobilecommons_groups[env].completed,
+    }
   }
 
   gambitGroups.findGroup(campaignId, campaignRunId).then((res) => {

--- a/app/models/Campaign.js
+++ b/app/models/Campaign.js
@@ -103,7 +103,7 @@ campaignSchema.methods.createMobileCommonsGroups = function () {
       const env = process.env.NODE_ENV;
       return {
         doing: res.mobilecommons_groups[env].doing,
-        completed: res.mobilecommons_groups[env].completed
+        completed: res.mobilecommons_groups[env].completed,
       };
     }
 
@@ -122,7 +122,7 @@ campaignSchema.methods.createMobileCommonsGroups = function () {
     return gambitGroups.createGroup(campaignId, campaignRunId);
   })
   .then(res => {
-    if (res == undefined) {
+    if (res === undefined) {
       return;
     }
 
@@ -134,7 +134,7 @@ campaignSchema.methods.createMobileCommonsGroups = function () {
   })
   .then(() => {
     this.save();
-  })
+  });
 };
 
 module.exports = function (connection) {

--- a/app/models/Campaign.js
+++ b/app/models/Campaign.js
@@ -98,7 +98,8 @@ campaignSchema.methods.createMobileCommonsGroups = function () {
   function parseApiRes(res) {
     if (res._id) {
       // If a group is in the response, save the data for this env.
-      const hasEnv = process.env.NODE_ENV in res.mobilecommons_groups;
+      const env = process.env.NODE_ENV;
+      const hasEnv = env in res.mobilecommons_groups;
       return {
         doing: hasEnv ? res.mobilecommons_groups[env].doing : '',
         completed: hasEnv ? res.mobilecommons_groups[env].completed : '',

--- a/app/models/Campaign.js
+++ b/app/models/Campaign.js
@@ -4,9 +4,8 @@
  * Models a DS Campaign.
  */
 const mongoose = require('mongoose');
-const mobilecommons = rootRequire('lib/mobilecommons');
-const parser = require('xml2json');
 const logger = app.locals.logger;
+const gambitGroups = require('../../lib/groups');
 
 const campaignSchema = new mongoose.Schema({
 
@@ -59,23 +58,6 @@ function parsePhoenixCampaign(phoenixCampaign) {
   return data;
 }
 
-/**
- * For a given campaign, update its mobile commons group id,
- * based on the mobile commons response.
- * @param {Campaign} campaign    Campaign model to update.
- * @param {string} status        Either completed or doing.
- * @param {string} groupResponse XML string from mobile commons API.
- */
-function setMobileCommonsGroup(campaign, status, groupResponse) {
-  const scope = campaign;
-  const parsedGroup = JSON.parse(parser.toJson(groupResponse));
-  // If the group name is available...
-  if (parsedGroup.response.success === 'true') {
-    // Save newly created group id to this campaign.
-    const groupId = parsedGroup.response.group.id;
-    scope.mobilecommons_groups[status] = groupId;
-  }
-}
 
 /**
  * Get given Campaigns from DS API then store.
@@ -112,18 +94,51 @@ campaignSchema.statics.lookupByIDs = function (campaignIDs) {
  * @see https://github.com/DoSomething/gambit/issues/673
  */
 campaignSchema.methods.createMobileCommonsGroups = function () {
-  const campaign = this;
-  const prefix = `env=${process.env.NODE_ENV}
-                  campaign_id=${campaign._id}
-                  run_id=${campaign.current_run}`;
+  const campaignId = this._id;
+  const campaignRunId = this.current_run;
 
-  // Create mobile commons group with custom name based on this campaign
-  mobilecommons.createGroup(`${prefix} status=doing`)
-  .then(doingGroup => setMobileCommonsGroup(campaign, 'doing', doingGroup))
-  .then(() => mobilecommons.createGroup(`${prefix} status=completed`))
-  .then(completedGroup => setMobileCommonsGroup(campaign, 'completed', completedGroup))
-  .then(() => campaign.save())
-  .catch(err => logger.error(err));
+  function parseApiRes(res) {
+    if (res._id) {
+      // If a group is in the response, save the data for this env.
+      const env = process.env.NODE_ENV;
+      return {
+        doing: res.mobilecommons_groups[env].doing,
+        completed: res.mobilecommons_groups[env].completed
+      };
+    }
+
+    return false;
+  }
+
+  gambitGroups.findGroup(campaignId, campaignRunId).then(res => {
+    // If a group was found, save the data.
+    const parsedRes = parseApiRes(res);
+    if (parsedRes) {
+      this.mobilecommons_groups.doing = parsedRes.doing;
+      this.mobilecommons_groups.completed = parsedRes.completed;
+      return true;
+    }
+
+    return false
+  })
+  .then(requiresCreation => {
+    if (!requiresCreation) {
+      return;
+    }
+
+    // Otherwise, create a new group.
+    gambitGroups.createGroup(campaignId, campaignRunId).then(res => {
+      const parsedRes = parseApiRes(res);
+      if (parsedRes) {
+        this.mobilecommons_groups.doing = parsedRes.doing;
+        this.mobilecommons_groups.completed = parsedRes.completed;
+        return;
+      }
+    });
+  })
+  .then(() => {
+    this.save();
+  })
 };
 
 module.exports = function (connection) {

--- a/app/models/Campaign.js
+++ b/app/models/Campaign.js
@@ -36,10 +36,8 @@ const campaignSchema = new mongoose.Schema({
   msg_no_photo_sent: String,
 
   // Mobile Commons Specific Fields.
-  mobilecommons_groups: {
-    doing: Number,
-    completed: Number,
-  },
+  mobilecommons_group_doing: Number,
+  mobilecommons_group_completed: Number,
 
 });
 
@@ -114,8 +112,8 @@ campaignSchema.methods.createMobileCommonsGroups = function () {
     // If a group was found, save the data.
     const parsedRes = parseApiRes(res);
     if (parsedRes) {
-      this.mobilecommons_groups.doing = parsedRes.doing;
-      this.mobilecommons_groups.completed = parsedRes.completed;
+      this.mobilecommons_group_doing = parsedRes.doing;
+      this.mobilecommons_group_completed = parsedRes.completed;
       return undefined;
     }
 
@@ -128,8 +126,8 @@ campaignSchema.methods.createMobileCommonsGroups = function () {
 
     const parsedRes = parseApiRes(res);
     if (parsedRes) {
-      this.mobilecommons_groups.doing = parsedRes.doing;
-      this.mobilecommons_groups.completed = parsedRes.completed;
+      this.mobilecommons_group_doing = parsedRes.doing;
+      this.mobilecommons_group_completed = parsedRes.completed;
     }
   })
   .then(() => {

--- a/app/models/Campaign.js
+++ b/app/models/Campaign.js
@@ -108,7 +108,7 @@ campaignSchema.methods.createMobileCommonsGroups = function () {
     return {
       doing: res.mobilecommons_groups[env].doing,
       completed: res.mobilecommons_groups[env].completed,
-    }
+    };
   }
 
   gambitGroups.findGroup(campaignId, campaignRunId).then((res) => {

--- a/app/models/Campaign.js
+++ b/app/models/Campaign.js
@@ -98,17 +98,17 @@ campaignSchema.methods.createMobileCommonsGroups = function () {
   function parseApiRes(res) {
     if (res._id) {
       // If a group is in the response, save the data for this env.
-      const env = process.env.NODE_ENV;
+      const hasEnv = process.env.NODE_ENV in res.mobilecommons_groups;
       return {
-        doing: res.mobilecommons_groups[env].doing,
-        completed: res.mobilecommons_groups[env].completed,
+        doing: hasEnv ? res.mobilecommons_groups[env].doing : '',
+        completed: hasEnv ? res.mobilecommons_groups[env].completed : '',
       };
     }
 
     return false;
   }
 
-  gambitGroups.findGroup(campaignId, campaignRunId).then(res => {
+  gambitGroups.findGroup(campaignId, campaignRunId).then((res) => {
     // If a group was found, save the data.
     const parsedRes = parseApiRes(res);
     if (parsedRes) {
@@ -119,8 +119,8 @@ campaignSchema.methods.createMobileCommonsGroups = function () {
 
     return gambitGroups.createGroup(campaignId, campaignRunId);
   })
-  .then(res => {
-    if (res === undefined) {
+  .then((res) => {
+    if (!res) {
       return;
     }
 

--- a/app/models/Campaign.js
+++ b/app/models/Campaign.js
@@ -116,25 +116,21 @@ campaignSchema.methods.createMobileCommonsGroups = function () {
     if (parsedRes) {
       this.mobilecommons_groups.doing = parsedRes.doing;
       this.mobilecommons_groups.completed = parsedRes.completed;
-      return true;
+      return undefined;
     }
 
-    return false
+    return gambitGroups.createGroup(campaignId, campaignRunId);
   })
-  .then(requiresCreation => {
-    if (!requiresCreation) {
+  .then(res => {
+    if (res == undefined) {
       return;
     }
 
-    // Otherwise, create a new group.
-    gambitGroups.createGroup(campaignId, campaignRunId).then(res => {
-      const parsedRes = parseApiRes(res);
-      if (parsedRes) {
-        this.mobilecommons_groups.doing = parsedRes.doing;
-        this.mobilecommons_groups.completed = parsedRes.completed;
-        return;
-      }
-    });
+    const parsedRes = parseApiRes(res);
+    if (parsedRes) {
+      this.mobilecommons_groups.doing = parsedRes.doing;
+      this.mobilecommons_groups.completed = parsedRes.completed;
+    }
   })
   .then(() => {
     this.save();

--- a/lib/groups.js
+++ b/lib/groups.js
@@ -1,0 +1,65 @@
+'use strict';
+
+/**
+ * API Wrapper for the Gambit Groups API.
+ */
+
+const superagent = require('superagent');
+const logger = app.locals.logger;
+
+const uri = process.env.GAMBIT_GROUPS_API_URI;
+const apiKey = process.env.GAMBIT_GROUPS_API_KEY;
+const apiHeaderName = 'x-gambit-group-api-key';
+
+/**
+ * Make a GET request to Gambit Groups API.
+ * Handles authentication & URL formation.
+ * @param  {string} path API Path. eg: /group
+ * @return {Promise}
+ */
+function get(path) {
+  return superagent.get(`${uri}${path}`)
+    .set(apiHeaderName, apiKey)
+    .then(res => res.body)
+    .catch(error => logger.error(error));
+}
+
+/**
+ * Make a post request to Gambit Groups API.
+ * Handles authentication & URL formation.
+ * @param  {string} path API Path. eg: /group
+ * @param  {object} data JSON data to send.
+ * @return {Promise}
+ */
+function post(path, data) {
+  return superagent.post(`${uri}${path}`)
+    .send(data)
+    .set(apiHeaderName, apiKey)
+    .then(res => res.body)
+    .catch(error => logger.error(error));
+}
+
+module.exports = {
+  /**
+   * Find the group for the given campaign ID & run ID.
+   * @param  {int} campaignId    Campaign ID to search for.
+   * @param  {int} campaignRunId Campaign Run ID to search for.
+   * @return {Promise}
+   */
+  findGroup: function(campaignId, campaignRunId) {
+    return get(`/group/${campaignId}/${campaignRunId}`);
+  },
+
+  /**
+   * Create a group for the given campaign ID & run ID.
+   * @param  {int} campaignId    Campaign ID to create a group for.
+   * @param  {ibt} campaignRunId Campaign Run ID to create a group for.
+   * @return {Promise}
+   */
+  createGroup: function(campaignId, campaignRunId) {
+    return post('/group', {
+      campaign_id: campaignId,
+      campaign_run_id: campaignRunId
+    });
+  }
+}

--- a/lib/groups.js
+++ b/lib/groups.js
@@ -61,5 +61,15 @@ module.exports = {
       campaign_id: campaignId,
       campaign_run_id: campaignRunId
     });
-  }
+  },
+
+  /**
+   * See docblock above.
+   */
+  get: get,
+
+  /**
+   * See docblock above.
+   */
+  post: post,
 }

--- a/lib/groups.js
+++ b/lib/groups.js
@@ -11,35 +11,35 @@ const uri = process.env.GAMBIT_GROUPS_API_URI;
 const apiKey = process.env.GAMBIT_GROUPS_API_KEY;
 const apiHeaderName = 'x-gambit-group-api-key';
 
-/**
- * Make a GET request to Gambit Groups API.
- * Handles authentication & URL formation.
- * @param  {string} path API Path. eg: /group
- * @return {Promise}
- */
-function get(path) {
-  return superagent.get(`${uri}${path}`)
-    .set(apiHeaderName, apiKey)
-    .then(res => res.body)
-    .catch(error => logger.error(error));
-}
-
-/**
- * Make a post request to Gambit Groups API.
- * Handles authentication & URL formation.
- * @param  {string} path API Path. eg: /group
- * @param  {object} data JSON data to send.
- * @return {Promise}
- */
-function post(path, data) {
-  return superagent.post(`${uri}${path}`)
-    .send(data)
-    .set(apiHeaderName, apiKey)
-    .then(res => res.body)
-    .catch(error => logger.error(error));
-}
-
 module.exports = {
+  /**
+   * Make a GET request to Gambit Groups API.
+   * Handles authentication & URL formation.
+   * @param  {string} path API Path. eg: /group
+   * @return {Promise}
+   */
+  get: function (path) {
+    return superagent.get(`${uri}${path}`)
+      .set(apiHeaderName, apiKey)
+      .then(res => res.body)
+      .catch(error => logger.error(error));
+  },
+
+  /**
+   * Make a post request to Gambit Groups API.
+   * Handles authentication & URL formation.
+   * @param  {string} path API Path. eg: /group
+   * @param  {object} data JSON data to send.
+   * @return {Promise}
+   */
+  post: function (path, data) {
+    return superagent.post(`${uri}${path}`)
+      .send(data)
+      .set(apiHeaderName, apiKey)
+      .then(res => res.body)
+      .catch(error => logger.error(error));
+  },
+
   /**
    * Find the group for the given campaign ID & run ID.
    * @param  {int} campaignId    Campaign ID to search for.
@@ -47,7 +47,7 @@ module.exports = {
    * @return {Promise}
    */
   findGroup: function(campaignId, campaignRunId) {
-    return get(`/group/${campaignId}/${campaignRunId}`);
+    return this.get(`/group/${campaignId}/${campaignRunId}`);
   },
 
   /**
@@ -57,19 +57,9 @@ module.exports = {
    * @return {Promise}
    */
   createGroup: function(campaignId, campaignRunId) {
-    return post('/group', {
+    return this.post('/group', {
       campaign_id: campaignId,
       campaign_run_id: campaignRunId
     });
   },
-
-  /**
-   * See docblock above.
-   */
-  get: get,
-
-  /**
-   * See docblock above.
-   */
-  post: post,
 }

--- a/server.js
+++ b/server.js
@@ -122,6 +122,10 @@ conn.on('connected', () => {
         app.locals.campaigns[campaignID] = campaign;
         logger.debug(`loaded app.locals.campaigns[${campaignID}]`);
 
+        if (!campaign.mobilecommons_groups.doing || !campaign.mobilecommons_groups.completed) {
+          campaign.createMobileCommonsGroups();
+        }
+
         if (!campaign.keywords.length) {
           logger.warn(`no keywords defined for campaign:${campaignID}`);
         }

--- a/server.js
+++ b/server.js
@@ -126,7 +126,7 @@ conn.on('connected', () => {
           campaign.createMobileCommonsGroups();
         }
 
-        if (!campaign.keywords.length < 1) {
+        if (campaign.keywords.length < 1) {
           logger.warn(`no keywords defined for campaign:${campaignID}`);
         }
         campaign.keywords.forEach((campaignKeyword) => {

--- a/server.js
+++ b/server.js
@@ -122,7 +122,7 @@ conn.on('connected', () => {
         app.locals.campaigns[campaignID] = campaign;
         logger.debug(`loaded app.locals.campaigns[${campaignID}]`);
 
-        if (!campaign.mobilecommons_groups.doing || !campaign.mobilecommons_groups.completed) {
+        if (!campaign.mobilecommons_group_doing || !campaign.mobilecommons_group_completed) {
           campaign.createMobileCommonsGroups();
         }
 


### PR DESCRIPTION
#### What's this PR do?
- Adds gambit groups API lib
- Makes calls to Gambit Groups API. **Requires dot env file update!**
- Creates groups for campaigns if not present on the campaign

#### How should this be reviewed?
Good lord. Heres the TLDR, it works:
![screen shot 2016-10-28 at 1 28 17 pm](https://cloud.githubusercontent.com/assets/897368/19817513/cf2ef68a-9d19-11e6-908e-7cc64999a68f.png)
![screen shot 2016-10-28 at 1 28 24 pm](https://cloud.githubusercontent.com/assets/897368/19817514/cf31a66e-9d19-11e6-8210-1587148a6cfb.png)

If you want to test this 100% through, you need to be really careful.
1. Delete the campaigns in your local DB.
2. Delete the group in the gambit groups prod DB.
3. Search mobile commons groups on there site for `campaign_id=some id`
4. Keep that tab open & open all 6 results into a new tab.
5. Rename each of those groups with some added random text. (We should probably start doing deleteme or some string that groups them together, sorry)
6. In that tab from step 3, select all of the groups & delete all.
7. Run Gambit.
HAVE FUN!

#### Any background context you want to provide?
I need a cookie if you're gonna make me write this one out again.

#### Relevant tickets
Fixes #673 

#### Checklist
- [ ] Tested on staging.
