### PR TITLE
Adds required-params middleware to POST signups, campaigns

### DIFF
--- a/app/routes/campaigns.js
+++ b/app/routes/campaigns.js
@@ -114,6 +114,15 @@ router.get('/:id', (req, res) => {
     .catch(err => helpers.sendErrorResponse(res, err));
 });
 
+// Config
+const requiredParamsConf = require('../../config/middleware/campaigns/required-params');
+
+// Middleware
+const requiredParamsMiddleware = require('../../lib/middleware/required-params');
+
+// Check for required body params.
+router.use(requiredParamsMiddleware(requiredParamsConf));
+
 /**
  * POST /:id/message: Sends SMS message to given mobile with the given Campaign and message type.
  *
@@ -128,12 +137,6 @@ router.post('/:id/message', (req, res, next) => {
   req.messageType = req.body.type;
   /* eslint-enable no-param-reassign */
 
-  if (!req.campaignId) {
-    return helpers.sendUnproccessibleEntityResponse(res, 'Missing required campaign id.');
-  }
-  if (!req.phone) {
-    return helpers.sendUnproccessibleEntityResponse(res, 'Missing required phone parameter.');
-  }
   if (!req.messageType) {
     return helpers.sendUnproccessibleEntityResponse(res, 'Missing required type parameter.');
   }

--- a/app/routes/signups.js
+++ b/app/routes/signups.js
@@ -17,20 +17,24 @@ const ClosedCampaignError = require('../exceptions/ClosedCampaignError');
 const Signup = require('../models/Signup');
 const User = require('../models/User');
 
+// Config
+const requiredParamsConf = require('../../config/middleware/signups/required-params');
+
+// Middleware
+const requiredParamsMiddleware = require('../../lib/middleware/required-params');
+
+
+/**
+ * Validate required body parameters.
+ */
+router.use(requiredParamsMiddleware(requiredParamsConf));
+
 /**
  * Validate required body parameters.
  */
 router.use((req, res, next) => {
   stathat.postStat('route: v1/signups');
   logger.debug(`signups post:${JSON.stringify(req.body)}`);
-
-  if (!req.body.id) {
-    return helpers.sendUnproccessibleEntityResponse(res, 'Missing required id.');
-  }
-
-  if (!req.body.source) {
-    return helpers.sendUnproccessibleEntityResponse(res, 'Missing required source.');
-  }
 
   newrelic.addCustomParameters({ signupId: req.body.id });
   const source = req.body.source;

--- a/config/middleware/campaigns/required-params.js
+++ b/config/middleware/campaigns/required-params.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const configVars = {};
+
+configVars.containerProperty = 'body';
+configVars.requiredParams = [
+  'phone',
+  'type',
+];
+module.exports = configVars;

--- a/config/middleware/signups/required-params.js
+++ b/config/middleware/signups/required-params.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const configVars = {};
+
+configVars.containerProperty = 'body';
+configVars.requiredParams = [
+  'id',
+  'source',
+];
+module.exports = configVars;


### PR DESCRIPTION
#### What's this PR do?
* Adds the middleware and required config to the `/signups` route to for quick wins on DRY and increased test coverage.

#### How should this be reviewed?
* Verify a 422 is returned if an `id` or `source` is not included in the body of a POST`/signups` request.

#### Any background context you want to provide?
This got me thinking about a bigger refactor to `signups` to share more middleware with `chatbot`, although it'd need some tweaking and would require a bit more work (and review), so keeping this PR bite (byte?) size for now.

* For the `user-get`, we'd need to:
   * Read the `identifier` field from a config, as well as the value to query for (`chatbot` queries by User `mobile`, `signups` queries by User`id`)
    * Separate middleware for `chatbot` to load the User's Current Campaign if a `req.campaignId` doesn't exist
    * Separate middleware for `chatbot` to post the inbound message to Dashbot

* For the `phoenix-campaign-get`, we'd need to:
    * Separate middleware for `chatbot.replyDispatcher` to deliver a Closed Campaign Message. We want to send a 422 for a Closed Campaign but don't want to deliver the Closed Campaign Message to an end user.


#### Checklist
- [ ] Tested on staging.
