### PR TITLE
Removes old HTTP max sockets code

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: node --prof server.js
+web: npm start

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: npm start
+web: node --prof server.js

--- a/server.js
+++ b/server.js
@@ -11,9 +11,6 @@ const express = require('express');
 const http = require('http');
 const Promise = require('bluebird');
 
-// Default is 5. Increasing # of concurrent sockets per host.
-http.globalAgent.maxSockets = 100;
-
 app = express();
 
 const bodyParser = require('body-parser');

--- a/server.js
+++ b/server.js
@@ -8,7 +8,6 @@ global.rootRequire = function (name) {
 };
 
 const express = require('express');
-const http = require('http');
 const Promise = require('bluebird');
 
 app = express();


### PR DESCRIPTION
Going wayyy back in the days of Node, max sockets was capped at 5. Developers had to manually increase this. However by v0.12, this was fixed to always be infinity. https://nodejs.org/en/blog/release/v0.12.0/

By capping this at 100, we're severely hurting ourselves, and it seems to correlate with the requests per minute chart in Heroku, where we keep taking large batches of ~100 requests and then do almost nothing 
