### PR TITLE
Send Error Message and suppress Blink retries on failed Phoenix POST request

### DIFF
--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -145,6 +145,17 @@ function endConversationWithError(req, res, error) {
 }
 
 /**
+ * Handles a Phoenix POST error, calling endConversationWithError if we shouldn't retry.
+ */
+function handlePhoenixPostError(req, res, err) {
+  if (err.message.includes('API response is false')) {
+    return endConversationWithError(req, res, err);
+  }
+
+  return helpers.sendErrorResponse(res, err);
+}
+
+/**
  * Check for required config variables.
  * TODO: This MUST be refactored. Why are we checking these env variabes exist on each request?
  */
@@ -447,13 +458,7 @@ router.use((req, res, next) => {
 
       return next();
     })
-    .catch((err) => {
-      if (err.status && err.status === 500) {
-        return endConversationWithError(req, res, err);
-      }
-
-      return helpers.sendErrorResponse(res, err);
-    });
+    .catch(err => handlePhoenixPostError(req, res, err));
 });
 
 /**
@@ -598,13 +603,7 @@ router.post('/', (req, res) => {
 
       return continueConversationWithMessageType(req, res, 'menu_completed');
     })
-    .catch((err) => {
-      if (err.status && err.status === 500) {
-        return endConversationWithError(req, res, err);
-      }
-
-      return helpers.sendErrorResponse(res, err);
-    });
+    .catch(err => handlePhoenixPostError(req, res, err));
 });
 
 module.exports = router;

--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -2,6 +2,7 @@
 
 // Third party modules
 const newrelic = require('newrelic');
+const emojiStrip = require('emoji-strip');
 const express = require('express');
 const logger = require('winston');
 
@@ -195,7 +196,12 @@ router.use((req, res, next) => {
 
   /* eslint-disable no-param-reassign */
   req.client = 'mobilecommons';
-  req.incoming_message = req.body.args;
+  if (req.body.args) {
+    req.incoming_message = emojiStrip(req.body.args);
+  } else {
+    req.incoming_message = '';
+  }
+
   req.incoming_image_url = req.body.mms_image_url;
   req.broadcast_id = req.body.broadcast_id;
   if (req.body.keyword) {

--- a/config/contentful.js
+++ b/config/contentful.js
@@ -30,5 +30,6 @@ module.exports = {
     scheduled_relative_to_reportback_date: 'scheduledRelativeToReportbackDateMessage',
     member_support: 'memberSupportMessage',
     campaign_closed: 'campaignClosedMessage',
+    error_occurred: 'errorOccurredMessage',
   },
 };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -6,6 +6,8 @@
 const crypto = require('crypto');
 const logger = require('winston');
 const newrelic = require('newrelic');
+const emojiStrip = require('emoji-strip')
+
 const contentful = require('./contentful');
 const stathat = require('./stathat');
 const config = require('../config/helpers');
@@ -230,14 +232,16 @@ module.exports.isCommand = function isCommand(incomingMessage, commandType) {
 };
 
 /**
- * Trims given input with an ellipsis if its length is greater than 255 characters.
+ * Trims given input with an ellipsis if its length is greater than 255 characters, stripping emoji.
  * @param {string} input
  * @return {string}
  */
 module.exports.trimReportbackText = function (input) {
-  if (input.length > 255) {
-    return `${input.substring(0, 252)}...`;
+  const scope = emojiStrip(input);
+
+  if (scope.length > 255) {
+    return `${scope.substring(0, 252)}...`;
   }
 
-  return input;
+  return scope;
 };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -6,8 +6,6 @@
 const crypto = require('crypto');
 const logger = require('winston');
 const newrelic = require('newrelic');
-const emojiStrip = require('emoji-strip')
-
 const contentful = require('./contentful');
 const stathat = require('./stathat');
 const config = require('../config/helpers');
@@ -232,16 +230,14 @@ module.exports.isCommand = function isCommand(incomingMessage, commandType) {
 };
 
 /**
- * Trims given input with an ellipsis if its length is greater than 255 characters, stripping emoji.
+ * Trims given input with an ellipsis if its length is greater than 255 characters.
  * @param {string} input
  * @return {string}
  */
 module.exports.trimReportbackText = function (input) {
-  const scope = emojiStrip(input);
-
-  if (scope.length > 255) {
-    return `${scope.substring(0, 252)}...`;
+  if (input.length > 255) {
+    return `${input.substring(0, 252)}...`;
   }
 
-  return scope;
+  return input;
 };

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "body-parser": "^1.9.2",
     "connect-timeout": "^1.8.0",
     "contentful": "^3.8.0",
+    "emoji-strip": "^1.0.1",
     "express": "^4.10.2",
     "html-entities": "^1.1.1",
     "mongoose": "~4.6.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "body-parser": "^1.9.2",
     "connect-timeout": "^1.8.0",
     "contentful": "^3.8.0",
-    "emoji-strip": "^1.0.1",
     "express": "^4.10.2",
     "html-entities": "^1.1.1",
     "mongoose": "~4.6.1",

--- a/test/stubs/contentful/all-campaign-fields.json
+++ b/test/stubs/contentful/all-campaign-fields.json
@@ -57,5 +57,9 @@
   "campaignClosedMessage": {
     "override": false,
     "raw": "Sorry, {{title}} is no longer available.\n\nText {{cmd_member_support}} for help."
+  },
+  "errorOccurredMessage": {
+    "override": false,
+    "raw": "Oops, an error occurred. We're looking into it -- sorry!"
   }
 }


### PR DESCRIPTION
#### What's this PR do?
When a POST Signup or Reportback request fails with status 500:
* Sends a new message type, `error_occurred`, to the end user and places them into Agent View
* Sets the response `x-blink-retry-suppress` to `true` 

Strips emoji from reportback text to fix #907 

#### How should this be reviewed?
Upon staging deploy, text an emoji for a caption and verify that
* Error Occurred Message is sent
* Blink does not retry

#### Any background context you want to provide?
Need to update Contentful tests. Opening now to test on staging.

#### Relevant tickets
Fixes #902, #907

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [x] Tested on staging.
