### PR TITLE
Rename contentful config.campaignFields properties

### DIFF
--- a/config/lib/contentful.js
+++ b/config/lib/contentful.js
@@ -12,30 +12,32 @@ module.exports = {
    *  in Contentful, which is based on the order in
    *  which our end user will see the templates.
    *
-   *  { message_template: 'contentfulCampaignField'}
+   *  { templateName: 'contentfulCampaignFieldName'}
    */
   campaignFields: {
-    menu_signedup_gambit: 'gambitSignupMenuMessage',
-    menu_signedup_external: 'externalSignupMenuMessage',
-    invalid_cmd_signedup: 'invalidSignupMenuCommandMessage',
-    ask_quantity: 'askQuantityMessage',
-    invalid_quantity: 'invalidQuantityMessage',
-    ask_photo: 'askPhotoMessage',
-    no_photo_sent: 'invalidPhotoMessage',
-    ask_caption: 'askCaptionMessage',
-    ask_why_participated: 'askWhyParticipatedMessage',
-    menu_completed: 'completedMenuMessage',
-    invalid_cmd_completed: 'invalidCompletedMenuCommandMessage',
+    gambitSignupMenu: 'gambitSignupMenuMessage',
+    externalSignupMenu: 'externalSignupMenuMessage',
+    invalidSignupMenuCommand: 'invalidSignupMenuCommandMessage',
+    askQuantity: 'askQuantityMessage',
+    invalidQuantity: 'invalidQuantityMessage',
+    askPhoto: 'askPhotoMessage',
+    invalidPhoto: 'invalidPhotoMessage',
+    askCaption: 'askCaptionMessage',
+    askWhyParticipated: 'askWhyParticipatedMessage',
+    completedMenu: 'completedMenuMessage',
+    invalidCompletedMenuCommand: 'invalidCompletedMenuCommandMessage',
+    memberSupport: 'memberSupportMessage',
+    campaignClosed: 'campaignClosedMessage',
+    errorOccurred: 'errorOccurredMessage',
+    askSignup: 'askSignupMessage',
+    declinedSignup: 'declinedSignupMessage',
+    invalidAskSignupResponse: 'invalidSignupResponseMessage',
+    askContinue: 'askContinueMessage',
+    declinedContinue: 'declinedContinueMessage',
+    invalidAskContinueResponse: 'invalidContinueResponseMessage',
+    // TODO: Remove these when Conversations goes live.
+    // They won't be used anymore, so we didn't bother to rename these.
     scheduled_relative_to_signup_date: 'scheduledRelativeToSignupDateMessage',
     scheduled_relative_to_reportback_date: 'scheduledRelativeToReportbackDateMessage',
-    member_support: 'memberSupportMessage',
-    campaign_closed: 'campaignClosedMessage',
-    error_occurred: 'errorOccurredMessage',
-    ask_signup: 'askSignupMessage',
-    declined_signup: 'declinedSignupMessage',
-    invalid_ask_signup: 'invalidSignupResponseMessage',
-    ask_continue: 'askContinueMessage',
-    declined_continue: 'declinedContinueMessage',
-    invalid_ask_continue: 'invalidContinueResponseMessage',
   },
 };

