### PR TITLE
Include Signup in a POST /receive-message response

### DIFF
--- a/app/models/User.js
+++ b/app/models/User.js
@@ -16,25 +16,10 @@ const stathat = require('../../lib/stathat');
  * Schema.
  */
 const userSchema = new mongoose.Schema({
-
   _id: { type: String, index: true },
-  // TODO: Not sure we need this index
   mobile: { type: String, index: true },
-  phoenix_id: Number,
   mobilecommons_id: Number,
-  email: String,
-  role: String,
-  first_name: String,
-  // Campaign the user is currently participating in via chatbot.
   current_campaign: Number,
-  signup_status: {
-    type: String,
-    // Eventually we'll be adding other values here like 'prompt, 'declined' to build out handling
-    // No or Invalid responses to a Ask Signup Message Template message (broadcasts, campaign menu).
-    enum: ['doing'],
-  },
-  last_outbound_template: String,
-
 });
 
 /**
@@ -44,11 +29,7 @@ function parseNorthstarUser(northstarUser) {
   const data = {
     _id: northstarUser.id,
     mobile: northstarUser.mobile,
-    first_name: northstarUser.firstName,
-    email: northstarUser.email,
-    phoenix_id: northstarUser.drupalID,
     mobilecommons_id: northstarUser.mobilecommonsID,
-    role: northstarUser.role,
   };
 
   return data;
@@ -136,16 +117,10 @@ userSchema.methods.postMobileCommonsProfileUpdate = function (oip, msgTxt) {
 };
 
 /**
- * @param {string} messageTemplate
  * @param {number} campaignId
  */
-userSchema.methods.updateConversation = function (outboundTemplate, campaignId) {
-  this.last_outbound_template = outboundTemplate;
-
-  if (campaignId && campaignId !== this.current_campaign) {
-    this.current_campaign = campaignId;
-    this.signup_status = 'doing';
-  }
+userSchema.methods.updateCurrentCampaign = function (campaignId) {
+  this.current_campaign = campaignId;
 
   return this.save();
 };

--- a/documentation/endpoints/receive-message.md
+++ b/documentation/endpoints/receive-message.md
@@ -54,10 +54,10 @@ curl -X "POST" "http://localhost:5000/v1/chatbot" \
       },
       "totalQuantitySubmitted": 453,
       "draftReportbackSubmission": {
-        "photo": "https://i.ytimg.com/vi/w6DW4i-mfbA/hqdefault.jpg",
         "id": "59cd5df31e1b4b2cc1ffe208",
         "v": 0,
         "quantity": 700,
+        "photo": "https://i.ytimg.com/vi/w6DW4i-mfbA/hqdefault.jpg",
         "createdAt": "2017-09-28T20:38:44.103Z"
       },
       "user": {
@@ -65,8 +65,8 @@ curl -X "POST" "http://localhost:5000/v1/chatbot" \
       }
     },
     "reply": {
-      "text": "@dev Got it! Now text back a caption for your photo (think Instagram)! Keep it short & sweet, under 60 characters please.",
-      "template": "askCaption"
+      "text": "@dev Sorry, I didn't understand that.\n\nGot it! Now text back a caption for your photo (think Instagram)! Keep it short & sweet, under 60 characters please.",
+      "template": "invalidCaption"
     }
   }
 }

--- a/documentation/endpoints/receive-message.md
+++ b/documentation/endpoints/receive-message.md
@@ -42,12 +42,31 @@ curl -X "POST" "http://localhost:5000/v1/chatbot" \
 
 ```
 {
-  "success": {
-    "code": 200,
-    "message": "Nice job! YOU deserve a Mirror Message for all the notes you posted. We've got you down for 97 messages posted. Have you posted more? Text START.",
-    "template": "completedMenu"
+  "data": {
+    "signup": {
+      "id": 4037166,
+      "campaign": {
+        "id": 6620
+      },
+      "keyword": "dunkbot",
+      "reportback": 4037166,
+      "totalQuantitySubmitted": 44,
+      "draftReportbackSubmission": {
+        "quantity": 453,
+        "id": "59cd56554fc8e92a6ce84b1c",
+        "createdAt": "2017-09-28T20:06:04.711Z"
+      },
+      "user": {
+        "id": "59cd4c1910707d778633e30f"
+      }
+    },
+    "reply": {
+      "text": "@dev Nice! Send your best pic of you and the 453 dunks you done.",
+      "template": "askPhoto"
+    }
   }
 }
+
 ```
 
 </p></details>

