### PR TITLE
removing logger instance from exported function in lib/Phoenix.js

### DIFF
--- a/lib/phoenix.js
+++ b/lib/phoenix.js
@@ -39,7 +39,7 @@ module.exports.isClosedCampaign = function (phoenixCampaign) {
  * @return {Promise}
  */
 module.exports.fetchCampaign = function (campaignId) {
-  logger.debug(`phoenix.fetchCampaign:${campaignId}`);
+  // logger.debug(`phoenix.fetchCampaign:${campaignId}`);
 
   return new Promise((resolve, reject) => {
     client.Campaigns.get(campaignId)


### PR DESCRIPTION
#### What's this PR do?
I'm removing the logger instance that is being used in the fetchCampaign function on the lib/Phoenix module. This is the main suspect of introducing the leak. This pull is primarily an experiment, based on the findings of comparing 2 Heap Snapshots. One taken at 9:46:51pm last night (4/4/17) and the second taken at 8:47:06am this morning (4/5/17).

#### How should this be reviewed?
Nothing should change functionally in the app. I think this should just be a visual check.

#### Any background context you want to provide?
Reviewed Snapshots captured in staging environment. There seems to be references to kept log strings as well as Winston logger scopes that are not being collected by the GC.

#### Relevant tickets
Pull request that introduced the memory leak
https://github.com/DoSomething/gambit/pull/825

Issue to implement fix for memory leak
https://github.com/DoSomething/gambit/issues/842

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
