### PR TITLE
Fix Messaging Groups creation for new Campaign Runs

### DIFF
--- a/app/routes/campaigns.js
+++ b/app/routes/campaigns.js
@@ -47,9 +47,10 @@ function fetchCampaign(id, renderMessages) {
       .then((keywords) => {
         campaign.keywords = keywords;
 
-        return groups.findOrCreateGroup(id, campaign.current_run);
+        return groups.getGroups(id, campaign.current_run);
       })
-      .then((groupsResponse) => {
+      .then((response) => {
+        const groupsResponse = response.body.data;
         if (!groupsResponse) {
           logger.warn(`Error returning Messaging Groups API response for id ${id}.`);
           campaign.mobilecommons_group_doing = null;
@@ -58,8 +59,8 @@ function fetchCampaign(id, renderMessages) {
           return resolve(campaign);
         }
 
-        campaign.mobilecommons_group_doing = groupsResponse.doing;
-        campaign.mobilecommons_group_completed = groupsResponse.completed;
+        campaign.mobilecommons_group_doing = groupsResponse.doing.id;
+        campaign.mobilecommons_group_completed = groupsResponse.completed.id;
 
         return resolve(campaign);
       })

--- a/lib/groups.js
+++ b/lib/groups.js
@@ -1,9 +1,7 @@
 'use strict';
 
-const Promise = require('bluebird');
-
 /**
- * API Wrapper for the Gambit Groups API.
+ * API Wrapper for the Messaging Groups API.
  */
 
 const superagent = require('superagent');
@@ -12,7 +10,6 @@ const logger = app.locals.logger;
 const uri = process.env.DS_MESSAGING_GROUPS_API_BASEURI;
 const apiKey = process.env.DS_MESSAGING_GROUPS_API_KEY;
 const apiHeaderName = 'x-messaging-group-api-key';
-const environment = process.env.NODE_ENV;
 
 if (!uri || !apiKey) {
   logger.error('Missing DS Messaging Groups API config vars');
@@ -20,118 +17,21 @@ if (!uri || !apiKey) {
 
 module.exports = {
   /**
-   * Make a GET request to DS Messaging Groups API.
-   * Handles authentication & URL formation.
-   * @param  {string} path API Path. eg: /group
+   * Gets the Mobile Commons groups for the given DS Campaign ID & Run ID.
+   * @param {int} campaignId - Campaign ID to search for.
+   * @param {int} campaignRunId - Campaign Run ID to search for.
    * @return {Promise}
    */
-  get(path) {
-    return superagent.get(`${uri}${path}`)
+  getGroups(campaignId, campaignRunId) {
+    logger.debug(`groups.getGroups campaign:${campaignId} run:${campaignRunId}`);
+
+    return superagent
+      .get(`${uri}/mobilecommons-groups`)
       .set(apiHeaderName, apiKey)
-      .then(this.parseGroupOutput)
-      .catch((error) => {
-        logger.warn(`groups.get error:${error.message}`);
+      .query({
+        campaign_id: campaignId,
+        campaign_run_id: campaignRunId,
+        environment: process.env.NODE_ENV,
       });
   },
-
-  /**
-   * Make a post request to DS Messaging Groups API.
-   * Handles authentication & URL formation.
-   * @param  {string} path API Path. eg: /group
-   * @param  {object} data JSON data to send.
-   * @return {Promise}
-   */
-  post(path, data) {
-    return superagent.post(`${uri}${path}`)
-      .send(data)
-      .set(apiHeaderName, apiKey)
-      .then(this.parseGroupOutput)
-      .catch((error) => {
-        logger.warn(`groups.post error:${error.message}`);
-      });
-  },
-
-  /**
-   * Find the group for the given campaign ID & run ID.
-   * @param  {int} campaignId    Campaign ID to search for.
-   * @param  {int} campaignRunId Campaign Run ID to search for.
-   * @return {Promise}
-   */
-  findGroup(campaignId, campaignRunId) {
-    return this.get(`/group/${campaignId}/${campaignRunId}`);
-  },
-
-  /**
-   * Create a group for the given campaign ID & run ID.
-   * @param  {int} campaignId    Campaign ID to create a group for.
-   * @param  {int} campaignRunId Campaign Run ID to create a group for.
-   * @return {Promise}
-   */
-  createGroup(campaignId, campaignRunId) {
-    logger.debug(`groups.createGroup campaign:${campaignId} run:${campaignRunId}`);
-
-    return this.post('/group', {
-      campaign_id: campaignId,
-      campaign_run_id: campaignRunId,
-    });
-  },
-
-  /**
-   * Returns messaging groups for the given campaign,
-   * create them when they don't exist.
-   *
-   * @param  {int} campaignId    Campaign ID to create a group for.
-   * @param  {int} campaignRunId Campaign Run ID to create a group for.
-   * @return {Promise}
-   */
-  findOrCreateGroup(campaignId, campaignRunId) {
-    logger.debug(`groups.findOrCreateGroup campaign:${campaignId} run:${campaignRunId}`);
-
-    return new Promise((resolve, reject) => {
-      // Check if groups already exist on Mobile commons:
-      this.findGroup(campaignId, campaignRunId)
-        .then((groups) => {
-          const message = 'groups.findOrCreateGroup found '
-             + `campaign:${campaignId} run:${campaignRunId} groups:${JSON.stringify(groups)}`;
-          logger.debug(message);
-          resolve(groups);
-        })
-        .catch(() => {
-          // TODO: This isn't checking for non 404 errors.
-          // Groups don't exist yet, let's create them.
-          this.createGroup(campaignId, campaignRunId)
-            .then((groups) => {
-              const message = 'groups.findOrCreateGroup created '
-                + `campaign:${campaignId} run:${campaignRunId} groups:${JSON.stringify(groups)}`;
-              logger.info(message);
-              resolve(groups);
-            })
-            .catch(error => reject(error));
-        });
-    });
-  },
-
-  /**
-   * Parses messaging groups API output.
-   *
-   * @param  {json} response Api response.
-   * @return {Promise}
-   */
-  parseGroupOutput(response) {
-    return new Promise((resolve, reject) => {
-      if (!response.body.id) {
-        return reject('groups.parseGroupOutput: id undefined');
-      }
-
-      if (!response.body.mobilecommons_groups[environment]) {
-        return reject('groups.parseGroupOutput: mobilecommons_groups undefined.');
-      }
-
-      const doing = response.body.mobilecommons_groups[environment].doing;
-      const completed = response.body.mobilecommons_groups[environment].completed;
-
-      return resolve({ doing, completed });
-    });
-  },
-
 };


### PR DESCRIPTION
#### What's this PR do?
Queries the new MGAPI `/api/v1/mobilecommons-groups` endpoint (https://github.com/DoSomething/messaging-groups-api/pull/13) to get the Doing and Completed Group ID's for each Campaign.

#### How should this be reviewed?
* Add a keyword to Thor via Gambini for a Campaign that has never run on Gambit before. I used 1524
* GET /campaigns to Gambit API and verify Doing and Completed groups are returned:
```
    {
      "id": "1524",
      "title": "Bubble Breaks",
      "status": "active",
      "current_run": "6242",
      "keywords": [
        {
          "keyword": "BUBBLEBOT"
        }
      ],
      "mobilecommons_group_doing": 296582,
      "mobilecommons_group_completed": 296588
    },
```
* Verify Mobile Commons Groups are created:
<img width="962" alt="screen shot 2017-04-06 at 12 50 07 pm" src="https://cloud.githubusercontent.com/assets/1236811/24772940/04eeb73e-1ac8-11e7-9652-3afd9b47e08c.png">

#### Any background context you want to provide?
Gambit no longer handles creating Mobile Commons Groups that don't exist for a given Campaign/Run/Environment, it's work done by the [**GET** `/mobilecommons-groups` request to the MGAPI](https://github.com/DoSomething/messaging-groups-api/tree/develop/documentation#get-mobile-commons-groups).

#### Relevant tickets
Fixes #845 

#### Checklist
- [x] Tested on staging.
