### PR TITLE
Issue 866/multi word yes responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ node_modules
 #code coverage directories
 .nyc_output
 coverage
+
+#local nvm configuration
+.nvmrc

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -60,11 +60,13 @@ module.exports.getFirstWord = function (message) {
 };
 
 module.exports.isYesResponse = function (message) {
-  const trimmed = this.getFirstWord(message.toLowerCase().trim());
+  const trimmedMsg = message.toLowerCase().trim();
   const yesResponses = process.env.GAMBIT_YES_RESPONSES ?
     process.env.GAMBIT_YES_RESPONSES.toLowerCase().split(',') : ['yes'];
 
-  return yesResponses.indexOf(trimmed) >= 0;
+  const matchRegex = new RegExp(`^(${yesResponses.join('|')})$`);
+
+  return !!trimmedMsg.match(matchRegex);
 };
 
 module.exports.hasLetters = function (message) {

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "url": "git+https://github.com/DoSomething/gambit.git"
   },
   "scripts": {
-    "test": "NODE_ENV=test ava",
+    "test": "NODE_ENV=test ava --serial",
     "all-tests": "npm run lint && npm run coverage",
-    "coverage": "NODE_ENV=test nyc --all ava",
+    "coverage": "NODE_ENV=test nyc --all ava --serial",
     "html-coverage-report": "nyc report --reporter=html",
     "publish-coverage-report": "nyc report --reporter=lcov && codecov",
     "start": "node server",
@@ -66,6 +66,7 @@
   "devDependencies": {
     "@dosomething/eslint-config": "^2.0.0",
     "ava": "^0.19.1",
+    "bluebird": "^3.5.0",
     "chai": "^3.5.0",
     "codecov": "^2.1.0",
     "dotenv": "^4.0.0",
@@ -73,6 +74,7 @@
     "eslint-plugin-ava": "^4.2.0",
     "node-mocks-http": "^1.6.1",
     "nyc": "^10.2.0",
-    "sinon": "^2.1.0"
+    "sinon": "^2.1.0",
+    "sinon-chai": "^2.9.0"
   }
 }

--- a/test/lib/helpers.test.js
+++ b/test/lib/helpers.test.js
@@ -1,44 +1,65 @@
 'use strict';
 
 require('dotenv').config();
+const Promise = require('bluebird');
 const test = require('ava');
 const chai = require('chai');
 const expect = require('chai').expect;
-const crypto = require('crypto');
 const stubs = require('../../test/utils/stubs');
 const sinon = require('sinon');
-const contentful = require('../../lib/contentful.js');
-const helpers = require('../../lib/helpers');
+const sinonChai = require('sinon-chai');
 const httpMocks = require('node-mocks-http');
+const contentful = require('../../lib/contentful.js');
+const stathat = require('../../lib/stathat');
+const crypto = require('crypto');
+const logger = require('winston');
 
-// TODO: Suppress logger console transport
+// Module to test
+const helpers = require('../../lib/helpers');
 
 // Stub functions
-const fetchKeywordsForCampaignIdStub = () => new Promise((resolve) => {
-  resolve(stubs.getKeywords());
-});
-const fetchKeywordsForCampaignIdStubFail = () => new Promise((resolve, reject) => {
-  reject({ status: 500 });
-});
-// const sendResponseStub = () => { true; };
-
-// Setup Spies
-sinon.spy(helpers, 'sendErrorResponse');
-sinon.spy(helpers, 'sendResponse');
-
-// Setup stubs
-sinon.stub(contentful, 'fetchKeywordsForCampaignId')
-  .onCall(0)
-  .callsFake(fetchKeywordsForCampaignIdStub)
-  .onCall(1)
-  .callsFake(fetchKeywordsForCampaignIdStubFail);
+const fetchKeywordsForCampaignIdStub = () => Promise.resolve(stubs.getKeywords());
+const fetchKeywordsForCampaignIdStubFail = () => Promise.reject({ status: 500 });
+const cryptoCreateHmacStub = {
+  update() { return this; },
+  digest() { return this; },
+  substring() { return this; },
+};
 
 // setup should assertion style
 chai.should();
+chai.use(sinonChai);
 
