### PR TITLE
Allow patchlevel  and minor updates to winston-mongodb

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "stathat": "0.0.8",
     "superagent": "^2.3.0",
     "winston": "0.8.x",
-    "winston-mongodb": "2.0.0"
+    "winston-mongodb": "^2.0.0"
   },
   "devDependencies": {
     "@dosomething/eslint-config": "^1.1.1",


### PR DESCRIPTION
#### What's this PR do?
Allows patch and minor updates to winston-mongodb, see https://docs.npmjs.com/misc/semver#caret-ranges-123-025-004

#### How should this be reviewed?
`npm install`

#### Any background context you want to provide?
 May have caused recent crashes on Gambit prod with the following stacktrace:

```
MongoError: index not found with name [timestamp_1]
at Function.MongoError.create (/app/node_modules/mongodb-core/lib/error.js:31:11)
at /app/node_modules/mongodb-core/lib/connection/pool.js:483:72
at authenticateStragglers (/app/node_modules/mongodb-core/lib/connection/pool.js:429:16)
at Connection.messageHandler (/app/node_modules/mongodb-core/lib/connection/pool.js:463:5)
at Socket.<anonymous> (/app/node_modules/mongodb-core/lib/connection/connection.js:309:22)
at emitOne (events.js:96:13)
at Socket.emit (events.js:191:7)
at readableAddChunk (_stream_readable.js:176:18)
at Socket.Readable.push (_stream_readable.js:134:10)
at TCP.onread (net.js:563:20)
```
The problem is described in  https://github.com/winstonjs/winston-mongodb/issues/75 and fixed in `winston-mongodb@2.0.1`. As of today, the most recent version is `winston-mongodb@2.0.8`.

cc @rapala61 