### PR TITLE
Adds Docker support to Gambit

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.gitignore
+node_modules
+.env
+*.log

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 .git
 .gitignore
 node_modules
-.env
 *.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:6.9.1
+
+RUN npm install -g foreman
+
+# Create app directory
+RUN mkdir -p /app
+WORKDIR /app
+
+# Install app dependencies
+COPY package.json /app
+RUN npm install
+
+# Bundle app source
+COPY . /app
+
+CMD nf start

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,12 @@
 FROM node:6.9.1
 
-# Packages required to run the app
-RUN npm install -g foreman
-RUN npm install -g nodemon
-
 # Create app directory
-RUN mkdir -p /app
 WORKDIR /app
-
-# Install app dependencies
-COPY package.json /app
-RUN npm install
 
 # Bundle app source
 COPY . /app
+
+# Get NPM Modules
+RUN npm install && npm install -g foreman nodemon
 
 CMD nodemon --exec "nf start"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM node:6.9.1
 
+# Packages required to run the app
 RUN npm install -g foreman
+RUN npm install -g nodemon
 
 # Create app directory
 RUN mkdir -p /app
@@ -13,4 +15,4 @@ RUN npm install
 # Bundle app source
 COPY . /app
 
-CMD nf start
+CMD nodemon --exec "nf start"

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: npm start
+web: node server.js

--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 * :speech_balloon: :calling:
 * [docs](https://github.com/DoSomething/gambit/wiki)
+
+# Setup
+## Entire Gambit System w/ Docker
+All Gambit services & required dependencies can be setup locally with docker compose. See the [gambit-services](https://github.com/DoSomething/gambit-services) repo.
+
+## Standalone w/ Docker
+In order to setup this app & required dependencies, simply
+
+1. `git clone`
+2. `docker-compose up`
+
+### Docker setup under the hood
+All apps are executed by `Foreman` to handle process management & mimic Heroku.
+`Nodemon` will autoreload the server when a file changes.
+The compose file defines env variables for connection details & network mapping.
+
+## Standalone without Docker
+1. Run an instance of RabbitMQ, MongoDB. Two options,
+  * Install these tools locally & run them
+  * Run the docker container with just backend tooling configured.
+2. Edit .env with correct service URI's, most likely in for the form of service://localhost:<port>.
+3. `npm start` (requires Foreman from the Heroku Toolbelt)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "2"
+
+services:
+  app:
+    build: ./
+    links:
+      - mongo
+    environment:
+      - MONGO_URI=mongodb://mongo_1:27017/gambit
+    volumes:
+      - ./:/app
+
+  mongo:
+    image: mongo:latest
+    ports:
+      - "27017:27017"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     links:
       - mongo
     environment:
-      - MONGO_URI=mongodb://mongo_1:27017/gambit
+      - DB_URI=mongodb://mongo_1:27017/gambit
     volumes:
       - ./:/app
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,12 @@ version: "2"
 services:
   app:
     build: ./
+    ports:
+      - "5000:5000"
     links:
       - mongo
     environment:
+      - PORT=5000
       - DB_URI=mongodb://mongo_1:27017/gambit
     volumes:
       - ./:/app

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "stathat": "0.0.8",
     "superagent": "^2.3.0",
     "winston": "0.8.x",
-    "winston-mongodb": "0.5.x",
+    "winston-mongodb": "2.0.0",
     "xml2json": "^0.10.0"
   },
   "devDependencies": {

--- a/server.js
+++ b/server.js
@@ -22,7 +22,6 @@ const errorHandler = require('errorhandler');
 app.use(errorHandler());
 
 const DB_URI = process.env.DB_URI || 'mongodb://localhost/ds-mdata-responder';
-
 /**
  * Load logger.
  */
@@ -40,11 +39,11 @@ app.locals.logger = new (winston.Logger)({
   },
   transports: [
     new winston.transports.Console({ prettyPrint: true, colorize: true, level: WINSTON_LEVEL }),
-    new winston.transports.MongoDB({ dbUri: DB_URI, level: WINSTON_LEVEL }),
+    new winston.transports.MongoDB({ db: DB_URI, level: WINSTON_LEVEL }),
   ],
   exceptionHandlers: [
     new winston.transports.Console({ prettyPrint: true, colorize: true }),
-    new winston.transports.MongoDB({ dbUri: DB_URI }),
+    new winston.transports.MongoDB({ db: DB_URI }),
   ],
 });
 if (!app.locals.logger) {


### PR DESCRIPTION
#### What's this PR do?
- Updates winston-mongodb to latest version (Had NPM error blocking startup)
- Updates Procfile command
- Adds Dockerfile & dockerignore

#### How should this be reviewed?
This repo itself should be build-able. However to run it you'll need to use the Docker Compose file [here](https://github.com/DoSomething/gambit-services/blob/master/docker-compose.yml)

In order to test the build process still works on Heroku I made a deploy with this branch to staging,
- The build log is here (Looks ✅ ) https://dashboard.heroku.com/apps/ds-mdata-responder-staging/activity/builds/ef1ca1a8-63e6-4bbc-822a-c71686d3b693
- The logs following the app start also seem good
<img width="1145" alt="screen shot 2016-11-20 at 1 16 13 pm" src="https://cloud.githubusercontent.com/assets/897368/20465092/8aa08300-af23-11e6-8396-0e8e4fce7769.png">


#### Any background context you want to provide?
As we start moving towards more services, docker compose will make it much easier for developers to get up & running with Gambit using a consistent image across all developers.