### PR TITLE
Pin Northstar JS dependency to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "node": "6.11.1"
   },
   "dependencies": {
-    "@dosomething/northstar-js": "git://github.com/DoSomething/northstar-js.git",
+    "@dosomething/northstar-js": "1.0.0",
     "@dosomething/phoenix-js": "git://github.com/DoSomething/phoenix-js.git",
     "aws-sdk": "2.36.0",
     "bluebird": "^3.4.6",


### PR DESCRIPTION
#### What's this PR do?
Edits `package.json` to pin Northstar version instead of pulling the latest `master`. 

#### Any background context you want to provide?
In [Northstar JS](https://github.com/DoSomething/northstar-js), I'm debating on whether it's worth casting the Northstar API response into an [object with `camelCase` properties](https://github.com/DoSomething/northstar-js/blob/1.0.0/lib/northstar-user.js), vs just returning the raw API response. If we go that route (or any other potential code-breaking routes), pinning the release prevents breakage.

#### Relevant tickets
* https://github.com/DoSomething/northstar-js/issues/35
* https://github.com/DoSomething/northstar-js/issues/33

