### PR TITLE
Pass Northstar ID + Consolebot improvements

### DIFF
--- a/app/models/Signup.js
+++ b/app/models/Signup.js
@@ -151,7 +151,7 @@ signupSchema.statics.post = function (user, campaign, keyword, broadcastId) {
     logger.debug(`Signup.post(${user._id}, ${campaign.id}, ${keyword})`);
     const postData = {
       source: postSource,
-      uid: user.phoenix_id,
+      northstar_id: user._id,
     };
 
     return phoenix.client.Campaigns.signup(campaign.id, postData)
@@ -240,7 +240,7 @@ signupSchema.methods.postDraftReportbackSubmission = function () {
     const submission = signup.draft_reportback_submission;
     const data = {
       source: postSource,
-      uid: signup.user.phoenix_id,
+      northstar_id: signup.user._id,
       quantity: submission.quantity,
       // Although we strip emoji in our chatbot router in pull#910, some submissions may have emoji
       // saved before we deployed Gambit version 4.3.0.

--- a/config/lib/consolebot/index.js
+++ b/config/lib/consolebot/index.js
@@ -5,11 +5,15 @@ const path = require('path');
 require('dotenv').config();
 const appConfig = require('../../');
 
+// Used as a Reportback image.
+const photoUrl = 'https://www.wired.com/wp-content/uploads/2015/03/The-X-Files1-1024x768.jpg';
+
 const configVars = {
   apiKey: appConfig.apiKey,
   introFilePath: path.resolve(__dirname, 'intro.txt'),
   phone: process.env.GAMBIT_CONSOLEBOT_PHONE,
   phoneUndefinedMessage: 'process.env.GAMBIT_CONSOLEBOT_PHONE undefined',
+  photoUrl: process.env.GAMBIT_CONSOLEBOT_PHOTO_URL || photoUrl,
   prompt: process.env.GAMBIT_CONSOLEBOT_PROMPT || 'You>',
   replyPrefix: process.env.GAMBIT_CONSOLEBOT_REPLY_PREFIX || 'Bot>',
   replyColor: process.env.GAMBIT_CONSOLEBOT_REPLY_COLOR || 'magenta',

--- a/config/lib/consolebot/intro.txt
+++ b/config/lib/consolebot/intro.txt
@@ -9,3 +9,11 @@
  ╚═════╝ ╚═╝  ╚═╝╚═╝     ╚═╝╚═════╝ ╚═╝   ╚═╝   
 
 
+===============================================================
+
+* Type a keyword to get started, using syntax keyword:[keyword]
+  e.g. 'keyword:mirrorbot'.
+
+* To send a photo, type 'photo'.
+
+================================================================

--- a/lib/consolebot.js
+++ b/lib/consolebot.js
@@ -21,17 +21,17 @@ class Consolebot {
       output: process.stdout,
     });
     this.readline.setPrompt(`${this.options.prompt} `.bold);
-    this.readline.on('line', input => this.post(input));
+    this.readline.on('line', input => this.post(Consolebot.parseInput(input)));
     this.readline.on('close', () => process.exit(0));
   }
-  post(inboundMessageText) {
+  post(data) {
+    const scope = data;
+    scope.phone = this.options.phone;
+
     return superagent
       .post(this.options.url)
       .set('x-gambit-api-key', this.options.apiKey)
-      .send({
-        phone: this.options.phone,
-        args: inboundMessageText,
-      })
+      .send(scope)
       .then(response => this.reply(response.body.success.message))
       .catch(err => this.reply(err.message));
   }
@@ -51,6 +51,17 @@ class Consolebot {
     const replyText = outboundMessageText[this.replyColor];
     Consolebot.print(prefix, replyText);
     this.prompt();
+  }
+  static parseInput(string) {
+    if (string.includes('keyword:')) {
+      const data = string.split(':');
+      return {
+        keyword: data[1],
+      };
+    }
+    return {
+      args: string,
+    };
   }
   static print(prefix, messageText) {
     /* eslint-disable no-console */

--- a/lib/consolebot.js
+++ b/lib/consolebot.js
@@ -21,8 +21,24 @@ class Consolebot {
       output: process.stdout,
     });
     this.readline.setPrompt(`${this.options.prompt} `.bold);
-    this.readline.on('line', input => this.post(Consolebot.parseInput(input)));
+    this.readline.on('line', input => this.post(this.parseInput(input)));
     this.readline.on('close', () => process.exit(0));
+  }
+  parseInput(string) {
+    if (string.includes('keyword:')) {
+      const data = string.split(':');
+      return {
+        keyword: data[1],
+      };
+    }
+    if (string === 'photo') {
+      return {
+        mms_image_url: this.options.photoUrl,
+      };
+    }
+    return {
+      args: string,
+    };
   }
   post(data) {
     const scope = data;
@@ -51,17 +67,6 @@ class Consolebot {
     const replyText = outboundMessageText[this.replyColor];
     Consolebot.print(prefix, replyText);
     this.prompt();
-  }
-  static parseInput(string) {
-    if (string.includes('keyword:')) {
-      const data = string.split(':');
-      return {
-        keyword: data[1],
-      };
-    }
-    return {
-      args: string,
-    };
   }
   static print(prefix, messageText) {
     /* eslint-disable no-console */

--- a/test/lib/consolebot.test.js
+++ b/test/lib/consolebot.test.js
@@ -14,10 +14,10 @@ const underscore = require('underscore');
 
 const readline = require('readline');
 
-const stubs = require('../utils/stubs.js');
-const config = require('../../config/lib/consolebot');
-
 // stubs
+const stubs = require('../utils/stubs.js');
+
+const consolebotPostArgs = stubs.consolebot.getPostArgs();
 
 // setup "x.should.y" assertion style
 chai.should();
@@ -26,6 +26,7 @@ chai.use(sinonChai);
 const sandbox = sinon.sandbox.create();
 
 // Module to test
+const config = require('../../config/lib/consolebot');
 const Consolebot = require('../../lib/consolebot');
 
 // Setup
@@ -109,7 +110,6 @@ test('post should call reply on success', async () => {
   const consolebot = new Consolebot(config);
   sandbox.spy(consolebot, 'reply');
 
-  const text = 'hello!';
   nock(config.url)
     .post('', {})
     .query(true)
@@ -120,7 +120,7 @@ test('post should call reply on success', async () => {
     });
 
   // test
-  await consolebot.post(text);
+  await consolebot.post(consolebotPostArgs);
   consolebot.reply.should.have.been.called;
 });
 
@@ -128,7 +128,6 @@ test('consolebot post should call reply on error', async () => {
   const consolebot = new Consolebot(config);
   sandbox.spy(consolebot, 'reply');
 
-  const text = 'hi!';
   nock(config.url)
     .post('', {})
     .query(true)
@@ -138,6 +137,6 @@ test('consolebot post should call reply on error', async () => {
       },
     });
 
-  await consolebot.post(text);
+  await consolebot.post(consolebotPostArgs);
   consolebot.reply.should.have.been.called;
 });

--- a/test/lib/consolebot.test.js
+++ b/test/lib/consolebot.test.js
@@ -140,3 +140,30 @@ test('consolebot post should call reply on error', async () => {
   await consolebot.post(consolebotPostArgs);
   consolebot.reply.should.have.been.called;
 });
+
+const testbot = new Consolebot(config);
+
+test('consolebot parseInput should return an object with args when no command found', (t) => {
+  const testString = 'hi';
+  const expected = {
+    args: testString,
+  };
+  t.deepEqual(testbot.parseInput(testString), expected);
+});
+
+test('consolebot parseInput should return an object with keyword when keyword command', (t) => {
+  const testKeyword = 'hi';
+  const testString = `keyword:${testKeyword}`;
+  const expected = {
+    keyword: testKeyword,
+  };
+  t.deepEqual(testbot.parseInput(testString), expected);
+});
+
+test('consolebot parseInput should return an object with mms_image_url when photo command', (t) => {
+  const testString = 'photo';
+  const expected = {
+    mms_image_url: config.photoUrl,
+  };
+  t.deepEqual(testbot.parseInput(testString), expected);
+});

--- a/test/utils/stubs.js
+++ b/test/utils/stubs.js
@@ -103,6 +103,13 @@ module.exports = {
       },
     };
   },
+  consolebot: {
+    getPostArgs: function getPostArgs() {
+      return {
+        args: 'hi',
+      };
+    },
+  },
 
   /**
    * This function returns mocks of the response that contentful sends to Gambit when queriyng for


### PR DESCRIPTION
#### What's this PR do?

* Passes `northstar_id` instead of a `uid` when we post to Phoenix Campaign Signup and Reportback resource,  but... 
    * I can consistently trigger a 422 error when passing `northstar_id` instead of `uid` when posting a Reportback, @DFurnes. Does Phoenix Next pass `northstar_id` ? 

* Adds `keyword` and `photo` commands to Consolebot to get it fully functional for testing, along with tests

#### How should this be reviewed?
Need to create a new User, since we don't have access to delete Signups or Reportbacks in Rogue yet. 

* Create new User via using a `phone` that doesn't exist
* Text in a keyword and verify Signup is created
* Complete the conversation to verify a Reportback is created (triggers 422)

#### Additional information

Can't merge this until verifying there's a bug in Phoenix/Rogue that's throwing the 422 upon passing `northstar_id` instead of `uid` to the Phoenix Campaign Reportback endpoint.

#### Relevant tickets
#940, #922 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
