### PR TITLE
Receive Message endpoint

### DIFF
--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -3,6 +3,7 @@
 // Routes
 const campaignsRoute = require('./campaigns');
 const chatbotRoute = require('./chatbot');
+const receiveMessageRoute = require('./receive-message');
 const signupsRoute = require('./signups');
 const statusRoute = require('./status');
 const homeRoute = require('./home');
@@ -30,5 +31,6 @@ module.exports = function init(app) {
   app.use('/v1/status', statusRoute);
   app.use('/v1/campaigns', campaignsRoute);
   app.use('/v1/chatbot', chatbotRoute);
+  app.use('/v1/receive-message', receiveMessageRoute);
   app.use('/v1/signups', signupsRoute);
 };

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -29,8 +29,16 @@ module.exports = function init(app) {
   regGlobalMiddleware(app);
   app.get('/', homeRoute);
   app.use('/v1/status', statusRoute);
+
+  // Provides list of Campaigns currently running on Gambit.
   app.use('/v1/campaigns', campaignsRoute);
+
+  // Receives inbound message from Mobile Commons mData.
   app.use('/v1/chatbot', chatbotRoute);
+
+  // Receives inbound message from Gambit Conversations service.
   app.use('/v1/receive-message', receiveMessageRoute);
+
+  // Sends external Signup message to a User for a Campaign.
   app.use('/v1/signups', signupsRoute);
 };

--- a/app/routes/receive-message.js
+++ b/app/routes/receive-message.js
@@ -1,0 +1,95 @@
+'use strict';
+
+const express = require('express');
+
+// configs
+const requiredParamsConf = require('../../config/middleware/receive-message/required-params');
+const mapParamsConf = require('../../config/middleware/receive-message/map-request-params');
+
+// Middleware
+const requiredParamsMiddleware = require('../../lib/middleware/required-params');
+const mapRequestParamsMiddleware = require('../../lib/middleware/map-request-params');
+const receiveMessageMiddleware = require('../../lib/middleware/receive-message');
+const getUserMiddleware = require('../../lib/middleware/user-get');
+const createNewUserIfNotFoundMiddleware = require('../../lib/middleware/user-create');
+const getPhoenixCampaignMiddleware = require('../../lib/middleware/phoenix-campaign-get');
+const getSignupMiddleware = require('../../lib/middleware/signup-get');
+const createNewSignupIfNotFoundMiddleware = require('../../lib/middleware/signup-create');
+const validateRequestMiddleware = require('../../lib/middleware/validate');
+const createDraftSubmissionMiddleware = require('../../lib/middleware/draft-create');
+const completedMenuMiddleware = require('../../lib/middleware/menu-completed');
+const doingMenuMiddleware = require('../../lib/middleware/menu-doing');
+const draftSubmissionQuantityMiddleware = require('../../lib/middleware/draft-quantity');
+const draftSubmissionPhotoMiddleware = require('../../lib/middleware/draft-photo');
+const draftSubmissionCaptionMiddleware = require('../../lib/middleware/draft-caption');
+const draftSubmissionWhyParticipatedMiddleware = require('../../lib/middleware/draft-why-participated');
+const postDraftSubmissionMiddleware = require('../../lib/middleware/draft-completed');
+
+// Router
+const router = express.Router(); // eslint-disable-line new-cap
+
+/**
+ * Check for required parameters,
+ * parse incoming params, and add/log helper variables.
+ */
+router.use(requiredParamsMiddleware(requiredParamsConf));
+router.use(mapRequestParamsMiddleware(mapParamsConf));
+router.use(receiveMessageMiddleware());
+
+
+router.use(
+  /**
+   * Check if DS User exists for given mobile number.
+   */
+  getUserMiddleware(),
+  /**
+   * Create DS User for given mobile number if we didn't find one.
+   */
+  createNewUserIfNotFoundMiddleware());
+
+/**
+ * Load Campaign from DS Phoenix API.
+ */
+router.use(getPhoenixCampaignMiddleware());
+
+router.use(
+  /**
+   * Check DS Phoenix API for existing Signup.
+   */
+  getSignupMiddleware(),
+  /**
+   * If Signup wasn't found, post Signup to DS Phoenix API.
+   */
+  createNewSignupIfNotFoundMiddleware());
+
+/**
+ * Run sanity checks
+ */
+router.use(validateRequestMiddleware());
+
+
+/**
+ * Checks Signup for existing draft, or creates draft when User has completed the Campaign.
+ */
+router.use(createDraftSubmissionMiddleware());
+
+/**
+ * If there's no Draft, send the relevant Menus.
+ */
+router.use(completedMenuMiddleware());
+router.use(doingMenuMiddleware());
+
+/**
+ * Collect data for our Reportback Submission.
+ */
+router.use(draftSubmissionQuantityMiddleware());
+router.use(draftSubmissionPhotoMiddleware());
+router.use(draftSubmissionCaptionMiddleware());
+router.use(draftSubmissionWhyParticipatedMiddleware());
+
+/**
+ * Post complete submission to the DS Phoenix API.
+ */
+router.use(postDraftSubmissionMiddleware());
+
+module.exports = router;

