### PR TITLE
Check Retry Count before logging incoming messages

### DIFF
--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -254,7 +254,7 @@ router.use((req, res, next) => {
  */
 router.use((req, res, next) => {
   // If this is a retry, we don't want to track duplicate analytics for this request.
-  const retryCount = Number(req.headers['x-blink-retry-count']);
+  const retryCount = Number(req.get('x-blink-retry-count'));
   if (retryCount && retryCount >= 1) {
     return next();
   }

--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -253,6 +253,12 @@ router.use((req, res, next) => {
  * Track incoming message (and outgoing, if this is a reply to a broadcast).
  */
 router.use((req, res, next) => {
+  // If this is a retry, we don't want to track duplicate analytics for this request.
+  const retryCount = Number(req.headers['x-blink-retry-count']);
+  if (retryCount && retryCount >= 1) {
+    return next();
+  }
+
   if (req.broadcast_id) {
     req.user.postDashbotOutgoing('broadcast');
   }
@@ -269,7 +275,8 @@ router.use((req, res, next) => {
   }
 
   req.user.postDashbotIncoming(dashbotLog.toLowerCase());
-  next();
+
+  return next();
 });
 
 /**

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -21,7 +21,7 @@ router.get('/', (req, res) => {
  */
 router.use((req, res, next) => {
   const apiKey = process.env.GAMBIT_API_KEY;
-  if (req.method === 'POST' && req.headers['x-gambit-api-key'] !== apiKey) {
+  if (req.method === 'POST' && req.get('x-gambit-api-key') !== apiKey) {
     stathat.postStat('error: invalid x-gambit-api-key');
     logger.warn('router invalid x-gambit-api-key:', req.url);
 

--- a/documentation/endpoints/chatbot.md
+++ b/documentation/endpoints/chatbot.md
@@ -11,7 +11,7 @@ POST /v1/chatbot
 Name | Type | Description
 --- | --- | ---
 `x-gambit-api-key` | `string` | **Required.**
-
+`x-blink-retry-count` | `number` | If set, number of times [Blink](github.com/dosomething/blink) has retried this request.
 
 **Input**
 


### PR DESCRIPTION
#### What's this PR do?
* Only tracks an incoming message (and an outgoing message of `broadcast` if incoming message is responding to a broadcast) for the first Blink attempt, fixing the count of incoming messages in Dashbot analytics.
 
#### How should this be reviewed?
* Post locally to `chatbot` and include a `x-blink-retry-count` of 1 or more in the headers. 
    * Verify Dashbot analytics are not sent for the incoming messages
    * Verify Dashbot analytics are sent when the ``x-blink-retry-count` header is removed

#### Relevant tickets
Fixes #897

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Tested on staging.

