### PR TITLE
Mongo keep alive

### DIFF
--- a/server.js
+++ b/server.js
@@ -124,7 +124,25 @@ function startWorker(id) {
 
   const mongoose = require('mongoose');
   mongoose.Promise = global.Promise;
-  mongoose.connect(DB_URI);
+
+  // Based on the answers of this Stack Overflow thread
+  // http://stackoverflow.com/questions/38486384/mongodb-connection-to-mongolab-timing-out-in-nodejs-on-heroku
+  const connOpts = {
+    server: {
+      socketOptions: {
+        keepAlive: parseInt(process.env.DB_KEEPALIVE, 10) || 300000,
+        connectTimeoutMS: parseInt(process.env.DB_TIMEOUT_MS, 10) || 30000,
+      },
+    },
+    replset: {
+      socketOptions: {
+        keepAlive: parseInt(process.env.DB_KEEPALIVE, 10) || 300000,
+        connectTimeoutMS: parseInt(process.env.DB_TIMEOUT_MS, 10) || 30000,
+      },
+    },
+  };
+
+  mongoose.connect(DB_URI, connOpts);
   const conn = mongoose.connection;
   conn.on('connected', () => {
     logger.info(`conn.readyState:${conn.readyState}`);


### PR DESCRIPTION
#### What's this PR do?
I explicitly added options to increase connection timeout threshold to 30000 and also enabling keepAlive.

Based on this thread in stack overflow
http://stackoverflow.com/questions/38486384/mongodb-connection-to-mongolab-timing-out-in-nodejs-on-heroku

#### How should this be reviewed?
- follow steps to get gambit up and running in localhost
- Test chatbot endpoint by signing up to a campaign using Postman and following this docs: https://github.com/DoSomething/gambit/blob/develop/documentation/endpoints/chatbot.md

#### Any background context you want to provide?
A failed signup showed that there seems to be a hangup happening at the time of upserting data to our Mongo database.

Log is here: https://gist.github.com/rapala61/b165ec13f77ff9500937ee8c0ac4ce17

#### Relevant tickets
Related to: https://github.com/DoSomething/gambit/issues/810

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