+const sandbox = sinon.sandbox.create();
+
+// Setup!
 test.beforeEach((t) => {
+  // setup stubs
+  sandbox.stub(contentful, 'fetchKeywordsForCampaignId')
+    .callsFake(fetchKeywordsForCampaignIdStub)
+    .withArgs('fail')
+    .callsFake(fetchKeywordsForCampaignIdStubFail)
+    .withArgs('empty')
+    .returns(Promise.resolve([]));
+  sandbox.stub(logger, 'error');
+  sandbox.stub(logger, 'debug');
+  sandbox.stub(stathat, 'postStat');
+  sandbox.stub(crypto, 'createHmac').returns(cryptoCreateHmacStub);
+
+  // setup spies
+  sandbox.spy(helpers, 'sendErrorResponse');
+  sandbox.spy(helpers, 'sendResponse');
+
+  // setup req, res mocks
   t.context.req = httpMocks.createRequest();
   t.context.res = httpMocks.createResponse();
+});
+
+// Cleanup!
+test.afterEach((t) => {
+  // reset stubs, spies, and mocks
+  sandbox.restore();
+  t.context = {};
 });
 
 /**
@@ -51,7 +72,8 @@ test('replacePhoenixCampaignVars', async () => {
   let renderedMessage = '';
   // signedup through gambit
   const signedupGambitMsg = stubs.getDefaultContenfulCampaignMessage('menu_signedup_gambit');
-  renderedMessage = await helpers.replacePhoenixCampaignVars(signedupGambitMsg, phoenixCampaign);
+  renderedMessage = await helpers
+    .replacePhoenixCampaignVars(signedupGambitMsg, phoenixCampaign);
   renderedMessage.should.have.string(phoenixCampaign.facts.problem);
   // invalid sign up command
   const invalidSignedupCmdMsg = stubs.getDefaultContenfulCampaignMessage('invalid_cmd_signedup');
@@ -67,26 +89,27 @@ test('replacePhoenixCampaignVars a message that makes a contentful request to ge
   let renderedMessage = '';
   const phoenixCampaign = stubs.getPhoenixCampaign();
   const relativeToSignUpMsg = stubs.getDefaultContenfulCampaignMessage('scheduled_relative_to_signup_date');
-  // fetchKeywordsForCampaignIdStub should be called here
-  // since it's the first time its called in our tests
-  renderedMessage = await helpers.replacePhoenixCampaignVars(relativeToSignUpMsg, phoenixCampaign);
+  renderedMessage = await helpers
+    .replacePhoenixCampaignVars(relativeToSignUpMsg, phoenixCampaign);
 
-  sinon.assert.called(contentful.fetchKeywordsForCampaignId);
+  contentful.fetchKeywordsForCampaignId.should.have.been.called;
   renderedMessage.should.have.string(keywords[0].keyword);
 });
 
 test('replacePhoenixCampaignVars failure to retrieve keywords should throw', async (t) => {
   const phoenixCampaign = stubs.getPhoenixCampaign();
+  // will trigger fetchKeywordsForCampaignIdStubFail stub
+  phoenixCampaign.id = 'fail';
   const memberSupportMsg = stubs.getDefaultContenfulCampaignMessage('member_support');
-  // fetchKeywordsForCampaignIdStubFail should be called here
-  // since it's the second time its called in our tests
+
   await t.throws(helpers.replacePhoenixCampaignVars(memberSupportMsg, phoenixCampaign));
-  sinon.assert.called(contentful.fetchKeywordsForCampaignId);
+  contentful.fetchKeywordsForCampaignId.should.have.been.called;
 });
 
 test('replacePhoenixCampaignVars with no message should return empty string', async () => {
   const phoenixCampaign = stubs.getPhoenixCampaign();
-  const renderedMessage = await helpers.replacePhoenixCampaignVars(undefined, phoenixCampaign);
+  const renderedMessage = await helpers
+    .replacePhoenixCampaignVars(undefined, phoenixCampaign);
   renderedMessage.should.equal('');
 });
 
@@ -141,15 +164,21 @@ test('getFirstWord should return null if no message is passed', () => {
   expect(result).to.be.null;
 });
 
-// TODO: It is now failing due to a bug when processing the message
-// which fails to properly parse multi-word acceptable answers
-// https://github.com/DoSomething/gambit/issues/866
-test.skip('isYesResponse', () => {
+// isYesResponse
+test('isYesResponse', () => {
   helpers.isYesResponse('yea').should.be.true;
+  helpers.isYesResponse('si').should.be.true;
+  helpers.isYesResponse('s').should.be.true;
   helpers.isYesResponse('yesss').should.be.true;
   helpers.isYesResponse('i can').should.be.true;
   helpers.isYesResponse('yes').should.be.true;
   helpers.isYesResponse('nah').should.be.false;
+  helpers.isYesResponse('ss').should.be.false;
+  helpers.isYesResponse('abs').should.be.false;
+  helpers.isYesResponse('def').should.be.false;
+  helpers.isYesResponse('hell').should.be.false;
+  helpers.isYesResponse('tamales').should.be.false;
+  helpers.isYesResponse('definitely not').should.be.false;
 });
 
 // isValidReportbackQuantity
@@ -171,14 +200,8 @@ test('isValidReportbackText', () => {
 
 // generatePassword
 test('generatePassword', () => {
-  process.env.DS_API_PASSWORD_KEY = 'bell';
-  const key = crypto
-    .createHmac('sha1', 'bell')
-    .update('taco')
-    .digest('hex')
-    .substring(0, 6);
-  helpers.generatePassword('taco').should.be.equal(key);
-  helpers.generatePassword('burrito').should.not.be.equal(key);
+  helpers.generatePassword('taco');
+  crypto.createHmac.should.have.been.calledWithExactly('sha1', process.env.DS_API_PASSWORD_KEY);
 });
 
 // isCommand
@@ -204,8 +227,8 @@ test('sendTimeoutResponse', (t) => {
   const timeoutNumSeconds = helpers.getGambitTimeoutNumSeconds();
   helpers.sendTimeoutResponse(t.context.res);
 
-  sinon.assert.called(helpers.sendResponse);
-  sinon.assert.calledWith(helpers.sendResponse, t.context.res, 504, `Request timed out after ${timeoutNumSeconds} seconds.`);
+  helpers.sendResponse.should.have.been.called;
+  helpers.sendResponse.should.have.been.calledWithExactly(t.context.res, 504, `Request timed out after ${timeoutNumSeconds} seconds.`);
 });
 
 // sendErrorResponse
@@ -213,8 +236,9 @@ test('sendTimeoutResponse', (t) => {
 test('sendErrorResponse', (t) => {
   helpers.sendErrorResponse(t.context.res, { /* Error Object */ });
 
