### PR TITLE
Receive Message: required userId param

### DIFF
--- a/app/routes/receive-message.js
+++ b/app/routes/receive-message.js
@@ -9,8 +9,6 @@ const mapParamsConf = require('../../config/middleware/receive-message/map-reque
 // Middleware
 const requiredParamsMiddleware = require('../../lib/middleware/required-params');
 const mapRequestParamsMiddleware = require('../../lib/middleware/map-request-params');
-const getUserMiddleware = require('../../lib/middleware/user-get');
-const createNewUserIfNotFoundMiddleware = require('../../lib/middleware/user-create');
 const getPhoenixCampaignMiddleware = require('../../lib/middleware/phoenix-campaign-get');
 const getSignupMiddleware = require('../../lib/middleware/signup-get');
 const createNewSignupIfNotFoundMiddleware = require('../../lib/middleware/signup-create');
@@ -33,16 +31,6 @@ const router = express.Router(); // eslint-disable-line new-cap
  */
 router.use(requiredParamsMiddleware(requiredParamsConf));
 router.use(mapRequestParamsMiddleware(mapParamsConf));
-
-router.use(
-  /**
-   * Check if DS User exists for given mobile number.
-   */
-  getUserMiddleware(),
-  /**
-   * Create DS User for given mobile number if we didn't find one.
-   */
-  createNewUserIfNotFoundMiddleware());
 
 /**
  * Load Campaign from DS Phoenix API.

--- a/config/middleware/receive-message/map-request-params.js
+++ b/config/middleware/receive-message/map-request-params.js
@@ -12,5 +12,6 @@ configVars.paramsMap = {
   campaignId: 'campaignId',
   text: 'incoming_message',
   mediaUrl: 'incoming_image_url',
+  userId: 'userId',
 };
 module.exports = configVars;

--- a/config/middleware/receive-message/required-params.js
+++ b/config/middleware/receive-message/required-params.js
@@ -4,7 +4,7 @@ const configVars = {};
 
 configVars.containerProperty = 'body';
 configVars.requiredParams = [
-  'phone',
   'campaignId',
+  'userId',
 ];
 module.exports = configVars;

--- a/documentation/endpoints/receive-message.md
+++ b/documentation/endpoints/receive-message.md
@@ -18,8 +18,8 @@ Name | Type | Description
 
 Name | Type | Description
 --- | --- | ---
-`phone` | `string` | **Required.** Mobile number that sent incoming message.
-`campaignId` | `string` | **Required.** Mobile number that sent incoming message.
+`userId` | `string` | **Required.** Northstar Id of User that sent incoming message.
+`campaignId` | `string` | **Required.** Campaign User has signed up for.
 `text` | `string` | Incoming text sent.
 `mediaUrl` | `string` | Incoming image sent.
 `keyword` | `string` | Campaign Signup keyword, if triggered
@@ -31,7 +31,7 @@ Name | Type | Description
 curl -X "POST" "http://localhost:5000/v1/chatbot" \
      -H "x-gambit-api-key: totallysecret" \
      -H "Content-Type: application/x-www-form-urlencoded; charset=utf-8" \
-     --data-urlencode "phone=5555555511" \
+     --data-urlencode "userId=59abca4200707d62db575a3b" \
      --data-urlencode "text=I love rock and roll"
      --data-urlencode "campaignId=7" \
 ```

--- a/lib/conversation/replies.js
+++ b/lib/conversation/replies.js
@@ -17,7 +17,7 @@ const BotRequest = require('../../app/models/BotRequest');
 
  /**
   * Decorator.
-  * Returns passed function wrapped with functionality to respond with a succes response to
+  * Returns passed function wrapped with functionality to respond with a success response to
   * the user.
   *
   * @param  {function} fn function to be wrapped.
@@ -33,59 +33,62 @@ function customMsg(fn) {
 /**
  * Decorator.
  * Returns passed function wrapped with functionality to retrieve and inject a rendered
- * version of the message given a messageTemplate string and args object as arguments.
- * It sends a succes response to the user.
+ * version of the message given a replyTemplate string and args object as arguments.
+ * It sends a success response to the user.
  *
  * @param  {function} fn function to be wrapped.
  * @return {function}    wrapped function
  */
 function renderEndConversationMsg(fn) {
-  return (messageTemplate, args) => helpers.renderMessageTemplate(args.req, messageTemplate)
-      .then((replyMessage) => {
-        args.replyText = replyMessage;
-        args.req.user.updateConversation(messageTemplate)
-          .then(() => {
-            fn(args);
-            stathat.postStat(`campaignbot:${messageTemplate}`);
-            BotRequest.log(args.req, 'campaignbot', messageTemplate, args.replyText);
-            return helpers.sendResponse(args.res, 200, args.replyText, messageTemplate);
-          });
-      })
-      .catch(err => helpers.sendErrorResponse(args.res, err));
+  return (replyTemplate, args) => helpers.renderMessageTemplate(args.req, replyTemplate)
+    .then((replyText) => {
+      if (!args.req.user) {
+        return helpers.sendResponse(args.res, 200, replyText, replyTemplate);
+      }
+
+      args.replyText = replyText;
+      fn(args);
+      stathat.postStat(`campaignbot:${replyTemplate}`);
+      BotRequest.log(args.req, 'campaignbot', replyTemplate, replyText);
+
+      return helpers.sendResponse(args.res, 200, replyText, replyTemplate);
+    })
+    .catch(err => helpers.sendErrorResponse(args.res, err));
 }
 
 /**
  * Decorator.
  * Returns passed function wrapped with functionality to retrieve and inject a rendered
- * version of the message given a messageTemplate string and args object as arguments.
+ * version of the message given a replyTemplate string and args object as arguments.
  * It sends an error response to the user.
  *
  * @param  {function} fn function to be wrapped.
  * @return {function}    wrapped function
  */
 function renderEndConversationWithErrorMsg(fn) {
-  return (messageTemplate, args) => helpers.renderMessageTemplate(args.req, messageTemplate)
-      .then((replyMessage) => {
-        args.replyText = replyMessage;
+  return (replyTemplate, args) => helpers.renderMessageTemplate(args.req, replyTemplate)
+    .then((replyText) => {
+      if (!args.req.user) {
+        return helpers.sendResponse(args.res, 200, replyText, replyTemplate);
+      }
 
-        args.req.user.updateConversation(messageTemplate)
-          .then(() => {
-            fn(args);
-            stathat.postStat(`campaignbot:${messageTemplate}`);
-            BotRequest.log(args.req, 'campaignbot', messageTemplate, args.replyText);
-            newrelic.addCustomParameters({ blinkSuppressRetry: true });
-            args.res.setHeader('x-blink-retry-suppress', true);
-            return helpers.sendErrorResponse(args.res, args.error);
-          });
-      })
-      .catch(err => helpers.sendErrorResponse(args.res, err));
+      args.replyText = replyText;
+      fn(args);
+      stathat.postStat(`campaignbot:${replyTemplate}`);
+      BotRequest.log(args.req, 'campaignbot', replyTemplate, replyText);
+      newrelic.addCustomParameters({ blinkSuppressRetry: true });
+      args.res.setHeader('x-blink-retry-suppress', true);
+
+      return helpers.sendErrorResponse(args.res, args.error);
+    })
+    .catch(err => helpers.sendErrorResponse(args.res, err));
 }
 
 
 /**
  * Decorator.
  * Returns passed function wrapped with functionality to retrieve and inject a rendered
- * version of the message given a messageTemplate string and args object as arguments.
+ * version of the message given a replyTemplate string and args object as arguments.
  * It also saves the campaignId as the user's current_campaign
  * It sends a success response to the user.
  *
@@ -93,18 +96,21 @@ function renderEndConversationWithErrorMsg(fn) {
  * @return {function}    wrapped function
  */
 function renderContinueConversationMsg(fn) {
-  return (messageTemplate, args) => helpers.renderMessageTemplate(args.req, messageTemplate)
-      .then((replyMessage) => {
-        args.replyText = replyMessage;
+  return (replyTemplate, args) => helpers.renderMessageTemplate(args.req, replyTemplate)
+      .then((replyText) => {
+        if (!args.req.user) {
+          return helpers.sendResponse(args.res, 200, replyText, replyTemplate);
+        }
 
+        args.replyText = replyText;
         // User's Current Campaign may need to be updated, pass req.campaignId to check.
-        args.req.user.updateConversation(messageTemplate, args.req.campaignId)
+        return args.req.user.updateConversation(replyTemplate, args.req.campaignId)
           .then(() => {
-            logger.verbose(`saved user:${args.req.user._id} current_campaign:${args.req.user.current_campaign}`);
+            logger.verbose(`saved user:${args.req.userId} current_campaign:${args.req.user.current_campaign}`);
             fn(args);
-            stathat.postStat(`campaignbot:${messageTemplate}`);
-            BotRequest.log(args.req, 'campaignbot', messageTemplate, args.replyText);
-            return helpers.sendResponse(args.res, 200, args.replyText, messageTemplate);
+            stathat.postStat(`campaignbot:${replyTemplate}`);
+            BotRequest.log(args.req, 'campaignbot', replyTemplate, replyText);
+            return helpers.sendResponse(args.res, 200, replyText, replyTemplate);
           });
       })
       .catch(err => helpers.sendErrorResponse(args.res, err));

--- a/lib/middleware/validate.js
+++ b/lib/middleware/validate.js
@@ -12,7 +12,7 @@ function validateSignup(req, res) {
     return false;
   }
 
-  logger.verbose(`user:${req.user._id} campaign:${req.campaign.id} signup:${req.signup._id}`);
+  logger.verbose(`userId:${req.userId} campaignId:${req.campaign.id} signupId:${req.signup._id}`);
   newrelic.addCustomParameters({ signupId: req.signup._id });
   return true;
 }


### PR DESCRIPTION
#### What's this PR do?
Now that Gambit Conversations is passing Northstar `userId` parameter when available (https://github.com/DoSomething/gambit-conversations/pull/140), and our Signup methods accept a `userId` string instead of a `user` object (#962), we can remove the Create / Get User middleware from `POST /receive-message` to avoid making double Northstar requests in Gambit Conversations.

#### How should this be reviewed?
Can't deploy this yet because we don't want to break Slack / Consolebot integration in the Conversations API - we'll need to figure out what `userId` to pass over for non phone numbers.

#### Any background context you want to provide?
Next up:
* [x] in Gambit Conversation, pass `userId` in Campaigns Receive Message requests for Conversations with platforms `'slack'` and `'api'`.
* [ ] Refactor `User.updateConversation` as `User.updateCurrentCampaign`
* [ ] Refactor Receive Message API response to return a Signup and the appropriate reply template, to unblock last task in https://github.com/DoSomething/gambit-conversations/issues/37

#### Relevant tickets
Fixes #959 

#### Checklist
- [x] Tested on staging.
