### PR TITLE
User.updateConversation

### DIFF
--- a/app/models/BotRequest.js
+++ b/app/models/BotRequest.js
@@ -57,7 +57,7 @@ botRequestSchema.statics.log = function (req, botType, msgType, msg) {
     data.user_id = req.user._id;
   }
   if (req.campaign) {
-    data.campaign_id = req.campaign._id;
+    data.campaign_id = req.campaign.id;
   }
   data.bot_type = botType;
   data.bot_response_type = msgType;
@@ -69,7 +69,7 @@ botRequestSchema.statics.log = function (req, botType, msgType, msg) {
 
       return doc;
     })
-    .catch(err => logger.err(`BotRequest error:${err.message}`));
+    .catch(err => logger.error(`BotRequest error:${err.message}`));
 };
 
 module.exports = mongoose.model('bot_requests', botRequestSchema);

--- a/app/models/User.js
+++ b/app/models/User.js
@@ -28,6 +28,12 @@ const userSchema = new mongoose.Schema({
   first_name: String,
   // Campaign the user is currently participating in via chatbot.
   current_campaign: Number,
+  signup_status: {
+    type: String,
+    // Eventually we'll be adding other values here like 'prompt, 'declined' to build out handling
+    // No or Invalid responses to a Ask Signup Message Template message (broadcasts, campaign menu).
+    enum: ['doing'],
+  },
   last_outbound_template: String,
 
 });
@@ -168,6 +174,7 @@ userSchema.methods.updateConversation = function (outboundTemplate, campaignId) 
 
   if (campaignId && campaignId !== this.current_campaign) {
     this.current_campaign = campaignId;
+    this.signup_status = 'doing';
   }
 
   return this.save();

--- a/app/models/User.js
+++ b/app/models/User.js
@@ -159,8 +159,16 @@ userSchema.methods.postDashbotOutgoing = function (gambitMessageType) {
   this.postDashbot('outgoing', gambitMessageType);
 };
 
