### PR TITLE
Use new invalidCaption and invalidWhyParticipated fields

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -32,23 +32,9 @@ module.exports.handlePhoenixPostError = function handlePhoenixPostError(req, res
 module.exports.renderMessageTemplate = function renderMessageTemplate(req, messageTemplate) {
   newrelic.addCustomParameters({ outboundMessageTemplate: messageTemplate });
 
-  let messagePrefix = '';
-  let template = messageTemplate;
-
-  // Check if we're replying to inform user they've submitted invalid values for text fields.
-  // If they did, ask for field again, setting messagePrefix to prepend to the rendered ask message.
-  const invalidTextSentMessage = 'Sorry, I didn\'t understand that.\n\n';
-  if (template === 'invalidCaption') {
-    template = 'askCaption';
-    messagePrefix = invalidTextSentMessage;
-  } else if (template === 'invalidWhyParticipated') {
-    template = 'askWhyParticipated';
-    messagePrefix = invalidTextSentMessage;
-  }
-
-  return contentful.renderMessageForPhoenixCampaign(req.campaign, template)
+  return contentful.renderMessageForPhoenixCampaign(req.campaign, messageTemplate)
     .then((renderedMessage) => {
-      let message = `${messagePrefix}${renderedMessage}`;
+      let message = renderedMessage;
 
       // Possible for edge cases like closed campaign messages.
       if (!req.signup) {


### PR DESCRIPTION
#### What's this PR do?
Leftover from #968 - use the new `invalidCaption` and `invalidWhyParticipated` Contentful fields instead of resending `askCaption` and `askWhyParticipated` with a hardcoded prefix.

#### How should this be reviewed?
Run Consolebot, test sending both invalid and valid caption/why values.

#### Any background context you want to provide?
Sure, we're deprecating the `POST /chatbot` route soon, but it's lame UX that the current invalid caption reads as:

> Sorry I didn't understand that.
> 
> Got it! Now text back a caption for your photo (think Instagram)! Keep it short & sweet, under 60 characters please.

Seemed worth making the quick fix while we're still running conversations via `POST /chatbot` this next month.

#### Relevant tickets
#968 

#### Checklist
- [ ] Tested on staging.
