### PR TITLE
Remove Phoenix POST Signup

### DIFF
--- a/app/models/Signup.js
+++ b/app/models/Signup.js
@@ -149,14 +149,7 @@ signupSchema.statics.createSignupForReq = function (req) {
   return new Promise((resolve, reject) => {
     logger.debug(`Signup.post(${userId}, ${campaignId}, ${keyword})`);
 
-    let promise;
-    if (rogue.isEnabled()) {
-      promise = rogue.postSignupForReq(req);
-    } else {
-      promise = phoenix.postSignupForReq(req);
-    }
-
-    return promise
+    return rogue.postSignupForReq(req)
       .then((signup) => {
         const signupId = signup.data.signup_id;
 

--- a/config/lib/rogue.js
+++ b/config/lib/rogue.js
@@ -8,6 +8,5 @@ module.exports = {
     baseUri: process.env.DS_ROGUE_API_BASEURI,
     apiKey: process.env.DS_ROGUE_API_KEY,
   },
-  enabled: process.env.DS_ROGUE_ENABLED === 'true',
   source: helpers.getCampaignActivitySource(),
 };

--- a/lib/phoenix.js
+++ b/lib/phoenix.js
@@ -5,7 +5,6 @@
  */
 const PhoenixClient = require('@dosomething/phoenix-js');
 const logger = require('winston');
-const helpers = require('./helpers');
 
 /**
  * Setup.
@@ -52,40 +51,4 @@ module.exports.fetchCampaign = function (campaignId) {
         return reject(scope);
       });
   });
-};
-
-/**
- * Returns a signupId as a mock Rogue POST Signups response.
- * @see https://github.com/DoSomething/rogue/blob/master/documentation/endpoints/signups.md#signups
- *
- * @param {number} signupId
- * @return {object}
- */
-function formatSignupResponse(signupId) {
-  return {
-    data: {
-      signup_id: signupId,
-    },
-  };
-}
-
-/**
- * @param {object} req
- * @return {Promise}
- */
-module.exports.postSignupForReq = function (req) {
-  const campaignId = req.campaignId;
-  const userId = req.userId;
-
-  const data = {
-    source: helpers.getCampaignActivitySource(),
-    northstar_id: userId,
-  };
-  logger.debug('phoenix.postSignupForReq', { campaignId, data });
-
-  return client.Campaigns.signup(campaignId, data)
-    .then((res) => {
-      logger.debug('phoenix.postSignupForReq', { res });
-      return formatSignupResponse(res);
-    });
 };

--- a/lib/rogue.js
+++ b/lib/rogue.js
@@ -24,13 +24,6 @@ function executePost(endpoint, data) {
 }
 
 /**
- * @return {boolean}
- */
-module.exports.isEnabled = function () {
-  return defaultConfig.enabled;
-};
-
-/**
  * @param {object} req
  * @return {Promise}
  */

--- a/lib/rogue.js
+++ b/lib/rogue.js
@@ -31,6 +31,7 @@ module.exports.postSignupForReq = function (req) {
   const campaign = req.campaign;
   const userId = req.userId;
 
+  // @see https://github.com/DoSomething/rogue/blob/master/documentation/endpoints/signups.md#signups
   const data = {
     source: defaultConfig.source,
     // TODO: This should happen in Phoenix JS.


### PR DESCRIPTION
#### What's this PR do?
Removes code for posting a Signup to the Phoenix API.

#### How should this be reviewed?
Send keyword for User who hasn't signed up and confirm signup is created.

#### Relevant tickets
#974 

#### Checklist
- [ ] Tested on staging.
