### PR TITLE
Ensure response contains text when asking for caption or why_participated

### DIFF
--- a/app/controllers/CampaignBotController.js
+++ b/app/controllers/CampaignBotController.js
@@ -313,6 +313,7 @@ class CampaignBotController {
    * Replaces placeholder variables in given msgTxt with data from incoming req
    * @param {object} req - Express request
    * @param {string} msgType - Type of bot message to send back
+   * @param {string} prefix - If set, prepended to the bot message text
    * @return {string} - msgTxt with all variables replaced with req properties
    */
   renderResponseMessage(req, msgType, prefix) {


### PR DESCRIPTION
#### What's this PR do?

Prevents User from submitting a photo (without a text response) for the Reportback Submission `caption` or `why_participated` -- resulting in null data on the DS backend.
#### How should this be reviewed?

Locally: 
- Don't pass `args`, only pass `mms_image_url` when responding to Ask Caption or Ask Why Participated, mimicing the response we receive from Mobile Commons if a user responds with an image and no text. 
- Verify the message returned is the Ask message, prefixed with "Sorry I didn't understand that".

Staging: 
- Text CampaignBot and send an image without any text for Caption, and Why Participated.
- Verify you're prompted to send the Caption/Why again, until you send a text response.
#### Any background context you want to provide?

This is minimalist fix. It hardcodes the text "Sorry, I didn't understand that" and then repeats whatever the Ask message was. It's an edge case when this would happen at all -- but it does read  awkwardly when the Ask Message includes an affirmation -- e.g.: 

> Sorry I didn't understand that. Got it! Now send a caption for the image you sent.

To avoid - we could potentially add new CampaignBot properties for `msg_no_caption_sent` or `msg_no_why_participated_sent`. That could come at a (minimal) cost too if we want to override noun/vergb -- it's another set of messages to maintain overrides for. 

For now -- recommend we use the minimalist approach as a stopgap to prevent users from submitting photo/why without any text at all when we launch.
#### Relevant tickets

Fixes #693 
#### Checklist
- [x] Tested on staging.
