### PR TITLE
Set req.userId

### DIFF
--- a/app/models/Signup.js
+++ b/app/models/Signup.js
@@ -94,16 +94,16 @@ signupSchema.statics.lookupById = function (id) {
 /**
  * Gets current Signup for given User / Campaign from DS API, stores if found. Returns false if not.
  * @param {string} userId
- * @param {Campaign} campaign - Phoenix Campaign object.
+ * @param {number} campaignId.
  */
-signupSchema.statics.lookupCurrent = function (userId, campaign) {
+signupSchema.statics.lookupCurrent = function (userId, campaignId) {
   const model = this;
   const statName = 'phoenix: GET signups';
 
   return new Promise((resolve, reject) => {
-    logger.debug(`Signup.lookupCurrent(${userId}, ${campaign.id})`);
+    logger.debug(`Signup.lookupCurrent(${userId}, ${campaignId})`);
 
-    return phoenix.client.Signups.index({ user: userId, campaigns: campaign.id })
+    return phoenix.client.Signups.index({ user: userId, campaigns: campaignId })
       .then((phoenixSignups) => {
         stathat.postStat(`${statName} 200`);
 
@@ -138,23 +138,23 @@ signupSchema.statics.lookupCurrent = function (userId, campaign) {
 /**
  * Posts Signup to DS API.
  * @param {string} userId
- * @param {Campaign} campaign - Phoenix Campaign object.
+ * @param {number} campaignId
  * @param {string} keyword - Keyword used to trigger Campaign Signup.
  * @param {number} broadcastId
  * @return {Promise}
  */
-signupSchema.statics.post = function (userId, campaign, keyword, broadcastId) {
+signupSchema.statics.post = function (userId, campaignId, keyword, broadcastId) {
   const model = this;
   const statName = 'phoenix: POST signups';
 
   return new Promise((resolve, reject) => {
-    logger.debug(`Signup.post(${userId}, ${campaign.id}, ${keyword})`);
+    logger.debug(`Signup.post(${userId}, ${campaignId}, ${keyword})`);
     const postData = {
       source: postSource,
       northstar_id: userId,
     };
 
-    return phoenix.client.Campaigns.signup(campaign.id, postData)
+    return phoenix.client.Campaigns.signup(campaignId, postData)
       .then((signupId) => {
         stathat.postStat(`${statName} 200`);
         if (keyword) {
@@ -163,7 +163,7 @@ signupSchema.statics.post = function (userId, campaign, keyword, broadcastId) {
         logger.info(`Signup.post created signup:${signupId}`);
 
         const data = {
-          campaign: campaign.id,
+          campaign: campaignId,
           user: userId,
         };
         if (keyword) {

--- a/app/models/Signup.js
+++ b/app/models/Signup.js
@@ -93,17 +93,17 @@ signupSchema.statics.lookupById = function (id) {
 
 /**
  * Gets current Signup for given User / Campaign from DS API, stores if found. Returns false if not.
- * @param {User} user - User model.
+ * @param {string} userId
  * @param {Campaign} campaign - Phoenix Campaign object.
  */
-signupSchema.statics.lookupCurrent = function (user, campaign) {
+signupSchema.statics.lookupCurrent = function (userId, campaign) {
   const model = this;
   const statName = 'phoenix: GET signups';
 
   return new Promise((resolve, reject) => {
-    logger.debug(`Signup.lookupCurrent(${user._id}, ${campaign.id})`);
+    logger.debug(`Signup.lookupCurrent(${userId}, ${campaign.id})`);
 
-    return phoenix.client.Signups.index({ user: user._id, campaigns: campaign.id })
+    return phoenix.client.Signups.index({ user: userId, campaigns: campaign.id })
       .then((phoenixSignups) => {
         stathat.postStat(`${statName} 200`);
 
@@ -137,21 +137,21 @@ signupSchema.statics.lookupCurrent = function (user, campaign) {
 
 /**
  * Posts Signup to DS API.
- * @param {User} user - User model.
+ * @param {string} userId
  * @param {Campaign} campaign - Phoenix Campaign object.
  * @param {string} keyword - Keyword used to trigger Campaign Signup.
  * @param {number} broadcastId
  * @return {Promise}
  */
-signupSchema.statics.post = function (user, campaign, keyword, broadcastId) {
+signupSchema.statics.post = function (userId, campaign, keyword, broadcastId) {
   const model = this;
   const statName = 'phoenix: POST signups';
 
   return new Promise((resolve, reject) => {
-    logger.debug(`Signup.post(${user._id}, ${campaign.id}, ${keyword})`);
+    logger.debug(`Signup.post(${userId}, ${campaign.id}, ${keyword})`);
     const postData = {
       source: postSource,
-      northstar_id: user._id,
+      northstar_id: userId,
     };
 
     return phoenix.client.Campaigns.signup(campaign.id, postData)
@@ -164,7 +164,7 @@ signupSchema.statics.post = function (user, campaign, keyword, broadcastId) {
 
         const data = {
           campaign: campaign.id,
-          user: user._id,
+          user: userId,
         };
         if (keyword) {
           data.keyword = keyword;

--- a/lib/middleware/signup-create.js
+++ b/lib/middleware/signup-create.js
@@ -9,7 +9,7 @@ module.exports = function createNewUser() {
     if (req.signup) {
       return next();
     }
-    return Signup.post(req.user, req.campaign, req.keyword, req.broadcast_id)
+    return Signup.post(req.userId, req.campaign, req.keyword, req.broadcast_id)
       .then((signup) => {
         helpers.handleTimeout(req, res);
         req.signup = signup; // eslint-disable-line no-param-reassign

--- a/lib/middleware/signup-create.js
+++ b/lib/middleware/signup-create.js
@@ -9,7 +9,7 @@ module.exports = function createNewUser() {
     if (req.signup) {
       return next();
     }
-    return Signup.post(req.userId, req.campaign, req.keyword, req.broadcast_id)
+    return Signup.post(req.userId, req.campaignId, req.keyword, req.broadcast_id)
       .then((signup) => {
         helpers.handleTimeout(req, res);
         req.signup = signup; // eslint-disable-line no-param-reassign

--- a/lib/middleware/signup-create.js
+++ b/lib/middleware/signup-create.js
@@ -12,7 +12,7 @@ module.exports = function createNewUser() {
     return Signup.post(req.userId, req.campaignId, req.keyword, req.broadcast_id)
       .then((signup) => {
         helpers.handleTimeout(req, res);
-        req.signup = signup; // eslint-disable-line no-param-reassign
+        req.signup = signup;
 
         return next();
       })

--- a/lib/middleware/signup-get.js
+++ b/lib/middleware/signup-get.js
@@ -4,8 +4,8 @@ const helpers = require('../helpers');
 const Signup = require('../../app/models/Signup.js');
 
 module.exports = function getSignup() {
-  return (req, res, next) => {
-    Signup.lookupCurrent(req.userId, req.campaignId)
+  return (req, res, next) => { // eslint-disable-line arrow-body-style
+    return Signup.lookupCurrent(req.userId, req.campaignId)
       .then((signup) => {
         helpers.handleTimeout(req, res);
 

--- a/lib/middleware/signup-get.js
+++ b/lib/middleware/signup-get.js
@@ -5,9 +5,8 @@ const Signup = require('../../app/models/Signup.js');
 
 module.exports = function getSignup() {
   return (req, res, next) => {
-    const user = req.user;
     const campaign = req.campaign;
-    return Signup.lookupCurrent(user, campaign)
+    return Signup.lookupCurrent(req.userId, campaign)
       .then((signup) => {
         helpers.handleTimeout(req, res);
 

--- a/lib/middleware/signup-get.js
+++ b/lib/middleware/signup-get.js
@@ -5,8 +5,7 @@ const Signup = require('../../app/models/Signup.js');
 
 module.exports = function getSignup() {
   return (req, res, next) => {
-    const campaign = req.campaign;
-    return Signup.lookupCurrent(req.userId, campaign)
+    Signup.lookupCurrent(req.userId, req.campaignId)
       .then((signup) => {
         helpers.handleTimeout(req, res);
 

--- a/lib/middleware/signup-get.js
+++ b/lib/middleware/signup-get.js
@@ -10,7 +10,7 @@ module.exports = function getSignup() {
         helpers.handleTimeout(req, res);
 
         if (signup) {
-          req.signup = signup; // eslint-disable-line no-param-reassign
+          req.signup = signup;
           req.draftSubmission = req.signup.draft_reportback_submission;
         }
 

--- a/lib/middleware/user-create.js
+++ b/lib/middleware/user-create.js
@@ -17,8 +17,11 @@ module.exports = function createNewUser() {
     return User.post(data)
       .then((user) => {
         helpers.handleTimeout(req, res);
-        req.user = user; // eslint-disable-line no-param-reassign
-        newrelic.addCustomParameters({ userId: user._id });
+        /* es-lint-disable no-param-resassign */
+        req.user = user;
+        req.userId = user.id;
+         /* es-lint-enable no-param-resassign */
+        newrelic.addCustomParameters({ userId: req.userId });
         return next();
       })
      .catch(err => helpers.sendErrorResponse(res, err));

--- a/lib/middleware/user-create.js
+++ b/lib/middleware/user-create.js
@@ -17,10 +17,8 @@ module.exports = function createNewUser() {
     return User.post(data)
       .then((user) => {
         helpers.handleTimeout(req, res);
-        /* es-lint-disable no-param-resassign */
         req.user = user;
         req.userId = user.id;
-         /* es-lint-enable no-param-resassign */
         newrelic.addCustomParameters({ userId: req.userId });
         return next();
       })

--- a/lib/middleware/user-get.js
+++ b/lib/middleware/user-get.js
@@ -22,8 +22,11 @@ module.exports = function getUser() {
     return User.lookup('mobile', phoneNumber)
       .then((user) => {
         helpers.handleTimeout(req, res);
-        req.user = user; // eslint-disable-line no-param-reassign
-        newrelic.addCustomParameters({ userId: user._id });
+        /* es-lint-disable no-param-resassign */
+        req.user = user;
+        req.userId = user.id;
+         /* es-lint-enable no-param-resassign */
+        newrelic.addCustomParameters({ userId: req.userId });
         populateCampaignIdIfNotFound(req, res);
         return next();
       })

--- a/lib/middleware/user-get.js
+++ b/lib/middleware/user-get.js
@@ -22,10 +22,8 @@ module.exports = function getUser() {
     return User.lookup('mobile', phoneNumber)
       .then((user) => {
         helpers.handleTimeout(req, res);
-        /* es-lint-disable no-param-resassign */
         req.user = user;
         req.userId = user.id;
-         /* es-lint-enable no-param-resassign */
         newrelic.addCustomParameters({ userId: req.userId });
         populateCampaignIdIfNotFound(req, res);
         return next();


### PR DESCRIPTION
#### What's this PR do?

* Sets a `req.userId` in the User Get and User Create middleware

* Modifies `Signup.lookupCurrent` and `Signup.post` to expect a `userId` string instead of a `user` object.
    * This is prep work for #959 - if we pass a `userId` parameter to `POST /receive-message` and set `req.userId`, we can remove the User Get / User Create middleware from Receive Message

* Modifies `Signup.lookupCurrent` and `Signup.post` to expect a `campaignId` number instead of a `campaign` object, to keep consistent with the `userId` change

#### How should this be reviewed?
* Set phone number in Consolebot to a number that doesn't exist for a User (I tend to always use a timestamp, like 201709201232)
* Post a signup , e.g. send `keyword:dunkbot`, to verify a Signup is created
* Continue conversation to verify Signup lookup is working as expected

#### Any background context you want to provide?
When we go live with Conversations, we can completely deprecate our `User` model and relevant middleware 🔥 

#### Relevant tickets
#959 

#### Checklist
- [x] Tested on staging.
