### PR TITLE
Adds conversation/actions test

### DIFF
--- a/test/lib/conversation/actions.test.js
+++ b/test/lib/conversation/actions.test.js
@@ -1,23 +1,72 @@
 'use strict';
 
-// env variables
 require('dotenv').config();
 
 const test = require('ava');
 const chai = require('chai');
 const sinonChai = require('sinon-chai');
+const sinon = require('sinon');
+
+// App Modules
+const stubs = require('../../../test/utils/stubs');
+const userFactory = require('../../utils/factories/user');
+
+// Stubs
+const user = userFactory.getValidUser();
+const chatbotArgs = stubs.conversation.getChatbotRequestArgs(user);
+const receiveMessageArgs = stubs.conversation.getRecieveMessageRequestArgs(user);
+const signupsArgs = stubs.conversation.getSignupsRequestArgs(user);
 
 // Module to test
 const actions = require('../../../lib/conversation/actions');
 
-// setup "x.should.y" assertion style
 chai.should();
 chai.use(sinonChai);
+
+const sandbox = sinon.sandbox.create();
+
+test.beforeEach(() => {
+  sandbox.stub(user, 'postMobileCommonsProfileUpdate');
+});
+
+test.afterEach(() => {
+  sandbox.restore();
+});
 
 test('actions should respond to continueConversation', () => {
   actions.should.respondTo('continueConversation');
 });
 
+test('continueConversation should postMobileCommonsProfileUpdate for chatbot requests', () => {
+  actions.continueConversation(chatbotArgs);
+  user.postMobileCommonsProfileUpdate.should.have.been.called;
+});
+
+test('continueConversation should postMobileCommonsProfileUpdate for receive-message requests', () => {
+  actions.continueConversation(receiveMessageArgs);
+  user.postMobileCommonsProfileUpdate.should.not.have.been.called;
+});
+
+test('continueConversation should postMobileCommonsProfileUpdate for signups requests', () => {
+  actions.continueConversation(signupsArgs);
+  user.postMobileCommonsProfileUpdate.should.have.been.called;
+});
+
 test('actions should respond to endConversation', () => {
   actions.should.respondTo('endConversation');
+});
+
+test('endConversation should postMobileCommonsProfileUpdate for chatbot requests', () => {
+  actions.endConversation(chatbotArgs);
+  user.postMobileCommonsProfileUpdate.should.have.been.called;
+});
+
+test('endConversation should not postMobileCommonsProfileUpdate for receive-message requests', () => {
+  actions.endConversation(receiveMessageArgs);
+  user.postMobileCommonsProfileUpdate.should.not.have.been.called;
+});
+
+test('endConversation should postMobileCommonsProfileUpdate for signups requests', () => {
+  actions.endConversation(signupsArgs);
+  user.postMobileCommonsProfileUpdate.should.have.been.called;
 });

--- a/test/utils/stubs.js
+++ b/test/utils/stubs.js
@@ -131,6 +131,32 @@ module.exports = {
       };
     },
   },
+  conversation: {
+    getChatbotRequestArgs: function getChatbotRequestArgs(user) {
+      return {
+        req: {
+          user,
+          client: 'mobilecommons',
+        },
+      };
+    },
+    getRecieveMessageRequestArgs: function getRecieveMessageRequestArgs(user) {
+      return {
+        req: {
+          user,
+          client: 'gambit-conversations',
+        },
+      };
+    },
+    getSignupsRequestArgs: function getSignupsRequestArgs(user) {
+      return {
+        req: {
+          user,
+          client: 'signups-api',
+        },
+      };
+    },
+  },
 
   /**
    * This function returns mocks of the response that contentful sends to Gambit when queriyng for


### PR DESCRIPTION
#### What's this PR do?
Adds test coverage for when Conversation Actions should call `req.user.postMobileCommonsProfileUpdate` 

#### How should this be reviewed?
`npm run all-tests`

#### Relevant tickets
 #947, #948

