### PR TITLE
Fixes Conversation Action check for POST Signups

### DIFF
--- a/lib/conversation/actions.js
+++ b/lib/conversation/actions.js
@@ -1,9 +1,16 @@
 'use strict';
 
+function isMobileCommonsRequest(args) {
+  return args.req.client === 'mobilecommons';
+}
+
 /**
  * Sends replyText to User via Mobile Commons, opting User in to Chatbot OIP.
  */
 module.exports.continueConversation = function continueConversation(args) {
+  if (!isMobileCommonsRequest(args)) {
+    return null;
+  }
   return args.req.user.postMobileCommonsProfileUpdate(
     process.env.MOBILECOMMONS_OIP_CHATBOT, args.replyText);
 };
@@ -12,6 +19,9 @@ module.exports.continueConversation = function continueConversation(args) {
  * Sends replyText to User via Mobile Commons, opting User in to Agent View OIP.
  */
 module.exports.endConversation = function endConversation(args) {
+  if (!isMobileCommonsRequest(args)) {
+    return null;
+  }
   return args.req.user.postMobileCommonsProfileUpdate(
     process.env.MOBILECOMMONS_OIP_AGENTVIEW, args.replyText);
 };

--- a/lib/conversation/actions.js
+++ b/lib/conversation/actions.js
@@ -1,14 +1,14 @@
 'use strict';
 
-function isMobileCommonsRequest(args) {
-  return args.req.client === 'mobilecommons';
+function isGambitConversationsRequest(args) {
+  return args.req.client === 'gambit-conversations';
 }
 
 /**
  * Sends replyText to User via Mobile Commons, opting User in to Chatbot OIP.
  */
 module.exports.continueConversation = function continueConversation(args) {
-  if (!isMobileCommonsRequest(args)) {
+  if (isGambitConversationsRequest(args)) {
     return null;
   }
   return args.req.user.postMobileCommonsProfileUpdate(
@@ -19,7 +19,7 @@ module.exports.continueConversation = function continueConversation(args) {
  * Sends replyText to User via Mobile Commons, opting User in to Agent View OIP.
  */
 module.exports.endConversation = function endConversation(args) {
-  if (!isMobileCommonsRequest(args)) {
+  if (isGambitConversationsRequest(args)) {
     return null;
   }
   return args.req.user.postMobileCommonsProfileUpdate(

--- a/test/lib/conversation/actions.test.js
+++ b/test/lib/conversation/actions.test.js
@@ -6,7 +6,6 @@ require('dotenv').config();
 const test = require('ava');
 const chai = require('chai');
 const sinonChai = require('sinon-chai');
-const sinon = require('sinon');
 
 // Module to test
 const actions = require('../../../lib/conversation/actions');
@@ -14,8 +13,6 @@ const actions = require('../../../lib/conversation/actions');
 // setup "x.should.y" assertion style
 chai.should();
 chai.use(sinonChai);
-
-const sandbox = sinon.sandbox.create();
 
 test('actions should respond to continueConversation', () => {
   actions.should.respondTo('continueConversation');

--- a/test/lib/conversation/actions.test.js
+++ b/test/lib/conversation/actions.test.js
@@ -1,0 +1,26 @@
+'use strict';
+
+// env variables
+require('dotenv').config();
+
+const test = require('ava');
+const chai = require('chai');
+const sinonChai = require('sinon-chai');
+const sinon = require('sinon');
+
+// Module to test
+const actions = require('../../../lib/conversation/actions');
+
+// setup "x.should.y" assertion style
+chai.should();
+chai.use(sinonChai);
+
+const sandbox = sinon.sandbox.create();
+
+test('actions should respond to continueConversation', () => {
+  actions.should.respondTo('continueConversation');
+});
+
+test('actions should respond to endConversation', () => {
+  actions.should.respondTo('endConversation');
+});


### PR DESCRIPTION
#### What's this PR do?
 Changes the logic for when to post to Mobile Commons by checking when `args.req.client ===  'gambit-campaigns'`. #944 introduced a bug that prevented the Quicksilver POST `/signups` request from delivering External Signup Confirmation messages by posting to Mobile Commons (hotfixed in #947).

#### How should this be reviewed?
You can test locally by using your phone number and sending a POST request to local endpoints:
* `/chatbot` -- Should send text to your number (via Mobile Commons)
* `/receive-message` - Should NOT receive text
* `/signups` -- Should send text to your number. [Can find the Signup `id` to pass](https://github.com/DoSomething/gambit/blob/develop/documentation/endpoints/signups.md) from the logs in your Chatbot request. 

#### Checklist
- [ ] Tested on staging.