--- a/documentation/endpoints/chatbot.md
+++ b/documentation/endpoints/chatbot.md
@@ -46,7 +46,7 @@ curl -X "POST" "http://localhost:5000/v1/chatbot" \
   "success": {
     "code": 200,
     "message": "Picking up where you left off on Bumble Bands...\n\nSend your best pic of you and the 33 bumble bands you created.",
-    "template": "askPhotoMessage"
+    "template": "askPhoto"
   }
 }
 ```

--- a/documentation/endpoints/receive-message.md
+++ b/documentation/endpoints/receive-message.md
@@ -45,7 +45,7 @@ curl -X "POST" "http://localhost:5000/v1/chatbot" \
   "success": {
     "code": 200,
     "message": "Nice job! YOU deserve a Mirror Message for all the notes you posted. We've got you down for 97 messages posted. Have you posted more? Text START.",
-    "template": "completedMenuMessage"
+    "template": "completedMenu"
   }
 }
 ```

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -222,14 +222,8 @@ module.exports.getAllTemplatesForCampaignId = function getAllTemplatesForCampaig
       })
       .then((defaultContentfulCampaign) => {
         campaignContent.defaults = defaultContentfulCampaign.fields;
-        campaignFieldNames.forEach((key) => {
-          const fieldName = config.campaignFields[key];
-          // This is a hack to avoid migrating our Contentful data in order to rename our fields.
-          // We want to return template values as 'askQuantity', not 'askQuantityMessage'.
-          const templateName = fieldName.split('Message')[0];
-          if (!templateName) {
-            return;
-          }
+        campaignFieldNames.forEach((templateName) => {
+          const fieldName = config.campaignFields[templateName];
           templates[templateName] = {};
 
           if (campaignContent.overrides[templateName]) {

--- a/lib/conversation/replies.js
+++ b/lib/conversation/replies.js
@@ -116,7 +116,7 @@ function renderContinueConversationMsg(fn) {
 
  /**
   * Continues conversation with user.
-  * It responds with a rendered ask_quantity message
+  * It responds with a rendered askQuantity message
   *
   * @param  {object} args
   * @return {Command}
@@ -124,12 +124,12 @@ function renderContinueConversationMsg(fn) {
 module.exports.askQuantity = function askQuantity(args) {
   return new Command(
     renderContinueConversationMsg(actions.continueConversation),
-    ['ask_quantity', args]);
+    ['askQuantity', args]);
 };
 
 /**
  * Continues conversation with user.
- * It responds with a rendered invalid_quantity message
+ * It responds with a rendered invalidQuantity message
  *
  * @param  {object} args
  * @return {Command}
@@ -137,12 +137,12 @@ module.exports.askQuantity = function askQuantity(args) {
 module.exports.invalidQuantity = function invalidQuantity(args) {
   return new Command(
     renderContinueConversationMsg(actions.continueConversation),
-    ['invalid_quantity', args]);
+    ['invalidQuantity', args]);
 };
 
 /**
  * Continues conversation with user.
- * It responds with a rendered ask_caption message
+ * It responds with a rendered askCaption message
  *
  * @param  {object} args
  * @return {Command}
@@ -150,12 +150,12 @@ module.exports.invalidQuantity = function invalidQuantity(args) {
 module.exports.askCaption = function askCaption(args) {
   return new Command(
     renderContinueConversationMsg(actions.continueConversation),
-    ['ask_caption', args]);
+    ['askCaption', args]);
 };
 
 /**
  * Continues conversation with user.
- * It responds with a rendered invalid_caption message
+ * It responds with a rendered invalidCaption message
  *
  * @param  {object} args
  * @return {Command}
@@ -163,12 +163,12 @@ module.exports.askCaption = function askCaption(args) {
 module.exports.invalidCaption = function invalidCaption(args) {
   return new Command(
     renderContinueConversationMsg(actions.continueConversation),
-    ['invalid_caption', args]);
+    ['invalidCaption', args]);
 };
 
 /**
  * Continues conversation with user.
- * It responds with a rendered ask_why_participated message
+ * It responds with a rendered askWhyParticipated message
  *
  * @param  {object} args
  * @return {Command}
@@ -176,7 +176,7 @@ module.exports.invalidCaption = function invalidCaption(args) {
 module.exports.askWhyParticipated = function askWhyParticipated(args) {
   return new Command(
     renderContinueConversationMsg(actions.continueConversation),
-    ['ask_why_participated', args]);
+    ['askWhyParticipated', args]);
 };
 
 /**
@@ -189,12 +189,12 @@ module.exports.askWhyParticipated = function askWhyParticipated(args) {
 module.exports.invalidWhyParticipated = function invalidWhyParticipated(args) {
   return new Command(
     renderContinueConversationMsg(actions.continueConversation),
-    ['invalid_why_participated', args]);
+    ['invalidWhyParticipated', args]);
 };
 
 /**
  * Continues conversation with user.
- * It responds with a rendered menu_completed message
+ * It responds with a rendered completedMenu message
  *
  * @param  {object} args
  * @return {Command}
@@ -202,12 +202,12 @@ module.exports.invalidWhyParticipated = function invalidWhyParticipated(args) {
 module.exports.menuCompleted = function menuCompleted(args) {
   return new Command(
     renderContinueConversationMsg(actions.continueConversation),
-    ['menu_completed', args]);
+    ['completedMenu', args]);
 };
 
 /**
  * Continues conversation with user.
- * It responds with a rendered invalid_cmd_completed message
+ * It responds with a rendered invalidCompletedMenuCommand message
  *
  * @param  {object} args
  * @return {Command}
@@ -215,12 +215,12 @@ module.exports.menuCompleted = function menuCompleted(args) {
 module.exports.invalidCmdCompleted = function invalidCmdCompleted(args) {
   return new Command(
     renderContinueConversationMsg(actions.continueConversation),
-    ['invalid_cmd_completed', args]);
+    ['invalidCompletedMenuCommand', args]);
 };
 
 /**
  * Continues conversation with user.
- * It responds with a rendered menu_signedup_gambit message
+ * It responds with a rendered gambitSignupMenu message
  *
  * @param  {object} args
  * @return {Command}
@@ -228,12 +228,12 @@ module.exports.invalidCmdCompleted = function invalidCmdCompleted(args) {
 module.exports.menuSignedUp = function menuSignedUp(args) {
   return new Command(
     renderContinueConversationMsg(actions.continueConversation),
-    ['menu_signedup_gambit', args]);
+    ['gambitSignupMenu', args]);
 };
 
 /**
  * Continues conversation with user.
- * It responds with a rendered menu_signedup_external message
+ * It responds with a rendered externalSignupMenu message
  *
  * @param  {object} args
  * @return {Command}
@@ -241,12 +241,12 @@ module.exports.menuSignedUp = function menuSignedUp(args) {
 module.exports.externalSignupMenu = function externalSignupMenu(args) {
   return new Command(
     renderContinueConversationMsg(actions.continueConversation),
-    ['menu_signedup_external', args]);
+    ['externalSignupMenu', args]);
 };
 
 /**
  * Continues conversation with user.
- * It responds with a rendered invalid_cmd_signedup message
+ * It responds with a rendered invalidSignupMenuCommand message
  *
  * @param  {object} args
  * @return {Command}
@@ -254,12 +254,12 @@ module.exports.externalSignupMenu = function externalSignupMenu(args) {
 module.exports.invalidCmdSignedup = function invalidCmdSignedup(args) {
   return new Command(
     renderContinueConversationMsg(actions.continueConversation),
-    ['invalid_cmd_signedup', args]);
+    ['invalidSignupMenuCommand', args]);
 };
 
 /**
  * Continues conversation with user.
- * It responds with a rendered ask_photo message
+ * It responds with a rendered askPhoto message
  *
  * @param  {object} args
  * @return {Command}
@@ -267,12 +267,12 @@ module.exports.invalidCmdSignedup = function invalidCmdSignedup(args) {
 module.exports.askPhoto = function askPhoto(args) {
   return new Command(
     renderContinueConversationMsg(actions.continueConversation),
-    ['ask_photo', args]);
+    ['askPhoto', args]);
 };
 
 /**
  * Continues conversation with user.
- * It responds with a rendered no_photo_sent message
+ * It responds with a rendered invalidPhoto message
  *
  * @param  {object} args
  * @return {Command}
@@ -280,12 +280,12 @@ module.exports.askPhoto = function askPhoto(args) {
 module.exports.noPhotoSent = function noPhotoSent(args) {
   return new Command(
     renderContinueConversationMsg(actions.continueConversation),
-    ['no_photo_sent', args]);
+    ['invalidPhoto', args]);
 };
 
 /**
  * Ends conversation with user.
- * It responds with a rendered campaign_closed message
+ * It responds with a rendered campaignClosed message
  *
  * @param  {object} args
  * @return {Command}
@@ -293,12 +293,12 @@ module.exports.noPhotoSent = function noPhotoSent(args) {
 module.exports.campaignClosed = function campaignClosed(args) {
   return new Command(
     renderEndConversationMsg(actions.endConversation),
-    ['campaign_closed', args]);
+    ['campaignClosed', args]);
 };
 
 /**
  * Ends conversation with user.
- * It responds with a rendered member_support message
+ * It responds with a rendered memberSupport message
  *
  * @param  {object} args
  * @return {Command}
@@ -306,13 +306,13 @@ module.exports.campaignClosed = function campaignClosed(args) {
 module.exports.memberSupport = function memberSupport(args) {
   return new Command(
     renderEndConversationMsg(actions.endConversation),
-    ['member_support', args]);
+    ['memberSupport', args]);
 };
 
 
 /**
  * Ends conversation with user.
- * It responds with a rendered error_occurred message
+ * It responds with a rendered errorOccurred message
  *
  * @param  {object} args
  * @return {Command}
@@ -320,7 +320,7 @@ module.exports.memberSupport = function memberSupport(args) {
 module.exports.legacyBugErrorOcurred = function legacyBugErrorOcurred(args) {
   return new Command(
     renderEndConversationWithErrorMsg(actions.endConversation),
-    ['error_occurred', args]);
+    ['errorOccurred', args]);
 };
 
 /**

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -36,11 +36,11 @@ module.exports.renderMessageTemplate = function renderMessageTemplate(req, messa
   // Check if we're replying to inform user they've submitted invalid values for text fields.
   // If they did, ask for field again, setting messagePrefix to prepend to the rendered ask message.
   const invalidTextSentMessage = 'Sorry, I didn\'t understand that.\n\n';
-  if (template === 'invalid_caption') {
-    template = 'ask_caption';
+  if (template === 'invalidCaption') {
+    template = 'askCaption';
     messagePrefix = invalidTextSentMessage;
-  } else if (template === 'invalid_why_participated') {
-    template = 'ask_why_participated';
+  } else if (template === 'invalidWhyParticipated') {
+    template = 'askWhyParticipated';
     messagePrefix = invalidTextSentMessage;
   }
 
@@ -259,10 +259,9 @@ module.exports.sendResponse = function (res, code, messageText, messageTemplate)
     message: messageText,
   };
   if (messageTemplate) {
-    const fieldName = contentful.getFieldNameForCampaignMessageTemplate(messageTemplate);
-    // Gambit Conversations stores Message.template by the fieldName, not our machine_name style.
-    response[type].template = fieldName;
+    response[type].template = messageTemplate;
   }
+  logger.verbose(response);
 
   return res.status(code).send(response);
 };

--- a/test/lib/contentful.test.js
+++ b/test/lib/contentful.test.js
@@ -243,7 +243,7 @@ async () => {
 
   // test
   // TODO: Find a way to not hard code the message type here
-  const message = await contentful.fetchMessageForCampaignId(stubs.getCampaignId(), 'menu_signedup_gambit');
+  const message = await contentful.fetchMessageForCampaignId(stubs.getCampaignId(), 'gambitSignupMenu');
   expect(message).to.be.undefined;
 });
 
@@ -261,7 +261,7 @@ test('fetchMessageForCampaignId should return null when no campaign is returned 
 
   // test
   // TODO: Find a way to not hard code the message type here
-  const message = await contentful.fetchMessageForCampaignId(stubs.getCampaignId(), 'menu_signedup_gambit');
+  const message = await contentful.fetchMessageForCampaignId(stubs.getCampaignId(), 'gambitSignupMenu');
   expect(message).to.be.null;
 });
 
@@ -272,7 +272,7 @@ test('fetchMessageForCampaignId should return error when it fails', async () => 
 
   // test
   // TODO: Find a way to not hard code the message type here
-  const error = await contentful.fetchMessageForCampaignId(stubs.getCampaignId(), 'menu_signedup_gambit');
+  const error = await contentful.fetchMessageForCampaignId(stubs.getCampaignId(), 'gambitSignupMenu');
   error.status.should.be.equal(500);
 });
 
@@ -285,7 +285,7 @@ test('renderMessageForPhoenixCampaign should return rendered override message', 
     getEntries: sinon.stub().returns(campaignWithOverridesStub),
   });
   // test
-  const msg = await contentful.renderMessageForPhoenixCampaign(campaign, 'menu_signedup_gambit');
+  const msg = await contentful.renderMessageForPhoenixCampaign(campaign, 'gambitSignupMenu');
   contentful.fetchMessageForCampaignId.should.have.been.calledOnce;
   msg.should.not.be.empty;
 });
@@ -304,7 +304,7 @@ test('renderMessageForPhoenixCampaign should return default message if there is 
     getEntries: stub,
   });
   // test
-  const msg = await contentful.renderMessageForPhoenixCampaign(campaign, 'menu_signedup_gambit');
+  const msg = await contentful.renderMessageForPhoenixCampaign(campaign, 'gambitSignupMenu');
   contentful.fetchMessageForCampaignId.should.have.been.calledTwice;
   helpers.replacePhoenixCampaignVars.should.have.been.calledOnce;
   msg.should.not.be.empty;
@@ -339,7 +339,7 @@ async () => {
   sandbox.stub(contentful, 'fetchMessageForCampaignId').returns(failStub);
   // test
   try {
-    await contentful.renderMessageForPhoenixCampaign(campaign, 'menu_signedup_gambit');
+    await contentful.renderMessageForPhoenixCampaign(campaign, 'gambitSignupMenu');
   } catch (error) {
     error.status.should.be.equal(500);
   }

--- a/test/lib/helpers.test.js
+++ b/test/lib/helpers.test.js
@@ -93,12 +93,12 @@ test('replacePhoenixCampaignVars', async () => {
   const phoenixCampaign = stubs.getPhoenixCampaign();
   let renderedMessage = '';
   // signedup through gambit
-  const signedupGambitMsg = stubs.getDefaultContenfulCampaignMessage('menu_signedup_gambit');
+  const signedupGambitMsg = stubs.getDefaultContenfulCampaignMessage('gambitSignupMenu');
   renderedMessage = await helpers
     .replacePhoenixCampaignVars(signedupGambitMsg, phoenixCampaign);
   renderedMessage.should.have.string(phoenixCampaign.facts.problem);
   // invalid sign up command
-  const invalidSignedupCmdMsg = stubs.getDefaultContenfulCampaignMessage('invalid_cmd_signedup');
+  const invalidSignedupCmdMsg = stubs.getDefaultContenfulCampaignMessage('invalidSignupMenuCommand');
   renderedMessage = await helpers
   .replacePhoenixCampaignVars(invalidSignedupCmdMsg, phoenixCampaign);
   renderedMessage.should.have.string('Sorry, I didn\'t understand that.');
@@ -122,7 +122,7 @@ test('replacePhoenixCampaignVars failure to retrieve keywords should throw', asy
   const phoenixCampaign = stubs.getPhoenixCampaign();
   // will trigger fetchKeywordsForCampaignIdStubFail stub
   phoenixCampaign.id = 'fail';
-  const memberSupportMsg = stubs.getDefaultContenfulCampaignMessage('member_support');
+  const memberSupportMsg = stubs.getDefaultContenfulCampaignMessage('memberSupport');
 
   await t.throws(helpers.replacePhoenixCampaignVars(memberSupportMsg, phoenixCampaign));
   contentful.fetchKeywordsForCampaignId.should.have.been.called;
@@ -138,7 +138,7 @@ test('replacePhoenixCampaignVars with no message should return empty string', as
 test('replacePhoenixCampaignVars on a campaign object missing reportbackInfo should throw', async (t) => {
   const phoenixCampaign = stubs.getPhoenixCampaign();
   delete phoenixCampaign.reportbackInfo;
-  const memberSupportMsg = stubs.getDefaultContenfulCampaignMessage('menu_signedup_gambit');
+  const memberSupportMsg = stubs.getDefaultContenfulCampaignMessage('gambitSignupMenu');
   await t.throws(helpers.replacePhoenixCampaignVars(memberSupportMsg, phoenixCampaign));
 });
 

--- a/test/utils/stubs.js
+++ b/test/utils/stubs.js
@@ -171,28 +171,28 @@ module.exports = {
   getDefaultContenfulCampaignMessage: function getContenfulCampaignMessage(type) {
     let msg = '';
     switch (type) {
-      case 'menu_signedup_gambit':
+      case 'gambitSignupMenu':
         msg = 'Thanks for joining {{title}}! {{fact_problem}} The solution is simple: {{tagline}} Once you have {{rb_verb}} some {{rb_noun}}, take a pic to prove it! Then text {{cmd_reportback}} to share it with us!';
         break;
-      case 'menu_signedup_external':
+      case 'externalSignupMenu':
         msg = 'Hey - this is Freddie from DoSomething. Thanks for joining {{title}}! {{fact_problem}} The solution is simple: {{tagline}} Make sure to take a photo of what you did! When you have {{rb_verb}} some {{rb_noun}}, text {{cmd_reportback}} to share your photo.';
         break;
-      case 'invalid_cmd_signedup':
+      case 'invalidSignupMenuCommand':
         msg = 'Sorry, I didn\'t understand that. Text {{cmd_reportback}} when you have {{rb_verb}} some {{rb_noun}}. If you have a question, text {{cmd_member_support}}.';
         break;
-      case 'member_support':
+      case 'memberSupport':
         msg = 'Text back your question and I\'ll try to get back to you within 24 hrs. If you want to continue {{title}}, text back {{keyword}}';
         break;
-      case 'menu_completed':
+      case 'completedMenu':
         msg = '{{rb_confirmation_msg}} We\'ve got you down for {{quantity}} {{rb_noun}} {{rb_verb}}. Have you {{rb_verb}} more? Text {{cmd_reportback}}';
         break;
-      case 'invalid_cmd_completed':
+      case 'invalidCompletedMenuCommand':
         msg = 'Sorry, I didn\'t understand that. Text {{cmd_reportback}} if you have {{rb_verb}} more {{rb_noun}}. If you have a question, text {{cmd_member_support}}.';
         break;
-      case 'ask_why_participated':
+      case 'askWhyParticipated':
         msg = 'Why was participating in {{title}} important to you? (No need to write an essay, one sentence is good).';
         break;
-      // When the user sends invalid why participated , why just ask_why_participated again
+      // When the user sends invalid why participated , why just askWhyParticipated again
       // case 'invalid_why_participated':
       //   msg = '';
       //   break;
@@ -202,26 +202,26 @@ module.exports = {
       case 'scheduled_relative_to_reportback_date':
         msg = '';
         break;
-      case 'ask_caption':
+      case 'askCaption':
         msg = 'Got it! Now text back a caption for your photo (think Instagram)! Keep it short & sweet, under 60 characters please.';
         break;
-      // When the user sends invalid cation, we just ask_caption again
+      // When the user sends invalid cation, we just askCaption again
       // case 'invalid_caption':
       //   msg = '';
       //   break;
-      case 'ask_photo':
+      case 'askPhoto':
         msg = 'Nice! Send your best pic of you and the {{quantity}} {{rb_noun}} you {{rb_verb}}.';
         break;
-      case 'no_photo_sent':
+      case 'invalidPhoto':
         msg = 'Sorry, I didn\'t get that. Send a photo of the {{rb_noun}} you have {{rb_verb}}. If you have a question, text {{cmd_member_support}} - I\'ll get back to you within 24 hours.';
         break;
-      case 'ask_quantity':
+      case 'askQuantity':
         msg = 'Sweet! First, what\'s the total number of {{rb_noun}} you {{rb_verb}}? Send the exact number back.';
         break;
-      case 'invalid_quantity':
+      case 'invalidQuantity':
         msg = 'What\'s the total number of {{rb_noun}} you have {{rb_verb}}? If you have a question, text {{cmd_member_support}}.';
         break;
-      case 'campaign_closed':
+      case 'campaignClosed':
         msg = 'Sorry, {{title}} is no longer available. Text {{cmd_member_support}} for help.';
         break;
       default:


### PR DESCRIPTION
#### What's this PR do?
* Renames the properties of `config.campaignFields` to return expected values in Gambit Conversations (https://github.com/dosomething/gambit-conversations/issues/49, https://github.com/DoSomething/gambit-conversations/pull/100/)

* Makes corresponding changes for values passed in `lib/conversation/replies` 

#### How should this be reviewed?
* GET /campaigns/:id
* Chatbot conversation

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Tested on staging.
