### PR TITLE
Include template in POST /receive-message

### DIFF
--- a/config/lib/contentful.js
+++ b/config/lib/contentful.js
@@ -12,7 +12,7 @@ module.exports = {
    *  in Contentful, which is based on the order in
    *  which our end user will see the messages.
    *
-   *  { message_type: 'campaignMessageField'}
+   *  { message_template: 'campaignMessageField'}
    */
   campaignFields: {
     menu_signedup_gambit: 'gambitSignupMenuMessage',

--- a/documentation/endpoints/chatbot.md
+++ b/documentation/endpoints/chatbot.md
@@ -45,7 +45,8 @@ curl -X "POST" "http://localhost:5000/v1/chatbot" \
 {
   "success": {
     "code": 200,
-    "message": "Picking up where you left off on Bumble Bands...\n\nSend your best pic of you and the 33 bumble bands you created."
+    "message": "Picking up where you left off on Bumble Bands...\n\nSend your best pic of you and the 33 bumble bands you created.",
+    "template": "askPhotoMessage"
   }
 }
 ```

--- a/documentation/endpoints/receive-message.md
+++ b/documentation/endpoints/receive-message.md
@@ -44,7 +44,8 @@ curl -X "POST" "http://localhost:5000/v1/chatbot" \
 {
   "success": {
     "code": 200,
-    "message": "Nice job! YOU deserve a Mirror Message for all the notes you posted. We've got you down for 97 messages posted. Have you posted more? Text START."
+    "message": "Nice job! YOU deserve a Mirror Message for all the notes you posted. We've got you down for 97 messages posted. Have you posted more? Text START.",
+    "template": "completedMenuMessage"
   }
 }
 ```

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -305,3 +305,7 @@ module.exports.mapCampaignIds = function mapCampaignIds(keywords = []) {
   });
   return Object.keys(campaignMap);
 };
+
+module.exports.getFieldNameForCampaignMessageTemplate = function (messageTemplate) {
+  return config.campaignFields[messageTemplate];
+};

--- a/lib/conversation/replies.js
+++ b/lib/conversation/replies.js
@@ -48,7 +48,7 @@ function renderEndConversationMsg(fn) {
             fn(args);
             stathat.postStat(`campaignbot:${messageTemplate}`);
             BotRequest.log(args.req, 'campaignbot', messageTemplate, args.replyText);
-            return helpers.sendResponse(args.res, 200, args.replyText);
+            return helpers.sendResponse(args.res, 200, args.replyText, messageTemplate);
           });
       })
       .catch(err => helpers.sendErrorResponse(args.res, err));
@@ -104,7 +104,7 @@ function renderContinueConversationMsg(fn) {
             fn(args);
             stathat.postStat(`campaignbot:${messageTemplate}`);
             BotRequest.log(args.req, 'campaignbot', messageTemplate, args.replyText);
-            return helpers.sendResponse(args.res, 200, args.replyText);
+            return helpers.sendResponse(args.res, 200, args.replyText, messageTemplate);
           });
       })
       .catch(err => helpers.sendErrorResponse(args.res, err));

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -242,18 +242,27 @@ module.exports.replacePhoenixCampaignVars = function (input, phoenixCampaign, si
  * Formats given Express response and sends an object including given message, with given code.
  * @param {object} res - Express response
  * @param {number} code - HTTP status code to return
- * @param {string} message - Message to include in response object.
+ * @param {string} messageText
+ * @param {string} messageTemplate
  */
-module.exports.sendResponse = function (res, code, message) {
+module.exports.sendResponse = function (res, code, messageText, messageTemplate) {
   let type = 'success';
   if (code > 200) {
     type = 'error';
-    logger.error(message);
-    stathat.postStat(`${code}: ${message}`);
+    logger.error(messageText);
+    stathat.postStat(`${code}: ${messageText}`);
   }
 
   const response = {};
-  response[type] = { code, message };
+  response[type] = {
+    code,
+    message: messageText,
+  };
+  if (messageTemplate) {
+    const fieldName = contentful.getFieldNameForCampaignMessageTemplate(messageTemplate);
+    // Gambit Conversations stores Message.template by the fieldName, not our machine_name style.
+    response[type].template = fieldName;
+  }
 
   return res.status(code).send(response);
 };

--- a/test/lib/contentful.test.js
+++ b/test/lib/contentful.test.js
@@ -421,3 +421,15 @@ test('mapCampaignIds should return an array', async () => {
     }
   });
 });
+
+
+test('getFieldNameForCampaignMessageTemplate should return a config.campaignFields value', (t) => {
+  // setup
+  const contentfulConfig = require('../../config/lib/contentful');
+  const template = 'askPhotoMessage';
+  const fieldName = contentfulConfig.campaignFields[template];
+
+  // test
+  const result = contentful.getFieldNameForCampaignMessageTemplate(template);
+  t.deepEqual(result, fieldName);
+});


### PR DESCRIPTION
#### What's this PR do?
Includes a `template` property to the responses of `POST /chatbot` and `POST /receive-message`, returning the name of the Contentful Campaign field used for the reply message text. 

#### How should this be reviewed?
* 👀 
* Post locally `/receive-message` or `/chatbot` to verify non-breakage

#### Relevant tickets
Fixes #955 

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Tested on staging.
