### PR TITLE
Removes deprecated CAMPAIGNBOT_CAMPAIGNS from app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -5,9 +5,6 @@
     "BITLY_GENERIC_ACCESS_TOKEN": {
       "required": true
     },
-    "CAMPAIGNBOT_CAMPAIGNS": {
-      "required": true
-    },
     "CONTENTFUL_ACCESS_TOKEN": {
       "required": true
     },


### PR DESCRIPTION
#### What's this PR do?
Removes deprecated `CAMPAIGNBOT_CAMPAIGNS` from` app.json` (required for Review apps)

#### Relevant tickets
Missed this in #841

