### PR TITLE
returns a Signup with reportback and user models after calling Signup…

### DIFF
--- a/app/models/Signup.js
+++ b/app/models/Signup.js
@@ -172,7 +172,10 @@ signupSchema.statics.post = function (user, campaign, keyword, broadcastId) {
           data.broadcast_id = broadcastId;
         }
 
-        return model.findOneAndUpdate({ _id: signupId }, data, helpers.upsertOptions()).exec();
+        return model.findOneAndUpdate({ _id: signupId }, data, helpers.upsertOptions())
+          .populate('user')
+          .populate('draft_reportback_submission')
+          .exec();
       })
       .then(signupDoc => resolve(signupDoc))
       .catch((err) => {


### PR DESCRIPTION
….post

#### What's this PR do?
Populates the signup model returned by the Signup.post method in the Signup model. Prevents Gambit from breaking when an user reports back under certain circumstances (detailed in issue-872)
#### How should this be reviewed?
- Install locally
- Use Postman to signup and reportback to a thor campaign.
- You should not get an the TypeError back from Gambit as described in the issue-872

#### Relevant tickets
Fixes #872

#### Checklist
- [x] Documentation added for new features/changed endpoints.
