### PR TITLE
Trim Reportback text to avoid Phoenix API errors

### DIFF
--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -493,7 +493,7 @@ router.post('/', (req, res, next) => {
       return continueConversationWithMessageType(req, res, 'invalid_caption');
     }
 
-    draft.caption = input;
+    draft.caption = helpers.trimReportbackText(input);
 
     return draft.save()
       .then(() => {
@@ -516,7 +516,7 @@ router.post('/', (req, res, next) => {
       return continueConversationWithMessageType(req, res, 'invalid_why_participated');
     }
 
-    draft.why_participated = input;
+    draft.why_participated = helpers.trimReportbackText(input);
 
     return draft.save()
       .then(() => next())

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -232,3 +232,16 @@ module.exports.isCommand = function isCommand(incomingMessage, commandType) {
 
   return result;
 };
+
+/**
+ * Trims given input with an ellipsis if its length is greater than 255 characters.
+ * @param {string} input
+ * @return {string}
+ */
+module.exports.trimReportbackText = function (input) {
+  if (input.length > 255) {
+    return `${input.substring(0, 252)}...`;
+  }
+
+  return input;
+};

--- a/test/lib/helpers.test.js
+++ b/test/lib/helpers.test.js
@@ -245,3 +245,13 @@ test('upsertOptions helper', () => {
   opts.upsert.should.be.true;
   opts.new.should.be.true;
 });
+
+// trimReportbackText
+test('trimReportbackText', () => {
+  const text = 'This is a caption';
+  helpers.trimReportbackText(text).should.be.equal(text);
+
+  const longText = 'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem.';
+  const trimmed = 'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium qu...';
+  helpers.trimReportbackText(longText).should.be.equal(trimmed);
+});


### PR DESCRIPTION
#### What's this PR do?
Trims data we send for Reportback `caption` and `why_participated` to avoid Phoenix API errors (which result in Gambit returning an error response)

#### How should this be reviewed?
Fire up Lorem Ipsum generator and send through values for `caption` and `why_participated` that exceed 255 characters, verify reportback is successfully submitted (and long values are trimmed)

#### Any background context you want to provide?
I'm having trouble finding the exact limit of `why_participated`. [The `length` value defined as `'2048'` for the `why_participated` field with type `'text'` in Phoenix doesn't seem correct](https://github.com/DoSomething/phoenix/blob/28d1ed6a5b8c8031c54f96244daee257c0e6398c/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install#L60), as I was able to pass a `why_participated` with 2049 characters (`'2048'` probably shouldn't be a string...)

Decided to share the 255 character limit for `why_participated` to keep the code simple for now.

#### Relevant tickets
Fixes #881 

#### Checklist
- [x] Tested on staging.
