### PR TITLE
Post Signups to Rogue

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,8 @@ DS_NORTHSTAR_API_KEY=totallysecret
 DS_PHOENIX_API_BASEURI=https://fake.dosomething.org/api/v1
 DS_PHOENIX_API_USERNAME=puppet.sloth@dosomething.org
 DS_PHOENIX_API_PASSWORD=totallysecret
+DS_ROGUE_API_BASEURI=https://rogue-fake.dosomething.org/api/v2
+DS_ROGUE_API_KEY=totallysecret
 
 MOBILECOMMONS_AUTH_EMAIL=puppet.sloth@dosomething.org
 MOBILECOMMONS_AUTH_PASS=totallysecret

--- a/app/models/Signup.js
+++ b/app/models/Signup.js
@@ -243,7 +243,7 @@ signupSchema.methods.postDraftReportbackSubmission = function () {
   return new Promise((resolve, reject) => {
     const submission = signup.draft_reportback_submission;
     const data = {
-      source: phoenix.getPostSource(),
+      source: helpers.getCampaignActivitySource(),
       northstar_id: signup.user,
       quantity: submission.quantity,
       // Although we strip emoji in our chatbot router in pull#910, some submissions may have emoji

--- a/config/lib/rogue.js
+++ b/config/lib/rogue.js
@@ -1,8 +1,12 @@
 'use strict';
 
+const enabled = process.env.DS_ROGUE_ENABLED === 'true';
+
 module.exports = {
+  apiKeyHeader: 'X-DS-Rogue-API-Key',
   clientOptions: {
     apiKey: process.env.DS_ROGUE_API_BASEURI,
     baseUri: process.env.DS_ROGUE_API_KEY,
   },
+  enabled: enabled || true,
 };

--- a/config/lib/rogue.js
+++ b/config/lib/rogue.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const enabled = process.env.DS_ROGUE_ENABLED === 'true';
+const helpers = require('../../lib/helpers');
 
 module.exports = {
   apiKeyHeader: 'X-DS-Rogue-API-Key',
@@ -8,5 +8,6 @@ module.exports = {
     baseUri: process.env.DS_ROGUE_API_BASEURI,
     apiKey: process.env.DS_ROGUE_API_KEY,
   },
-  enabled,
+  enabled: process.env.DS_ROGUE_ENABLED === 'true',
+  source: helpers.getCampaignActivitySource(),
 };

--- a/config/lib/rogue.js
+++ b/config/lib/rogue.js
@@ -5,8 +5,8 @@ const enabled = process.env.DS_ROGUE_ENABLED === 'true';
 module.exports = {
   apiKeyHeader: 'X-DS-Rogue-API-Key',
   clientOptions: {
-    apiKey: process.env.DS_ROGUE_API_BASEURI,
-    baseUri: process.env.DS_ROGUE_API_KEY,
+    baseUri: process.env.DS_ROGUE_API_BASEURI,
+    apiKey: process.env.DS_ROGUE_API_KEY,
   },
-  enabled: enabled || true,
+  enabled,
 };

--- a/config/lib/rogue.js
+++ b/config/lib/rogue.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = {
+  clientOptions: {
+    apiKey: process.env.DS_ROGUE_API_BASEURI,
+    baseUri: process.env.DS_ROGUE_API_KEY,
+  },
+};

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -397,3 +397,13 @@ module.exports.trimReportbackText = function (input) {
 
   return input;
 };
+
+/**
+ * Returns source value to pass when posting Campaign Activity (Signups, Reportbacks) to DS API.
+ * @return {string}
+ */
+module.exports.getCampaignActivitySource = function () {
+  const source = process.env.DS_API_POST_SOURCE || 'sms-mobilecommons';
+  return source;
+};
+

--- a/lib/middleware/signup-create.js
+++ b/lib/middleware/signup-create.js
@@ -4,12 +4,12 @@ const helpers = require('../helpers');
 
 const Signup = require('../../app/models/Signup.js');
 
-module.exports = function createNewUser() {
+module.exports = function createNewSignup() {
   return (req, res, next) => {
     if (req.signup) {
       return next();
     }
-    return Signup.post(req.userId, req.campaignId, req.keyword, req.broadcast_id)
+    return Signup.createSignupForReq(req)
       .then((signup) => {
         helpers.handleTimeout(req, res);
         req.signup = signup;

--- a/lib/phoenix.js
+++ b/lib/phoenix.js
@@ -5,6 +5,7 @@
  */
 const PhoenixClient = require('@dosomething/phoenix-js');
 const logger = require('winston');
+const helpers = require('./helpers');
 
 /**
  * Setup.
@@ -54,12 +55,19 @@ module.exports.fetchCampaign = function (campaignId) {
 };
 
 /**
- * @return {string}
+ * Returns a signupId as a mock Rogue POST Signups response.
+ * @see https://github.com/DoSomething/rogue/blob/master/documentation/endpoints/signups.md#signups
+ *
+ * @param {number} signupId
+ * @return {object}
  */
-module.exports.getPostSource = function () {
-  const source = process.env.DS_API_POST_SOURCE || 'sms-mobilecommons';
-  return source;
-};
+function formatSignupResponse(signupId) {
+  return {
+    data: {
+      signup_id: signupId,
+    },
+  };
+}
 
 /**
  * @param {object} req
@@ -70,10 +78,14 @@ module.exports.postSignupForReq = function (req) {
   const userId = req.userId;
 
   const data = {
-    source: exports.getPostSource(),
+    source: helpers.getCampaignActivitySource(),
     northstar_id: userId,
   };
   logger.debug('phoenix.postSignupForReq', { campaignId, data });
 
-  return client.Campaigns.signup(campaignId, data);
+  return client.Campaigns.signup(campaignId, data)
+    .then((res) => {
+      logger.debug('phoenix.postSignupForReq', { res });
+      return formatSignupResponse(res);
+    });
 };

--- a/lib/phoenix.js
+++ b/lib/phoenix.js
@@ -52,3 +52,28 @@ module.exports.fetchCampaign = function (campaignId) {
       });
   });
 };
+
+/**
+ * @return {string}
+ */
+module.exports.getPostSource = function () {
+  const source = process.env.DS_API_POST_SOURCE || 'sms-mobilecommons';
+  return source;
+};
+
+/**
+ * @param {object} req
+ * @return {Promise}
+ */
+module.exports.postSignupForReq = function (req) {
+  const campaignId = req.campaignId;
+  const userId = req.userId;
+
+  logger.debug('phoenix.postSignupForReq', { campaignId, userId });
+  const data = {
+    source: exports.getPostSource(),
+    northstar_id: userId,
+  };
+
+  return client.Campaigns.signup(campaignId, data);
+};

--- a/lib/phoenix.js
+++ b/lib/phoenix.js
@@ -69,11 +69,11 @@ module.exports.postSignupForReq = function (req) {
   const campaignId = req.campaignId;
   const userId = req.userId;
 
-  logger.debug('phoenix.postSignupForReq', { campaignId, userId });
   const data = {
     source: exports.getPostSource(),
     northstar_id: userId,
   };
+  logger.debug('phoenix.postSignupForReq', { campaignId, data });
 
   return client.Campaigns.signup(campaignId, data);
 };

--- a/lib/rogue.js
+++ b/lib/rogue.js
@@ -3,24 +3,40 @@
 /**
  * Imports.
  */
-const logger = require('winston');
+const Promise = require('bluebird');
 const superagent = require('superagent');
 
 const defaultConfig = require('../config/lib/rogue');
 
+/**
+ * @param {string} endpoint
+ * @param {object} data
+ */
 function executePost(endpoint, data) {
-  const uri = `${this.options.baseUri}/${endpoint}`;
+  const url = `${defaultConfig.clientOptions.baseUri}/${endpoint}`;
 
   return superagent
     .post(url)
-    .set('X-DS-Rogue-API-Key', defaultConfig.apiKey)
-    .send(data);
-};
+    .set(defaultConfig.apiKeyHeader, defaultConfig.clientOptions.apiKey)
+    .send(data)
+    .then(res => res.body)
+    .reject(err => Promise.reject(err));
+}
 
+/**
+ * @param {object} data
+ */
 module.exports.createSignup = function (data) {
   return executePost('signups', data);
 };
 
+/**
+ * @param {object} data
+ */
 module.exports.createPost = function (data) {
   return executePost('posts', data);
+};
+
+module.exports.isEnabled = function () {
+  return defaultConfig.enabled;
 };

--- a/lib/rogue.js
+++ b/lib/rogue.js
@@ -5,7 +5,6 @@
  */
 const logger = require('winston');
 const superagent = require('superagent');
-const helpers = require('./helpers');
 
 const defaultConfig = require('../config/lib/rogue');
 
@@ -40,7 +39,7 @@ module.exports.postSignupForReq = function (req) {
   const userId = req.userId;
 
   const data = {
-    source: helpers.getCampaignActivitySource(),
+    source: defaultConfig.source,
     // TODO: This should happen in Phoenix JS.
     campaign_id: Number(campaign.id),
     campaign_run_id: Number(campaign.currentCampaignRun.id),

--- a/lib/rogue.js
+++ b/lib/rogue.js
@@ -3,7 +3,7 @@
 /**
  * Imports.
  */
-const Promise = require('bluebird');
+const logger = require('winston');
 const superagent = require('superagent');
 
 const defaultConfig = require('../config/lib/rogue');
@@ -20,23 +20,32 @@ function executePost(endpoint, data) {
     .set(defaultConfig.apiKeyHeader, defaultConfig.clientOptions.apiKey)
     .send(data)
     .then(res => res.body)
-    .reject(err => Promise.reject(err));
+    .catch(err => err);
 }
 
 /**
- * @param {object} data
+ * @return {boolean}
  */
-module.exports.createSignup = function (data) {
-  return executePost('signups', data);
+module.exports.isEnabled = function () {
+  return defaultConfig.enabled;
 };
 
 /**
- * @param {object} data
+ * @param {object} req
+ * @return {Promise}
  */
-module.exports.createPost = function (data) {
-  return executePost('posts', data);
-};
+module.exports.postSignupForReq = function (req) {
+  const campaign = req.campaign;
+  const userId = req.userId;
 
-module.exports.isEnabled = function () {
-  return defaultConfig.enabled;
+  const data = {
+//    source: exports.getPostSource(),
+    // TODO: This should happen in Phoenix JS.
+    campaign_id: Number(campaign.id),
+    campaign_run_id: Number(campaign.currentCampaignRun.id),
+    northstar_id: userId,
+  };
+  logger.debug('rogue.postSignupForReq', { data });
+
+  return executePost('signups', data);
 };

--- a/lib/rogue.js
+++ b/lib/rogue.js
@@ -5,6 +5,7 @@
  */
 const logger = require('winston');
 const superagent = require('superagent');
+const helpers = require('./helpers');
 
 const defaultConfig = require('../config/lib/rogue');
 
@@ -39,7 +40,7 @@ module.exports.postSignupForReq = function (req) {
   const userId = req.userId;
 
   const data = {
-//    source: exports.getPostSource(),
+    source: helpers.getCampaignActivitySource(),
     // TODO: This should happen in Phoenix JS.
     campaign_id: Number(campaign.id),
     campaign_run_id: Number(campaign.currentCampaignRun.id),

--- a/lib/rogue.js
+++ b/lib/rogue.js
@@ -1,0 +1,26 @@
+'use strict';
+
+/**
+ * Imports.
+ */
+const logger = require('winston');
+const superagent = require('superagent');
+
+const defaultConfig = require('../config/lib/rogue');
+
+function executePost(endpoint, data) {
+  const uri = `${this.options.baseUri}/${endpoint}`;
+
+  return superagent
+    .post(url)
+    .set('X-DS-Rogue-API-Key', defaultConfig.apiKey)
+    .send(data);
+};
+
+module.exports.createSignup = function (data) {
+  return executePost('signups', data);
+};
+
+module.exports.createPost = function (data) {
+  return executePost('posts', data);
+};


### PR DESCRIPTION
#### What's this PR do?
Starts on Rogue integration, posting Signups to Rogue instead of Phoenix if `DS_ROGUE_ENABLED` config var is set to true.

#### How should this be reviewed?
Set `DS_ROGUE_ENABLED` to `true` and add the relevant config variables for Base URI and API Key. Use consolebot to test signups for a new phone number to verify Signups are created.

Set `DS_ROGUE_ENABLED` to `false` -- verify Signup is posted to Phoenix. this is currently not working on Thor (we get the "API response is false" error -- #devops issue)

#### Any background context you want to provide?
Once this is deployed to production and works beautifully, we can remove the conditional posting to Phoenix and always post to Rogue, to keep code simpler.

Next up: posting Reportbacks

Because we're looking to get this in for testing with TSG, haven't added test coverage yet. 🤦‍♂️ 👎 

#### Relevant tickets
First task in #970

#### Checklist
- [x] Tested on staging.
