### PR TITLE
Fix New Relic version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "express": "^4.10.2",
     "html-entities": "^1.1.1",
     "mongoose": "~4.6.1",
-    "newrelic": "1.3.0",
+    "newrelic": "1.38.x",
     "node-request-retry": "^1.0.0",
     "path": "~0.4.9",
     "request": "2.34.x",


### PR DESCRIPTION
#### What's this PR do?
Fixes mistake of setting New Relic version number to 1.3 in https://github.com/DoSomething/gambit/pull/841/files#r109963622. I was editing the version number locally to see if I could replicate the failed builds that were failing on the Native Metrics module, but for sure didn't mean to set it to 1.3.

<img width="773" alt="screen shot 2017-04-05 at 9 28 27 am" src="https://cloud.githubusercontent.com/assets/1236811/24716048/5cf7d41a-19e2-11e7-922a-20c25ec33c7a.png">

#### How should this be reviewed?
I caught this by checking the staging logs after texting in a staging keyword and found `TypeError: newrelic.addCustomParameters is not a function`. 

Upon stage deploy, verify that doesn't happen :\

#### Any background context you want to provide?
<img src="https://media.giphy.com/media/13HBDT4QSTpveU/giphy.gif">


#### Checklist
- [x] Tested on staging.