-  sinon.assert.called(helpers.sendResponse);
-  sinon.assert.calledWith(helpers.sendResponse, t.context.res, 500);
+  helpers.sendResponse.should.have.been.called;
+  // TODO: Use calledWithExactly when testing specific errors
+  helpers.sendResponse.should.have.been.calledWith(t.context.res, 500);
 });
 
 // sendUnproccessibleEntityResponse
@@ -222,8 +246,8 @@ test('sendUnproccessibleEntityResponse', (t) => {
   const message = 'Test';
   helpers.sendUnproccessibleEntityResponse(t.context.res, message);
 
-  sinon.assert.called(helpers.sendResponse);
-  sinon.assert.calledWith(helpers.sendResponse, t.context.res, 422, message);
+  helpers.sendResponse.should.have.been.called;
+  helpers.sendResponse.should.have.been.calledWithExactly(t.context.res, 422, message);
 });
 
 // getGambitTimeoutNumSeconds


### PR DESCRIPTION
#### What's this PR do?
Refactored the `isYesResponse` method in our `lib/helpers` file.
Adds test for `isYesResponse`.

#### How should this be reviewed?
- Install locally
- Make sure your GAMBIT_YES_RESPONSES env variable is populated with the latest accepted responses in production
- Run `npm run all-tests`
- All tests should pass

#### Any background context you want to provide?
Accepted responses that where longer than 1 word were being ignored, example: "i can, hell yea", this change fixes that.

#### Relevant tickets
Fixes #866 

#### Checklist
- [x] Documentation added for new features/changed endpoints.
