### PR TITLE
Return data.templates in GET campaigns/:id 

### DIFF
--- a/app/routes/campaigns.js
+++ b/app/routes/campaigns.js
@@ -33,7 +33,7 @@ function fetchCampaign(id, renderMessages) {
         campaign.status = phoenixCampaign.status;
         campaign.current_run = phoenixCampaign.currentCampaignRun.id;
         if (renderMessages === true) {
-          return contentful.renderAllMessagesForPhoenixCampaign(phoenixCampaign);
+          return contentful.renderAllTemplatesForPhoenixCampaign(phoenixCampaign);
         }
 
         return false;
@@ -97,7 +97,7 @@ router.get('/:id', (req, res) => {
       return contentful.fetchCampaign(campaignId);
     })
     // TODO: Querying Contentful again here to get its sys.id. We could avoid this extra query
-    // by refactoring contentful.renderAllMessagesForPhoenixCampaign to optionally accept a loaded
+    // by refactoring contentful.renderAllTemplatesForPhoenixCampaign to optionally accept a loaded
     // Contentful campaign.
     .then((contentfulCampaign) => {
       const spaceId = process.env.CONTENTFUL_SPACE_ID;

--- a/app/routes/campaigns.js
+++ b/app/routes/campaigns.js
@@ -38,9 +38,9 @@ function fetchCampaign(id, renderMessages) {
 
         return false;
       })
-      .then((renderedMessages) => {
-        if (renderedMessages) {
-          campaign.messages = renderedMessages;
+      .then((renderedTemplates) => {
+        if (renderedTemplates) {
+          campaign.templates = renderedTemplates;
         }
 
         return contentful.fetchKeywordsForCampaignId(id);

--- a/config/lib/contentful.js
+++ b/config/lib/contentful.js
@@ -10,9 +10,9 @@ module.exports = {
    *  The sequence we define properties here determines the order they appear
    *  in GET Gambit Campaigns API response. Should match the sequence defined
    *  in Contentful, which is based on the order in
-   *  which our end user will see the messages.
+   *  which our end user will see the templates.
    *
-   *  { message_template: 'campaignMessageField'}
+   *  { message_template: 'contentfulCampaignField'}
    */
   campaignFields: {
     menu_signedup_gambit: 'gambitSignupMenuMessage',

--- a/documentation/endpoints/campaigns.md
+++ b/documentation/endpoints/campaigns.md
@@ -108,81 +108,18 @@ curl http://localhost:5000/v1/campaigns/7483 \
     "id": "7483",
     "title": "Rinse, Recycle, Repeat",
     "status": "active",
-    "messages": {
-      "gambitSignupMenuMessage": {
+    "templates": {
+      "gambitSignupMenu": {
         "override": true,
         "raw": "Great - it's simple: Keep beauty and personal care products out of landfills by making fun and creative recycling bins for the bathroom! \n\nThis action should take between 10 - 20 mins. Make it colorful so friends and family won't forget to recycle their bathroom empties. \n\nWhen you're done, text START to share a photo of your bin and you'll be entered to win a $5000 scholarship!",
         "rendered": "Great - it's simple: Keep beauty and personal care products out of landfills by making fun and creative recycling bins for the bathroom! \n\nThis action should take between 10 - 20 mins. Make it colorful so friends and family won't forget to recycle their bathroom empties. \n\nWhen you're done, text START to share a photo of your bin and you'll be entered to win a $5000 scholarship!"
       },
-      "externalSignupMenuMessage": {
+      "externalSignupMenu": {
         "override": true,
         "raw": "Thanks for joining {{title}}!\n\nNearly half of Americans don’t regularly recycle their beauty and personal care products. That’s a major reason these items account for a significant amount of landfill waste.\n\nThe solution is simple: Make fun and creative bins for bathrooms.\n\nOnce you have created some bathroom recycling bins, take a pic to prove it! Then text {{cmd_reportback}} to share it with us!",
         "rendered": "Thanks for joining Rinse Recycle Repeat!\n\nNearly half of Americans don’t regularly recycle their beauty and personal care products. That’s a major reason these items account for a significant amount of landfill waste.\n\nThe solution is simple: Make fun and creative bins for bathrooms.\n\nOnce you have created some bathroom recycling bins, take a pic to prove it! Then text P to share it with us!"
       },
-      "invalidSignupMenuCommandMessage": {
-        "override": false,
-        "raw": "Sorry, I didn't understand that.\n\nText {{cmd_reportback}} when you have {{rb_verb}} some {{rb_noun}}.\n\nIf you have a question, text {{cmd_member_support}}.",
-        "rendered": "Sorry, I didn't understand that.\n\nText P when you have decorated some bins.\n\nIf you have a question, text Q."
-      },
-      "askQuantityMessage": {
-        "override": false,
-        "raw": "Sweet! First, what's the total number of {{rb_noun}} you {{rb_verb}}?\n\nSend the exact number back.",
-        "rendered": "Sweet! First, what's the total number of bins you decorated?\n\nSend the exact number back."
-      },
-      "invalidQuantityMessage": {
-        "override": false,
-        "raw": "Sorry, that's not a valid number.\n\nWhat's the total number of {{rb_noun}} you have {{rb_verb}}?\n\nIf you have a question, text {{cmd_member_support}}.",
-        "rendered": "Sorry, that's not a valid number.\n\nWhat's the total number of bins you have decorated?\n\nIf you have a question, text Q."
-      },
-      "askPhotoMessage": {
-        "override": false,
-        "raw": "Nice! Send your best pic of you and the {{quantity}} {{rb_noun}} you {{rb_verb}}.",
-        "rendered": "Nice! Send your best pic of you and the {{quantity}} bins you decorated."
-      },
-      "invalidPhotoMessage": {
-        "override": false,
-        "raw": "Sorry, I didn't get that.\n\nSend a photo of the {{rb_noun}} you have {{rb_verb}}.\n\nIf you have a question, text {{cmd_member_support}} - I'll get back to you within 24 hours.",
-        "rendered": "Sorry, I didn't get that.\n\nSend a photo of the bins you have decorated.\n\nIf you have a question, text Q - I'll get back to you within 24 hours."
-      },
-      "askCaptionMessage": {
-        "override": false,
-        "raw": "Got it! Now text back a caption for your photo (think Instagram)! Keep it short & sweet, under 60 characters please.",
-        "rendered": "Got it! Now text back a caption for your photo (think Instagram)! Keep it short & sweet, under 60 characters please."
-      },
-      "askWhyParticipatedMessage": {
-        "override": false,
-        "raw": "Last question: Why was participating in {{title}} important to you? (No need to write an essay, one sentence is good).",
-        "rendered": "Last question: Why was participating in Rinse, Recycle, Repeat important to you? (No need to write an essay, one sentence is good)."
-      },
-      "completedMenuMessage": {
-        "override": false,
-        "raw": "{{rb_confirmation_msg}}\n\nWe've got you down for {{quantity}} {{rb_noun}} {{rb_verb}}.\n\nHave you {{rb_verb}} more? Text {{cmd_reportback}}",
-        "rendered": "Thanks for helping to keep #empties out of landfills! You'll receive an email shortly with a free shipping label so you can send your empties to TerraCycle be upcycled.\n\nWe've got you down for {{quantity}} bins decorated.\n\nHave you decorated more? Text P"
-      },
-      "invalidCompletedMenuCommandMessage": {
-        "override": false,
-        "raw": "Sorry, I didn't understand that.\n\nText {{cmd_reportback}} if you have {{rb_verb}} more {{rb_noun}}.\n\nIf you have a question, text {{cmd_member_support}}.",
-        "rendered": "Sorry, I didn't understand that.\n\nText P if you have decorated more bins.\n\nIf you have a question, text Q."
-      },
-      "scheduledRelativeToSignupDateMessage": {
-        "override": true,
-        "raw": "Hey it's Freddie again! Have you had a chance to create a recycling bin?\n\nShare what you've done with other DoSomething members. Text back RINSE!",
-        "rendered": "Hey it's Freddie again! Have you had a chance to create a recycling bin?\n\nShare what you've done with other DoSomething members. Text back RINSE!"
-      },
-      "scheduledRelativeToReportbackDateMessage": {
-        "override": false,
-        "rendered": ""
-      },
-      "memberSupportMessage": {
-        "override": false,
-        "raw": "Text back your question and I'll try to get back to you within 24 hrs.\n\nIf you want to continue {{title}}, text back {{keyword}}",
-        "rendered": "Text back your question and I'll try to get back to you within 24 hrs.\n\nIf you want to continue Rinse, Recycle, Repeat, text back RINSEBOT"
-      },
-      "campaignClosedMessage": {
-        "override": false,
-        "raw": "Sorry, {{title}} is no longer available.\n\nText {{cmd_member_support}} for help.",
-        "rendered": "Sorry, Rinse, Recycle, Repeat is no longer available.\n\nText Q for help."
-      }
+      ...
     },
     "keywords": [
       {

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -249,8 +249,8 @@ module.exports.getAllTemplatesForCampaignId = function getAllTemplatesForCampaig
 /**
  * Returns all rendered messages for given phoenixCampaign, using defaults when no override defined.
  */
-module.exports.renderAllMessagesForPhoenixCampaign = function (phoenixCampaign) {
-  logger.debug(`renderAllMessagesForPhoenixCampaign:${phoenixCampaign.id}`);
+module.exports.renderAllTemplatesForPhoenixCampaign = function (phoenixCampaign) {
+  logger.debug(`renderAllTemplatesForPhoenixCampaign:${phoenixCampaign.id}`);
   return new Promise((resolve, reject) =>
     // get all fields, overrides and default
     exports.getAllTemplatesForCampaignId(phoenixCampaign.id)

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -208,31 +208,39 @@ module.exports.renderMessageForPhoenixCampaign = function (phoenixCampaign, msgT
  * @param  {type} campaignId
  * @return {Promise}
  */
-module.exports.getAllFieldsForCampaign = function getAllFieldsForCampaign(campaignId) {
+module.exports.getAllTemplatesForCampaignId = function getAllTemplatesForCampaignId(campaignId) {
   return new Promise((resolve, reject) => {
     const campaignFieldNames = Object.keys(config.campaignFields);
     const campaignContent = {};
-    const campaignFields = {};
+    const templates = {};
     return exports.fetchCampaign(campaignId)
       .then((contentfulCampaign) => {
         campaignContent.overrides = contentfulCampaign.fields;
+        // TODO: Pass the default Campaign, to avoid fetching every time we call this.
+        // GET campaigns could fetch default once, instead of every time we get each Campaign.
         return exports.fetchCampaign(defaultCampaignId);
       })
       .then((defaultContentfulCampaign) => {
         campaignContent.defaults = defaultContentfulCampaign.fields;
         campaignFieldNames.forEach((key) => {
           const fieldName = config.campaignFields[key];
-          campaignFields[fieldName] = {};
+          // This is a hack to avoid migrating our Contentful data in order to rename our fields.
+          // We want to return template values as 'askQuantity', not 'askQuantityMessage'.
+          const templateName = fieldName.split('Message')[0];
+          if (!templateName) {
+            return;
+          }
+          templates[templateName] = {};
 
-          if (campaignContent.overrides[fieldName]) {
-            campaignFields[fieldName].override = true;
-            campaignFields[fieldName].raw = campaignContent.overrides[fieldName];
+          if (campaignContent.overrides[templateName]) {
+            templates[templateName].override = true;
+            templates[templateName].raw = campaignContent.overrides[fieldName];
           } else {
-            campaignFields[fieldName].override = false;
-            campaignFields[fieldName].raw = campaignContent.defaults[fieldName];
+            templates[templateName].override = false;
+            templates[templateName].raw = campaignContent.defaults[fieldName];
           }
         });
-        return resolve(campaignFields);
+        return resolve(templates);
       })
       .catch(err => reject(err));
   });
@@ -245,7 +253,7 @@ module.exports.renderAllMessagesForPhoenixCampaign = function (phoenixCampaign) 
   logger.debug(`renderAllMessagesForPhoenixCampaign:${phoenixCampaign.id}`);
   return new Promise((resolve, reject) =>
     // get all fields, overrides and default
-    exports.getAllFieldsForCampaign(phoenixCampaign.id)
+    exports.getAllTemplatesForCampaignId(phoenixCampaign.id)
       .then(campaignFields => Promise.map(
           /**
            * Iterator

--- a/test/lib/contentful.test.js
+++ b/test/lib/contentful.test.js
@@ -37,7 +37,7 @@ const campaignStub = Promise.resolve(stubs.contentful.getEntries('campaign'));
 const defaultCampaignStub = Promise.resolve(stubs.contentful.getEntries('default-campaign'));
 const campaignWithOverridesStub = Promise.resolve(stubs.contentful.getEntries('campaign-with-overrides'));
 const keywordsForCampaignStub = Promise.resolve(stubs.contentful.getEntries('keyword-for-campaign'));
-const getAllFieldsForCampaignStub = Promise.resolve(stubs.contentful.getAllFieldsForCampaign());
+const getAllTemplatesForCampaignIdStub = Promise.resolve(stubs.contentful.getAllTemplatesForCampaignId());
 const failStub = Promise.reject({ status: 500 });
 const contentfulAPIStub = {
   getEntries: () => {},
@@ -346,8 +346,8 @@ async () => {
   contentful.fetchMessageForCampaignId.should.have.been.calledOnce;
 });
 
-// getAllFieldsForCampaign
-test('getAllFieldsForCampaign should return fields with raw and override properties', async () => {
+// getAllTemplatesForCampaignId
+test('getAllTemplatesForCampaignId should return fields with raw and override properties', async () => {
   // setup
   sandbox.spy(contentful, 'fetchCampaign');
   const stub = sinon.stub();
@@ -360,20 +360,20 @@ test('getAllFieldsForCampaign should return fields with raw and override propert
   });
 
   // test
-  const fields = await contentful.getAllFieldsForCampaign(stubs.getCampaignId());
+  const fields = await contentful.getAllTemplatesForCampaignId(stubs.getCampaignId());
   contentful.fetchCampaign.should.have.been.calledTwice;
   Object.keys(fields).forEach((fieldName) => {
     fields[fieldName].should.include.keys(['raw', 'override']);
   });
 });
 
-test('getAllFieldsForCampaign should throw when fetchCampaign fails', async () => {
+test('getAllTemplatesForCampaignId should throw when fetchCampaign fails', async () => {
   // setup
   sandbox.stub(contentful, 'fetchCampaign').returns(failStub);
 
   // test
   try {
-    await contentful.getAllFieldsForCampaign(stubs.getCampaignId());
+    await contentful.getAllTemplatesForCampaignId(stubs.getCampaignId());
   } catch (error) {
     error.status.should.be.equal(500);
   }
@@ -383,7 +383,7 @@ test('getAllFieldsForCampaign should throw when fetchCampaign fails', async () =
 test('renderAllMessagesForPhoenixCampaign should inject a rendered property to each campaign field', async () => {
   // setup
   const renderedMessageStub = 'rendered!';
-  sandbox.stub(contentful, 'getAllFieldsForCampaign').returns(getAllFieldsForCampaignStub);
+  sandbox.stub(contentful, 'getAllTemplatesForCampaignId').returns(getAllTemplatesForCampaignIdStub);
   sandbox.stub(helpers, 'replacePhoenixCampaignVars').returns(Promise.resolve(renderedMessageStub));
 
   // test
@@ -393,9 +393,9 @@ test('renderAllMessagesForPhoenixCampaign should inject a rendered property to e
   });
 });
 
-test('renderAllMessagesForPhoenixCampaign should return and error if getAllFieldsForCampaign fails', async () => {
+test('renderAllMessagesForPhoenixCampaign should return and error if getAllTemplatesForCampaignId fails', async () => {
   // setup
-  sandbox.stub(contentful, 'getAllFieldsForCampaign').returns(failStub);
+  sandbox.stub(contentful, 'getAllTemplatesForCampaignId').returns(failStub);
 
   // test
   try {

--- a/test/lib/contentful.test.js
+++ b/test/lib/contentful.test.js
@@ -37,7 +37,7 @@ const campaignStub = Promise.resolve(stubs.contentful.getEntries('campaign'));
 const defaultCampaignStub = Promise.resolve(stubs.contentful.getEntries('default-campaign'));
 const campaignWithOverridesStub = Promise.resolve(stubs.contentful.getEntries('campaign-with-overrides'));
 const keywordsForCampaignStub = Promise.resolve(stubs.contentful.getEntries('keyword-for-campaign'));
-const getAllTemplatesForCampaignIdStub = Promise.resolve(stubs.contentful.getAllTemplatesForCampaignId());
+const templatesForCampaignIdStub = Promise.resolve(stubs.contentful.getAllTemplatesForCampaignId());
 const failStub = Promise.reject({ status: 500 });
 const contentfulAPIStub = {
   getEntries: () => {},
@@ -379,27 +379,27 @@ test('getAllTemplatesForCampaignId should throw when fetchCampaign fails', async
   }
 });
 
-// renderAllMessagesForPhoenixCampaign
-test('renderAllMessagesForPhoenixCampaign should inject a rendered property to each campaign field', async () => {
+// renderAllTemplatesForPhoenixCampaign
+test('renderAllTemplatesForPhoenixCampaign should inject a rendered property to each campaign field', async () => {
   // setup
   const renderedMessageStub = 'rendered!';
-  sandbox.stub(contentful, 'getAllTemplatesForCampaignId').returns(getAllTemplatesForCampaignIdStub);
+  sandbox.stub(contentful, 'getAllTemplatesForCampaignId').returns(templatesForCampaignIdStub);
   sandbox.stub(helpers, 'replacePhoenixCampaignVars').returns(Promise.resolve(renderedMessageStub));
 
   // test
-  const fields = await contentful.renderAllMessagesForPhoenixCampaign(stubs.getPhoenixCampaign());
+  const fields = await contentful.renderAllTemplatesForPhoenixCampaign(stubs.getPhoenixCampaign());
   Object.keys(fields).forEach((fieldName) => {
     fields[fieldName].rendered.should.be.equal(renderedMessageStub);
   });
 });
 
-test('renderAllMessagesForPhoenixCampaign should return and error if getAllTemplatesForCampaignId fails', async () => {
+test('renderAllTemplatesForPhoenixCampaign should return and error if getAllTemplatesForCampaignId fails', async () => {
   // setup
   sandbox.stub(contentful, 'getAllTemplatesForCampaignId').returns(failStub);
 
   // test
   try {
-    await contentful.renderAllMessagesForPhoenixCampaign(stubs.getPhoenixCampaign());
+    await contentful.renderAllTemplatesForPhoenixCampaign(stubs.getPhoenixCampaign());
   } catch (error) {
     error.status.should.be.equal(500);
   }

--- a/test/utils/stubs.js
+++ b/test/utils/stubs.js
@@ -231,7 +231,7 @@ module.exports = {
   },
   contentful: {
 
-    getAllFieldsForCampaign: function getAllFieldsForCampaign() {
+    getAllTemplatesForCampaignId: function getAllTemplatesForCampaignId() {
       return module.exports.getJSONstub('all-campaign-fields');
     },
 


### PR DESCRIPTION
#### What's this PR do?
* Renames the `data.messages` property as `data.templates`
* Removes the `Message` suffix from the values returned, to improve data readability 

#### How should this be reviewed?
* Verify `GET /campaigns/:id` returns `data.templates` without a `Message` suffix
* Sanity check that `POST /chatbot` conversations work as expected

#### Any background context you want to provide?
Not renaming the single `renderMessage` functions yet. Ideally we should avoid querying Contentful for each request and re-introduce caching Campaigns to this app to improve performance and fail-proofing.

This will break 2 things that will be quick to change, with PR's coming soon:
* [ ] Gambit Conversations sync process
* [ ] Gambit Slackbot "View messages" response

#### Relevant tickets
* Fixes https://github.com/DoSomething/gambit-conversations/pull/99#issuecomment-327223167
* https://github.com/DoSomething/gambit-conversations/issues/49

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