--- a/config/middleware/receive-message/map-request-params.js
+++ b/config/middleware/receive-message/map-request-params.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const configVars = {};
+
+configVars.client = 'gambit-conversations';
+configVars.containerProperty = 'body';
+configVars.emojiStripParam = 'text';
+configVars.lowercaseParam = 'text';
+configVars.paramsMap = {
+  keyword: 'keyword',
+  broadcastId: 'broadcast_id',
+  text: 'incoming_message',
+  mediaUrl: 'incoming_image_url',
+};
+module.exports = configVars;

--- a/config/middleware/receive-message/required-params.js
+++ b/config/middleware/receive-message/required-params.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const configVars = {};
+
+configVars.containerProperty = 'body';
+configVars.requiredParams = [
+  'phone',
+  'campaignId',
+];
+module.exports = configVars;

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -8,6 +8,7 @@ Endpoint                                       | Functionality
 `POST /v1/chatbot` | [CampaignBot chat](endpoints/chatbot.md)
 
 
+
 ## Campaigns
 
 Endpoint                                       | Functionality                                           
@@ -15,6 +16,12 @@ Endpoint                                       | Functionality
 `GET /v1/campaigns` | [Retrieve all campaigns](endpoints/campaigns.md#retrieve-all-campaigns)
 `GET /v1/campaigns/:id` | [Retrieve a campaign](endpoints/campaigns.md#retrieve-a-campaigns)
 `GET /v1/campaigns/:id/messages` | [Send a campaign message](endpoints/campaigns.md#send-a-campaign-message)
+
+## Receive Message
+
+Endpoint                                       | Functionality                                           
+---------------------------------------------- | --------------------------------------------------------
+`POST /v1/receive-message` | [Receive Signup Message](endpoints/receive-message.md)
 
 
 ## Signups

--- a/documentation/endpoints/receive-message.md
+++ b/documentation/endpoints/receive-message.md
@@ -1,0 +1,52 @@
+# Receive Message
+
+Receives an inbound message forwarded from the Gambit Conversations API to create or update a User's Signup for the given `campaignId`. 
+
+```
+POST /v1/receive-message
+```
+
+**Headers**
+
+Name | Type | Description
+--- | --- | ---
+`x-gambit-api-key` | `string` | **Required.**
+`x-blink-retry-count` | `number` | If set, number of times [Blink](github.com/dosomething/blink) has retried this request.
+
+**Input**
+
+
+Name | Type | Description
+--- | --- | ---
+`phone` | `string` | **Required.** Mobile number that sent incoming message.
+`campaignId` | `string` | **Required.** Mobile number that sent incoming message.
+`text` | `string` | Incoming text sent.
+`mediaUrl` | `string` | Incoming image sent.
+`keyword` | `string` | Campaign Signup keyword, if triggered
+`broadcastId` | `string` | Broadcast ID, if User is responding to a Broadcast
+
+<details><summary>**Example Request**</summary><p>
+
+```
+curl -X "POST" "http://localhost:5000/v1/chatbot" \
+     -H "x-gambit-api-key: totallysecret" \
+     -H "Content-Type: application/x-www-form-urlencoded; charset=utf-8" \
+     --data-urlencode "phone=5555555511" \
+     --data-urlencode "text=I love rock and roll"
+     --data-urlencode "campaignId=7" \
+```
+
+</p></details>
+
+<details><summary>**Example Response**</summary><p>
+
+```
+{
+  "success": {
+    "code": 200,
+    "message": "Nice job! YOU deserve a Mirror Message for all the notes you posted. We've got you down for 97 messages posted. Have you posted more? Text START."
+  }
+}
+```
+
+</p></details>

--- a/lib/conversation/actions.js
+++ b/lib/conversation/actions.js
@@ -1,11 +1,27 @@
 'use strict';
 
+function isMobileCommonsRequest(args) {
+  return args.req.client === 'mobilecommons';
+}
+
+/**
+ * Sends replyText to User via Mobile Commons, opting User in to Chatbot OIP.
+ */
 module.exports.continueConversation = function continueConversation(args) {
+  if (!isMobileCommonsRequest(args)) {
+    return null;
+  }
   return args.req.user.postMobileCommonsProfileUpdate(
     process.env.MOBILECOMMONS_OIP_CHATBOT, args.replyText);
 };
 
+/**
+ * Sends replyText to User via Mobile Commons, opting User in to Agent View OIP.
+ */
 module.exports.endConversation = function endConversation(args) {
+  if (!isMobileCommonsRequest(args)) {
+    return null;
+  }
   return args.req.user.postMobileCommonsProfileUpdate(
     process.env.MOBILECOMMONS_OIP_AGENTVIEW, args.replyText);
 };

--- a/lib/middleware/map-request-params.js
+++ b/lib/middleware/map-request-params.js
@@ -13,6 +13,7 @@ const helpers = require('../../lib/helpers');
 function logParams(req) {
   stathat.postStat(`route: ${req.baseUrl}`);
   const incomingParams = {
+    phone: req.body.phone,
     profile_id: req.body.profile_id,
     incoming_message: req.incoming_message,
     incoming_image_url: req.incoming_image_url,

--- a/lib/middleware/receive-message.js
+++ b/lib/middleware/receive-message.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = function receiveMessage() {
+  return (req, res, next) => {
+    req.campaignId = req.body.campaignId;
+
+    return next();
+  };
+};


### PR DESCRIPTION
#### What's this PR do?
Adds a **POST** `/receive-message` endpoint that acts like **POST** `/chatbot`, with a few differences:
* It expects a `campaignId` parameter to determine which Campaign to create a Signup for (or to save Signup data against, e.g. quantity, photo)
* It doesn't post to Mobile Commons to send the Gambit reply back to the User-- sending the reply will be the responsibility of the Conversations resource that posts here  https://github.com/DoSomething/gambit-conversations/issues/59

#### How should this be reviewed?
Post locally to `/receive-message` to verify Signup + Campaign Completion steps.

```
curl -X "POST" "http://localhost:5000/v1/receive-message" \
     -H "x-gambit-api-key: [apiKey]" \
     -H "Content-Type: application/x-www-form-urlencoded; charset=utf-8" \
     --data-urlencode "phone=[yourPhoneNumber]" \
     --data-urlencode "text=3" \
     --data-urlencode "campaignId=2900"
 ```

#### Any background context you want to provide?
This endpoint will deprecate the `/chatbot` endpoint (and `User` model) once Conversations launches - our [Conversation model will store the Campaign](https://github.com/DoSomething/gambit-conversations/blob/1158a34dc98da6ddee347e6fbcd475bea29b7c69/app/models/Conversation.js#L21) a User is currently in a conversation for.

#### Relevant tickets
Fixes #939 

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Tested on staging.
