### PR TITLE
Deprecate middleware/receive-message

### DIFF
--- a/app/routes/receive-message.js
+++ b/app/routes/receive-message.js
@@ -9,7 +9,6 @@ const mapParamsConf = require('../../config/middleware/receive-message/map-reque
 // Middleware
 const requiredParamsMiddleware = require('../../lib/middleware/required-params');
 const mapRequestParamsMiddleware = require('../../lib/middleware/map-request-params');
-const receiveMessageMiddleware = require('../../lib/middleware/receive-message');
 const getUserMiddleware = require('../../lib/middleware/user-get');
 const createNewUserIfNotFoundMiddleware = require('../../lib/middleware/user-create');
 const getPhoenixCampaignMiddleware = require('../../lib/middleware/phoenix-campaign-get');
@@ -34,8 +33,6 @@ const router = express.Router(); // eslint-disable-line new-cap
  */
 router.use(requiredParamsMiddleware(requiredParamsConf));
 router.use(mapRequestParamsMiddleware(mapParamsConf));
-router.use(receiveMessageMiddleware());
-
 
 router.use(
   /**
@@ -66,7 +63,6 @@ router.use(
  * Run sanity checks
  */
 router.use(validateRequestMiddleware());
-
 
 /**
  * Checks Signup for existing draft, or creates draft when User has completed the Campaign.

--- a/config/middleware/receive-message/map-request-params.js
+++ b/config/middleware/receive-message/map-request-params.js
@@ -9,6 +9,7 @@ configVars.lowercaseParam = 'text';
 configVars.paramsMap = {
   keyword: 'keyword',
   broadcastId: 'broadcast_id',
+  campaignId: 'campaignId',
   text: 'incoming_message',
   mediaUrl: 'incoming_image_url',
 };

--- a/lib/middleware/map-request-params.js
+++ b/lib/middleware/map-request-params.js
@@ -88,9 +88,7 @@ function parseBroadcastDeclinedMessage(req) {
 
 module.exports = function mapRequestParams(config = {}) {
   return (req, res, next) => {
-    const asyncRequests = [];
     req.client = config.client;
-    req.contentfulObjects = {};
 
     /**
      * config.paramsMap is a hash that holds the names of the new req properties that will
@@ -108,19 +106,27 @@ module.exports = function mapRequestParams(config = {}) {
       }
 
       req[config.paramsMap[param]] = value;
+      logger.verbose(`req.${config.paramsMap[param]}=${value}`);
     });
 
     // sync parsers
     parseRetryCount(req);
     parseIsNewConversation(req);
 
-    // async parsers
-    asyncRequests.push(parseContentfulBroadcast(req, res));
-    asyncRequests.push(parseContentfulKeyword(req, res));
-
     // log
     logParams(req);
     addNewRelicParams(req);
+
+    if (req.client !== 'mobilecommons') {
+      return next();
+    }
+
+    const asyncRequests = [];
+    req.contentfulObjects = {};
+
+    // async parsers
+    asyncRequests.push(parseContentfulBroadcast(req, res));
+    asyncRequests.push(parseContentfulKeyword(req, res));
 
     // Process async parsers
     return Promise.all(asyncRequests)

--- a/lib/middleware/receive-message.js
+++ b/lib/middleware/receive-message.js
@@ -1,9 +1,0 @@
-'use strict';
-
-module.exports = function receiveMessage() {
-  return (req, res, next) => {
-    req.campaignId = req.body.campaignId;
-
-    return next();
-  };
-};

--- a/lib/middleware/user-get.js
+++ b/lib/middleware/user-get.js
@@ -11,6 +11,7 @@ const User = require('../../app/models/User');
  */
 function populateCampaignIdIfNotFound(req, res) {
   if (!req.campaignId) {
+    logger.debug('req.campaignId not found');
     req.campaignId = helpers.getCampaignIdFromUser(req, res);
   }
 }


### PR DESCRIPTION
#### What's this PR do?
* Adds a `campaignId` to  `config/middleware/receive-message/map-request-params`
* Refactors `lib/middleware/map-request-params` to call async parsers only when `req.client` is Mobile Commons. This is what was causing https://github.com/DoSomething/gambit/pull/944#discussion_r132808228.
    * Deletes now deprecated `lib/middleware/receive-message`

#### How should this be reviewed?
Post to `/receive-message` and pass different values for `campaignId`. Verify the reply message returned is for your User's Signup for the Campaign you passed 

Coming soon: Consolebot Campaign ID arg to test **POST** `/receive-message` instead of **POST** `/chatbot` via terminal


#### Checklist
- [ ] Tested on staging.
