### PR TITLE
text should be replyText or the reply action wont find the replyText …

### DIFF
--- a/lib/middleware/broadcast.js
+++ b/lib/middleware/broadcast.js
@@ -25,7 +25,8 @@ module.exports = function processBroadcast() {
       BotRequest.log(req, 'broadcast', 'prompt_declined', replyMessage);
       req.user.postDashbotOutgoing('broadcast_declined');
 
-      return replyDispatcher.execute(replies.sendCustomMessage({ req, res, text: replyMessage }));
+      return replyDispatcher.execute(
+        replies.sendCustomMessage({ req, res, replyText: replyMessage }));
     }
 
     return next();


### PR DESCRIPTION
…to send the user

#### What's this PR do?
Solves a bug found while testing in Thor.
Declined broadcast message was not being sent to the user because it was stored on a `text` property that should have been renamed `replyText`

#### How should this be reviewed?
- Post to chatbot with a broadcast_id=1246319 and args=N. You should see a message in the response.

#### Checklist
- [x] Tested on localhost.
