### PR TITLE
Catches the rejection at User.lookup in the loadCampaign promise

### DIFF
--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -119,6 +119,7 @@ router.post('/', (req, res) => {
           });
           return resolve(user);
         }
+
         return reject(err);
       });
   });
@@ -213,7 +214,8 @@ router.post('/', (req, res) => {
 
             return resolve(campaign);
           });
-      });
+      })
+      .catch(err => reject(err));
   });
 
   return loadCampaign


### PR DESCRIPTION
#### What's this PR do?
Previously, when Northstar is unreachable/fails we were not "catching" this failure. This has been shown to lock the main process, potentially leading to Timeout errors seen in Gambit production.

This PR properly catches the error and allows the app to log and respond with an appropriate 500 error.

#### How should this be reviewed?
- Start Gambit in local development env
- change the .env variable DS_NORTHSTAR_API_BASEURI and point to a non-existent URL
- POST a signup with keyword using POSTMAN to your local Gambit
- You should get back an error with a 500 code.


#### Any background context you want to provide?

#### Relevant tickets
Solves Issue https://github.com/DoSomething/gambit/issues/832
Potentially solves issue https://github.com/DoSomething/gambit/issues/810
References https://github.com/DoSomething/gambit/issues/704

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