--- a/documentation/endpoints/receive-message.md
+++ b/documentation/endpoints/receive-message.md
@@ -49,20 +49,24 @@ curl -X "POST" "http://localhost:5000/v1/chatbot" \
         "id": 6620
       },
       "keyword": "dunkbot",
-      "reportback": 4037166,
-      "totalQuantitySubmitted": 44,
+      "reportback": {
+        "id": 4037166
+      },
+      "totalQuantitySubmitted": 453,
       "draftReportbackSubmission": {
-        "quantity": 453,
-        "id": "59cd56554fc8e92a6ce84b1c",
-        "createdAt": "2017-09-28T20:06:04.711Z"
+        "photo": "https://i.ytimg.com/vi/w6DW4i-mfbA/hqdefault.jpg",
+        "id": "59cd5df31e1b4b2cc1ffe208",
+        "v": 0,
+        "quantity": 700,
+        "createdAt": "2017-09-28T20:38:44.103Z"
       },
       "user": {
         "id": "59cd4c1910707d778633e30f"
       }
     },
     "reply": {
-      "text": "@dev Nice! Send your best pic of you and the 453 dunks you done.",
-      "template": "askPhoto"
+      "text": "@dev Got it! Now text back a caption for your photo (think Instagram)! Keep it short & sweet, under 60 characters please.",
+      "template": "askCaption"
     }
   }
 }

