### PR TITLE
Makes the reply dispatcher execute method static and stops keeping st…

### DIFF
--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -30,8 +30,6 @@ const processUserSupportConversationMiddleware = require('../../lib/middleware/u
 // Router
 const router = express.Router(); // eslint-disable-line new-cap
 
-const replyDispatcher = new ReplyDispatcher();
-
 /**
  * Check for required parameters,
  * parse incoming params, and add/log helper variables.
@@ -98,24 +96,24 @@ router.post('/', (req, res, next) => {
 
   if (helpers.isCommand(req.incoming_message, 'reportback')) {
     return req.signup.createDraftReportbackSubmission()
-      .then(() => replyDispatcher.execute(replies.askQuantity({ req, res })))
+      .then(() => ReplyDispatcher.execute(replies.askQuantity({ req, res })))
       .catch(err => helpers.sendErrorResponse(res, err));
   }
 
   // If member has completed this campaign:
   if (req.signup.reportback) {
     if (req.isNewConversation) {
-      return replyDispatcher.execute(replies.menuCompleted({ req, res }));
+      return ReplyDispatcher.execute(replies.menuCompleted({ req, res }));
     }
     // Otherwise member didn't text back a Reportback or Member Support command.
-    return replyDispatcher.execute(replies.invalidCmdCompleted({ req, res }));
+    return ReplyDispatcher.execute(replies.invalidCmdCompleted({ req, res }));
   }
 
   if (req.isNewConversation) {
-    return replyDispatcher.execute(replies.menuSignedUp({ req, res }));
+    return ReplyDispatcher.execute(replies.menuSignedUp({ req, res }));
   }
 
-  return replyDispatcher.execute(replies.invalidCmdSignedup({ req, res }));
+  return ReplyDispatcher.execute(replies.invalidCmdSignedup({ req, res }));
 });
 
 /**
@@ -128,40 +126,40 @@ router.post('/', (req, res, next) => {
 
   if (!draft.quantity) {
     if (req.isNewConversation) {
-      return replyDispatcher.execute(replies.askQuantity({ req, res }));
+      return ReplyDispatcher.execute(replies.askQuantity({ req, res }));
     }
     if (!helpers.isValidReportbackQuantity(input)) {
-      return replyDispatcher.execute(replies.invalidQuantity({ req, res }));
+      return ReplyDispatcher.execute(replies.invalidQuantity({ req, res }));
     }
 
     draft.quantity = Number(input);
 
     return draft.save()
-      .then(() => replyDispatcher.execute(replies.askPhoto({ req, res })))
+      .then(() => ReplyDispatcher.execute(replies.askPhoto({ req, res })))
       .catch(err => helpers.sendErrorResponse(res, err));
   }
 
   if (!draft.photo) {
     if (req.isNewConversation) {
-      return replyDispatcher.execute(replies.askPhoto({ req, res }));
+      return ReplyDispatcher.execute(replies.askPhoto({ req, res }));
     }
     if (!req.incoming_image_url) {
-      return replyDispatcher.execute(replies.noPhotoSent({ req, res }));
+      return ReplyDispatcher.execute(replies.noPhotoSent({ req, res }));
     }
 
     draft.photo = req.incoming_image_url;
 
     return draft.save()
-      .then(() => replyDispatcher.execute(replies.askCaption({ req, res })))
+      .then(() => ReplyDispatcher.execute(replies.askCaption({ req, res })))
       .catch(err => helpers.sendErrorResponse(res, err));
   }
 
   if (!draft.caption) {
     if (req.isNewConversation) {
-      return replyDispatcher.execute(replies.askCaption({ req, res }));
+      return ReplyDispatcher.execute(replies.askCaption({ req, res }));
     }
     if (!helpers.isValidReportbackText(input)) {
-      return replyDispatcher.execute(replies.invalidCaption({ req, res }));
+      return ReplyDispatcher.execute(replies.invalidCaption({ req, res }));
     }
 
     draft.caption = helpers.trimReportbackText(input);
@@ -170,7 +168,7 @@ router.post('/', (req, res, next) => {
       .then(() => {
         // If member hasn't submitted a reportback yet, ask for why_participated.
         if (!req.signup.total_quantity_submitted) {
-          return replyDispatcher.execute(replies.askWhyParticipated({ req, res }));
+          return ReplyDispatcher.execute(replies.askWhyParticipated({ req, res }));
         }
 
         // Otherwise skip to post reportback to DS API.
@@ -181,10 +179,10 @@ router.post('/', (req, res, next) => {
 
   if (!draft.why_participated) {
     if (req.isNewConversation) {
-      return replyDispatcher.execute(replies.askWhyParticipated({ req, res }));
+      return ReplyDispatcher.execute(replies.askWhyParticipated({ req, res }));
     }
     if (!helpers.isValidReportbackText(input)) {
-      return replyDispatcher.execute(replies.invalidWhyParticipated({ req, res }));
+      return ReplyDispatcher.execute(replies.invalidWhyParticipated({ req, res }));
     }
 
     draft.why_participated = helpers.trimReportbackText(input);
@@ -205,7 +203,7 @@ router.post('/', (req, res) => {
     .then(() => {
       helpers.handleTimeout(req, res);
 
-      return replyDispatcher.execute(replies.menuCompleted({ req, res }));
+      return ReplyDispatcher.execute(replies.menuCompleted({ req, res }));
     })
     .catch(err => helpers.handlePhoenixPostError(req, res, err));
 });

--- a/lib/conversation/reply-dispatcher.js
+++ b/lib/conversation/reply-dispatcher.js
@@ -4,12 +4,8 @@ const logger = require('winston');
 
 // TODO: Should this be a singleton?
 class ReplyDispatcher {
-  constructor() {
-    this.commands = [];
-  }
-  execute(command) {
+  static execute(command) {
     logger.info(`executing command: ${command.args}`);
-    this.commands.push(command);
     return command.execute(...command.args);
   }
 }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -16,10 +16,8 @@ const replies = require('./conversation/replies');
  * Handles a Phoenix POST error, firing the legacyBugErrorOcurred reply if we shouldn't retry.
  */
 module.exports.handlePhoenixPostError = function handlePhoenixPostError(req, res, err) {
-  const replyDispatcher = new ReplyDispatcher();
-
   if (err.message.includes('API response is false')) {
-    return replyDispatcher.execute(replies.legacyBugErrorOcurred({ req, res, error: err }));
+    return ReplyDispatcher.execute(replies.legacyBugErrorOcurred({ req, res, error: err }));
   }
   return module.exports.sendErrorResponse(res, err);
 };

--- a/lib/middleware/broadcast.js
+++ b/lib/middleware/broadcast.js
@@ -17,7 +17,6 @@ module.exports = function processBroadcast() {
     const saidNo = !(req.incoming_message && helpers.isYesResponse(req.incoming_message));
 
     if (saidNo) {
-      const replyDispatcher = new ReplyDispatcher();
       const replyMessage = helpers
         .addSenderPrefix(req.broadcastDeclinedMessage);
 
@@ -25,7 +24,7 @@ module.exports = function processBroadcast() {
       BotRequest.log(req, 'broadcast', 'prompt_declined', replyMessage);
       req.user.postDashbotOutgoing('broadcast_declined');
 
-      return replyDispatcher.execute(
+      return ReplyDispatcher.execute(
         replies.sendCustomMessage({ req, res, replyText: replyMessage }));
     }
 

--- a/lib/middleware/phoenix-campaign-get.js
+++ b/lib/middleware/phoenix-campaign-get.js
@@ -13,7 +13,6 @@ const replies = require('../conversation/replies');
 module.exports = function getCampaign() {
   return (req, res, next) => {
     const campaignId = req.campaignId;
-    const replyDispatcher = new ReplyDispatcher();
     return phoenix.fetchCampaign(campaignId)
       .then((campaign) => {
         req.campaign = campaign; // eslint-disable-line no-param-reassign
@@ -25,7 +24,7 @@ module.exports = function getCampaign() {
           logger.warn(err.message);
           stathat.postStat(err.message);
 
-          return replyDispatcher.execute(replies.campaignClosed({ req, res }));
+          return ReplyDispatcher.execute(replies.campaignClosed({ req, res }));
         }
 
         return next();

--- a/lib/middleware/user-support-conversation.js
+++ b/lib/middleware/user-support-conversation.js
@@ -6,9 +6,8 @@ const replies = require('../conversation/replies');
 
 module.exports = function processSupportConversation() {
   return (req, res, next) => {
-    const replyDispatcher = new ReplyDispatcher();
     if (helpers.isCommand(req.incoming_message, 'member_support')) {
-      return replyDispatcher.execute(replies.memberSupport({ req, res }));
+      return ReplyDispatcher.execute(replies.memberSupport({ req, res }));
     }
     return next();
   };


### PR DESCRIPTION
…ate of all commands executed

#### What's this PR do?
It makes the reply dispatcher execute command static.  This PR removes the code that kept track of the commands executed creating a memory leak since one instance of the reply dispatcher is used for the life of the process in chatbot.

Theory: Every request to the chatbot route was pushing its reply command in the state of the reply dispatcher, increasing in size per request.

#### How should this be reviewed?
- 👀 
- There will be a review app for this PR which I will load test and confirm that memory leak no longer exist.
- Locally try to signup, reply to broadcast with N, Reportback, member support command.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [] Tested on staging.
- [x] Tested Locally.