-userSchema.methods.setLastOutboundTemplate = function (messageTemplate) {
-  this.last_outbound_template = messageTemplate;
+/**
+ * @param {string} messageTemplate
+ * @param {number} campaignId
+ */
+userSchema.methods.updateConversation = function (outboundTemplate, campaignId) {
+  this.last_outbound_template = outboundTemplate;
+
+  if (campaignId && campaignId !== this.current_campaign) {
+    this.current_campaign = campaignId;
+  }
 
   return this.save();
 };

--- a/lib/conversation/replies.js
+++ b/lib/conversation/replies.js
@@ -46,7 +46,6 @@ function renderEndConversationMsg(fn) {
         args.req.user.updateConversation(messageTemplate)
           .then(() => {
             fn(args);
-            args.req.user.setLastOutboundTemplate(messageTemplate);
             args.req.user.postDashbotOutgoing(messageTemplate);
             stathat.postStat(`campaignbot:${messageTemplate}`);
             BotRequest.log(args.req, 'campaignbot', messageTemplate, args.replyText);
@@ -73,7 +72,6 @@ function renderEndConversationWithErrorMsg(fn) {
         args.req.user.updateConversation(messageTemplate)
           .then(() => {
             fn(args);
-            args.req.user.setLastOutboundTemplate(messageTemplate);
             args.req.user.postDashbotOutgoing(messageTemplate);
             stathat.postStat(`campaignbot:${messageTemplate}`);
             BotRequest.log(args.req, 'campaignbot', messageTemplate, args.replyText);

--- a/lib/conversation/replies.js
+++ b/lib/conversation/replies.js
@@ -40,7 +40,7 @@ function customMsg(fn) {
  * @return {function}    wrapped function
  */
 function renderEndConversationMsg(fn) {
-  return (messageTemplate, args) => helpers.renderMessageForMessageType(args.req, messageTemplate)
+  return (messageTemplate, args) => helpers.renderMessageTemplate(args.req, messageTemplate)
       .then((replyMessage) => {
         args.replyText = replyMessage;
         args.req.user.updateConversation(messageTemplate)
@@ -65,7 +65,7 @@ function renderEndConversationMsg(fn) {
  * @return {function}    wrapped function
  */
 function renderEndConversationWithErrorMsg(fn) {
-  return (messageTemplate, args) => helpers.renderMessageForMessageType(args.req, messageTemplate)
+  return (messageTemplate, args) => helpers.renderMessageTemplate(args.req, messageTemplate)
       .then((replyMessage) => {
         args.replyText = replyMessage;
 
@@ -95,7 +95,7 @@ function renderEndConversationWithErrorMsg(fn) {
  * @return {function}    wrapped function
  */
 function renderContinueConversationMsg(fn) {
-  return (messageTemplate, args) => helpers.renderMessageForMessageType(args.req, messageTemplate)
+  return (messageTemplate, args) => helpers.renderMessageTemplate(args.req, messageTemplate)
       .then((replyMessage) => {
         args.replyText = replyMessage;
 

--- a/lib/conversation/replies.js
+++ b/lib/conversation/replies.js
@@ -238,6 +238,19 @@ module.exports.menuSignedUp = function menuSignedUp(args) {
 
 /**
  * Continues conversation with user.
+ * It responds with a rendered menu_signedup_external message
+ *
+ * @param  {object} args
+ * @return {Command}
+ */
+module.exports.externalSignupMenu = function externalSignupMenu(args) {
+  return new Command(
+    renderContinueConversationMsg(actions.continueConversation),
+    ['menu_signedup_external', args]);
+};
+
+/**
+ * Continues conversation with user.
  * It responds with a rendered invalid_cmd_signedup message
  *
  * @param  {object} args

--- a/lib/conversation/replies.js
+++ b/lib/conversation/replies.js
@@ -43,7 +43,7 @@ function renderEndConversationMsg(fn) {
   return (messageTemplate, args) => helpers.renderMessageForMessageType(args.req, messageTemplate)
       .then((replyMessage) => {
         args.replyText = replyMessage;
-        args.req.user.setLastOutboundTemplate(messageTemplate)
+        args.req.user.updateConversation(messageTemplate)
           .then(() => {
             fn(args);
             args.req.user.setLastOutboundTemplate(messageTemplate);
@@ -70,7 +70,7 @@ function renderEndConversationWithErrorMsg(fn) {
       .then((replyMessage) => {
         args.replyText = replyMessage;
 
-        args.req.user.setLastOutboundTemplate(messageTemplate)
+        args.req.user.updateConversation(messageTemplate)
           .then(() => {
             fn(args);
             args.req.user.setLastOutboundTemplate(messageTemplate);
@@ -101,10 +101,8 @@ function renderContinueConversationMsg(fn) {
       .then((replyMessage) => {
         args.replyText = replyMessage;
 
-        // Store current campaign to continue conversation in subsequent messages.
-        // TODO: Should this be handled more eloquently?
-        args.req.user.current_campaign = args.req.campaignId;
-        args.req.user.setLastOutboundTemplate(messageTemplate)
+        // User's Current Campaign may need to be updated, pass req.campaignId to check.
+        args.req.user.updateConversation(messageTemplate, args.req.campaignId)
           .then(() => {
             logger.verbose(`saved user:${args.req.user._id} current_campaign:${args.req.user.current_campaign}`);
             fn(args);

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -25,8 +25,7 @@ module.exports.handlePhoenixPostError = function handlePhoenixPostError(req, res
 /**
  * Renders message for given message type and request.
  */
-module.exports.renderMessageForMessageType = function renderMessageForMessageType(
-  req, messageType) {
+module.exports.renderMessageTemplate = function renderMessageTemplate(req, messageType) {
   newrelic.addCustomParameters({ gambitResponseMessageType: messageType });
 
   let messagePrefix = '';

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -23,26 +23,28 @@ module.exports.handlePhoenixPostError = function handlePhoenixPostError(req, res
 };
 
 /**
- * Renders message for given message type and request.
+ * Renders message for given request and messageTemplate.
+ * @param {object} req - Express request
+ * @param {string} messageTemplate
  */
-module.exports.renderMessageTemplate = function renderMessageTemplate(req, messageType) {
-  newrelic.addCustomParameters({ gambitResponseMessageType: messageType });
+module.exports.renderMessageTemplate = function renderMessageTemplate(req, messageTemplate) {
+  newrelic.addCustomParameters({ outboundMessageTemplate: messageTemplate });
 
   let messagePrefix = '';
-  let renderMessageType = messageType;
+  let template = messageTemplate;
 
   // Check if we're replying to inform user they've submitted invalid values for text fields.
   // If they did, ask for field again, setting messagePrefix to prepend to the rendered ask message.
   const invalidTextSentMessage = 'Sorry, I didn\'t understand that.\n\n';
-  if (messageType === 'invalid_caption') {
-    renderMessageType = 'ask_caption';
+  if (template === 'invalid_caption') {
+    template = 'ask_caption';
     messagePrefix = invalidTextSentMessage;
-  } else if (messageType === 'invalid_why_participated') {
-    renderMessageType = 'ask_why_participated';
+  } else if (template === 'invalid_why_participated') {
+    template = 'ask_why_participated';
     messagePrefix = invalidTextSentMessage;
   }
 
-  return contentful.renderMessageForPhoenixCampaign(req.campaign, renderMessageType)
+  return contentful.renderMessageForPhoenixCampaign(req.campaign, template)
     .then((renderedMessage) => {
       let message = `${messagePrefix}${renderedMessage}`;
 


### PR DESCRIPTION
#### What's this PR do?
* Refactors `User.setOutboundTemplate(messageTemplate)` as `User.updateConversation(messageTemplate, campaignId)`, setting the User:
    * Last Outbound Template -- The last message template the User received
    * Current Campaign
    * Signup Status -- a new property, set to `'doing'` by default if a `campaignId` is passed. As we look to handle more responses than just "Yes" an Ask Signup Message, we'll want to save values like `'ask_signup'` or `'declined_signup'` here to determine how to reply.

* DRY - Refactor the `signups` router to use `lib/conversations/replies` for External Signup Menu Message delivery.  This route was missed in #932 

* Rename  `helpers.renderMessageForMessageType` as `helpers.renderMessageTemplate` for better readability, as ideally all references to `messageType` should eventually get renamed to `messageTemplate`. 

#### How should this be reviewed?
* Full chatbot conversation to test signing up, changing current campaigns, and conversation enders (e.g. send a Closed Campaign keyword)
* Test a POST `/signups` request with a Signup for your User to verify the External Signup Message is sent (and your Campaign and Last Outbound Template are updated)

#### Any background context you want to provide?
Signup Broadcast functionality currently ends the conversation if the User says a non-YES to an incoming Broadcast.

Potential game plan for our chatbot to continue the conversation instead is:
* Set the User's Current Campaign to the broadcast campaign
* If they responded with a NO, send a new Campaign `askSignupDeclinedMessage` and set their Signup Status to `signup_declined`.
* If responded with neither YES or NO, send a new Campaign `invalidAskSignupResponseMessage` to the User, and set their Signup Status to `'ask_signup'`.

This sets the Current Campaign to the Broadcast Campaign so we can eventually listen for any Campaign specific questions, and still allow the User to say YES to the Signup after we've answered the question -- the MVP of this approach is [here in Slothie.](https://github.com/DoSomething/slothie/blob/master/app/routes/chatbot.js)

#### Relevant tickets
Refs https://github.com/DoSomething/gambit/pull/932#discussion_r127262532

#### Checklist
- [ ] Tested on staging.