--- a/lib/conversation/replies.js
+++ b/lib/conversation/replies.js
@@ -43,7 +43,9 @@ function renderEndConversationMsg(fn) {
   return (replyTemplate, args) => helpers.renderMessageTemplate(args.req, replyTemplate)
     .then((replyText) => {
       if (!args.req.user) {
-        return helpers.sendResponseForSignup(args.res, args.req.signup, replyText, replyTemplate);
+        const signup = args.req.signup;
+        const userId = args.req.userId;
+        return helpers.sendResponseForSignup(args.res, signup, userId, replyText, replyTemplate);
       }
 
       args.replyText = replyText;
@@ -69,7 +71,9 @@ function renderEndConversationWithErrorMsg(fn) {
   return (replyTemplate, args) => helpers.renderMessageTemplate(args.req, replyTemplate)
     .then((replyText) => {
       if (!args.req.user) {
-        return helpers.sendResponseForSignup(args.res, args.req.signup, replyText, replyTemplate);
+        const signup = args.req.signup;
+        const userId = args.req.userId;
+        return helpers.sendResponseForSignup(args.res, signup, userId, replyText, replyTemplate);
       }
 
       args.replyText = replyText;
@@ -99,12 +103,13 @@ function renderContinueConversationMsg(fn) {
   return (replyTemplate, args) => helpers.renderMessageTemplate(args.req, replyTemplate)
       .then((replyText) => {
         if (!args.req.user) {
-          return helpers.sendResponseForSignup(args.res, args.req.signup, replyText, replyTemplate);
+          const signup = args.req.signup;
+          const userId = args.req.userId;
+          return helpers.sendResponseForSignup(args.res, signup, userId, replyText, replyTemplate);
         }
 
         args.replyText = replyText;
-        // User's Current Campaign may need to be updated, pass req.campaignId to check.
-        return args.req.user.updateConversation(replyTemplate, args.req.campaignId)
+        return args.req.user.updateCurrentCampaign(args.req.campaignId)
           .then(() => {
             logger.verbose(`saved user:${args.req.userId} current_campaign:${args.req.user.current_campaign}`);
             fn(args);

--- a/lib/conversation/replies.js
+++ b/lib/conversation/replies.js
@@ -43,7 +43,7 @@ function renderEndConversationMsg(fn) {
   return (replyTemplate, args) => helpers.renderMessageTemplate(args.req, replyTemplate)
     .then((replyText) => {
       if (!args.req.user) {
-        return helpers.sendResponseForSignup(args.res, args.req.signup, replyTemplate);
+        return helpers.sendResponseForSignup(args.res, args.req.signup, replyText, replyTemplate);
       }
 
       args.replyText = replyText;
@@ -69,7 +69,7 @@ function renderEndConversationWithErrorMsg(fn) {
   return (replyTemplate, args) => helpers.renderMessageTemplate(args.req, replyTemplate)
     .then((replyText) => {
       if (!args.req.user) {
-        return helpers.sendResponseForSignup(args.res, args.req.signup, replyTemplate);
+        return helpers.sendResponseForSignup(args.res, args.req.signup, replyText, replyTemplate);
       }
 
       args.replyText = replyText;
@@ -99,7 +99,7 @@ function renderContinueConversationMsg(fn) {
   return (replyTemplate, args) => helpers.renderMessageTemplate(args.req, replyTemplate)
       .then((replyText) => {
         if (!args.req.user) {
-          return helpers.sendResponseForSignup(args.res, args.req.signup, replyTemplate);
+          return helpers.sendResponseForSignup(args.res, args.req.signup, replyText, replyTemplate);
         }
 
         args.replyText = replyText;

--- a/lib/conversation/replies.js
+++ b/lib/conversation/replies.js
@@ -43,7 +43,7 @@ function renderEndConversationMsg(fn) {
   return (replyTemplate, args) => helpers.renderMessageTemplate(args.req, replyTemplate)
     .then((replyText) => {
       if (!args.req.user) {
-        return helpers.sendResponse(args.res, 200, replyText, replyTemplate);
+        return helpers.sendResponseForSignup(args.res, args.req.signup, replyTemplate);
       }
 
       args.replyText = replyText;
@@ -69,7 +69,7 @@ function renderEndConversationWithErrorMsg(fn) {
   return (replyTemplate, args) => helpers.renderMessageTemplate(args.req, replyTemplate)
     .then((replyText) => {
       if (!args.req.user) {
-        return helpers.sendResponse(args.res, 200, replyText, replyTemplate);
+        return helpers.sendResponseForSignup(args.res, args.req.signup, replyTemplate);
       }
 
       args.replyText = replyText;
@@ -99,7 +99,7 @@ function renderContinueConversationMsg(fn) {
   return (replyTemplate, args) => helpers.renderMessageTemplate(args.req, replyTemplate)
       .then((replyText) => {
         if (!args.req.user) {
-          return helpers.sendResponse(args.res, 200, replyText, replyTemplate);
+          return helpers.sendResponseForSignup(args.res, args.req.signup, replyTemplate);
         }
 
         args.replyText = replyText;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -7,6 +7,7 @@ const crypto = require('crypto');
 const logger = require('winston');
 const newrelic = require('newrelic');
 const camelCaseKeys = require('camelcase-keys-deep');
+const underscore = require('underscore');
 
 const contentful = require('./contentful');
 const stathat = require('./stathat');
@@ -273,14 +274,26 @@ module.exports.sendResponse = function (res, code, messageText, messageTemplate)
  * @param {Signup} signup
  * @return {object}
  */
-function formatSignupResponse(signupDoc) {
+function formatSignupResponse(signupDoc, userId) {
   const draftDoc = signupDoc.draft_reportback_submission;
-  const signup = signupDoc.toObject();
-  if (draftDoc) {
-    signup.draft_reportback_submission = draftDoc.toObject();
-    // A Mongo objectId gets cast as an object, we just want the string for our draft id:
-    signup.draft_reportback_submission._id = draftDoc._id.toString();
+  let draftId = null;
+  if (draftDoc && draftDoc._id) {
+    draftId = draftDoc._id.toString();
   }
+  const omitKeys = ['user', '__v'];
+  const signupObject = signupDoc.toObject();
+  const signup = underscore.omit(signupObject, omitKeys);
+  signup.campaign = { _id: signupObject.campaign };
+  signup.user = { _id: userId };
+
+  if (draftId) {
+    const draft = signup.draft_reportback_submission;
+    // A Mongo objectId gets cast as an object, we just want the string for our draft id:
+    draft._id = draftDoc._id.toString();
+    omitKeys.push('campaign');
+    signup.draft_reportback_submission = underscore.omit(draft, omitKeys);
+  }
+
   return camelCaseKeys(signup);
 }
 
@@ -290,9 +303,9 @@ function formatSignupResponse(signupDoc) {
  * @param {Signup} signup
  * @param {string} replyTemplate
  */
-module.exports.sendResponseForSignup = function (res, signup, replyText, replyTemplate) {
+module.exports.sendResponseForSignup = function (res, signup, userId, replyText, replyTemplate) {
   const data = {
-    signup: formatSignupResponse(signup),
+    signup: formatSignupResponse(signup, userId),
     reply: {
       text: replyText,
       template: replyTemplate,

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -6,6 +6,7 @@
 const crypto = require('crypto');
 const logger = require('winston');
 const newrelic = require('newrelic');
+const camelCaseKeys = require('camelcase-keys-deep');
 
 const contentful = require('./contentful');
 const stathat = require('./stathat');
@@ -267,18 +268,38 @@ module.exports.sendResponse = function (res, code, messageText, messageTemplate)
 };
 
 /**
+ * Converts a Signup document (and its nested draft Reportback Submission) into an object with
+ * camelCase keys.
+ * @param {Signup} signup
+ * @return {object}
+ */
+function formatSignupResponse(signupDoc) {
+  const draftDoc = signupDoc.draft_reportback_submission;
+  const signup = signupDoc.toObject();
+  if (draftDoc) {
+    signup.draft_reportback_submission = draftDoc.toObject();
+    // A Mongo objectId gets cast as an object, we just want the string for our draft id:
+    signup.draft_reportback_submission._id = draftDoc._id.toString();
+  }
+  return camelCaseKeys(signup);
+}
+
+/**
  * Sends response with the request Signup and the template to reply with.
  * @param {object} res - Express response
  * @param {Signup} signup
  * @param {string} replyTemplate
  */
-module.exports.sendResponseForSignup = function (res, signup, replyTemplate) {
+module.exports.sendResponseForSignup = function (res, signup, replyText, replyTemplate) {
   const data = {
-    signup,
-    replyTemplate,
+    signup: formatSignupResponse(signup),
+    reply: {
+      text: replyText,
+      template: replyTemplate,
+    },
   };
 
-  return res.send(data);
+  return res.send({ data });
 };
 
 module.exports.handleTimeout = function handleTimeout(req, res) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -266,6 +266,21 @@ module.exports.sendResponse = function (res, code, messageText, messageTemplate)
   return res.status(code).send(response);
 };
 
+/**
+ * Sends response with the request Signup and the template to reply with.
+ * @param {object} res - Express response
+ * @param {Signup} signup
+ * @param {string} replyTemplate
+ */
+module.exports.sendResponseForSignup = function (res, signup, replyTemplate) {
+  const data = {
+    signup,
+    replyTemplate,
+  };
+
+  return res.send(data);
+};
+
 module.exports.handleTimeout = function handleTimeout(req, res) {
   const timedout = req.timedout;
   if (timedout) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -275,26 +275,32 @@ module.exports.sendResponse = function (res, code, messageText, messageTemplate)
  * @return {object}
  */
 function formatSignupResponse(signupDoc, userId) {
+  const omitKeys = ['user', '__v'];
+  const signup = underscore.omit(signupDoc.toObject(), omitKeys);
   const draftDoc = signupDoc.draft_reportback_submission;
-  let draftId = null;
+  let draftId;
   if (draftDoc && draftDoc._id) {
+    // A Mongo objectId gets cast as an object, we just want the string for our draft id:
     draftId = draftDoc._id.toString();
   }
-  const omitKeys = ['user', '__v'];
-  const signupObject = signupDoc.toObject();
-  const signup = underscore.omit(signupObject, omitKeys);
-  signup.campaign = { _id: signupObject.campaign };
-  signup.user = { _id: userId };
 
-  if (draftId) {
-    const draft = signup.draft_reportback_submission;
-    // A Mongo objectId gets cast as an object, we just want the string for our draft id:
-    draft._id = draftDoc._id.toString();
+  const camelCaseSignup = camelCaseKeys(signup);
+  camelCaseSignup.campaign = { id: signup.campaign };
+  camelCaseSignup.user = { id: userId };
+  if (draftDoc) { 
+    const draft = camelCaseSignup.draftReportbackSubmission;
+    // We don't need to repeat the Campaign property within the draft Reportback Submission, it's
+    // defined on the Signup.
     omitKeys.push('campaign');
-    signup.draft_reportback_submission = underscore.omit(draft, omitKeys);
+    camelCaseSignup.draftReportbackSubmission = underscore.omit(draft, omitKeys);
+    camelCaseSignup.draftReportbackSubmission.id = draftId;
   }
 
-  return camelCaseKeys(signup);
+  if (signup.reportback) {
+    camelCaseSignup.reportback = { id: signup.reportback }
+  }
+
+  return camelCaseSignup;
 }
 
 /**

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -271,36 +271,38 @@ module.exports.sendResponse = function (res, code, messageText, messageTemplate)
 /**
  * Converts a Signup document (and its nested draft Reportback Submission) into an object with
  * camelCase keys.
- * @param {Signup} signup
+ * @param {Signup} signupDoc
  * @return {object}
  */
 function formatSignupResponse(signupDoc, userId) {
-  const omitKeys = ['user', '__v'];
-  const signup = underscore.omit(signupDoc.toObject(), omitKeys);
   const draftDoc = signupDoc.draft_reportback_submission;
   let draftId;
   if (draftDoc && draftDoc._id) {
-    // A Mongo objectId gets cast as an object, we just want the string for our draft id:
     draftId = draftDoc._id.toString();
   }
 
-  const camelCaseSignup = camelCaseKeys(signup);
-  camelCaseSignup.campaign = { id: signup.campaign };
-  camelCaseSignup.user = { id: userId };
-  if (draftDoc) { 
-    const draft = camelCaseSignup.draftReportbackSubmission;
-    // We don't need to repeat the Campaign property within the draft Reportback Submission, it's
+  const signupObject = signupDoc.toObject();
+  const omitKeys = ['user', '__v'];
+  const formattedSignup = camelCaseKeys(underscore.omit(signupObject, omitKeys));
+
+  if (draftDoc) {
+    const draft = formattedSignup.draftReportbackSubmission;
+    // We don't need to repeat the Campaign property inside our draft Reportback Submission, it's
     // defined on the Signup.
     omitKeys.push('campaign');
-    camelCaseSignup.draftReportbackSubmission = underscore.omit(draft, omitKeys);
-    camelCaseSignup.draftReportbackSubmission.id = draftId;
+    formattedSignup.draftReportbackSubmission = underscore.omit(draft, omitKeys);
+    // A Mongo ObjectId gets converted to an id object, we just want an ID string.
+    formattedSignup.draftReportbackSubmission.id = draftId;
   }
 
-  if (signup.reportback) {
-    camelCaseSignup.reportback = { id: signup.reportback }
+  // Return ID properties as objects instead.
+  formattedSignup.campaign = { id: formattedSignup.campaign };
+  formattedSignup.user = { id: userId };
+  if (formattedSignup.reportback) {
+    formattedSignup.reportback = { id: formattedSignup.reportback };
   }
 
-  return camelCaseSignup;
+  return formattedSignup;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "aws-sdk": "2.36.0",
     "bluebird": "^3.4.6",
     "body-parser": "^1.9.2",
+    "camelcase-keys-deep": "^0.1.0",
     "colors": "^1.1.2",
     "connect-timeout": "^1.8.0",
     "contentful": "^3.8.0",


### PR DESCRIPTION
#### What's this PR do?

* Adds a Signup object to unblock the final task in https://github.com/DoSomething/gambit-conversations/issues/37: Using the Gambit Conversations cache to return Signup reply messages. When that's in place, a `POST /receive-message` request won't need to GET Phoenix or Contentful Campaigns at all.

* Completes cleanup task in #965, renaming `user.updateConversation` to `update.currentCurrentCampaign`

* Removes User properties no longer used, either from:
    * abandoned monolith Gambit+Rivescript approach (`last_outbound_template`, `signup_status`) - #932, #934
    * Refactor Phoenix posts (`phoenix_id`) - #941
    * DonorsChooseBot (`first_name`, `email`)
    * Was never used (`'role`)

#### How should this be reviewed?
Will need to update Conversations API to return the Gambit Campaigns response body `data.reply.text` instead of `success.message`

#### Relevant tickets
#965 

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Tested on staging.
