### PR TITLE
Post Reportbacks to Rogue

### DIFF
--- a/app/models/Signup.js
+++ b/app/models/Signup.js
@@ -149,7 +149,7 @@ signupSchema.statics.createSignupForReq = function (req) {
   return new Promise((resolve, reject) => {
     logger.debug(`Signup.post(${userId}, ${campaignId}, ${keyword})`);
 
-    return rogue.postSignupForReq(req)
+    return rogue.createSignupForReq(req)
       .then((signup) => {
         const signupId = signup.data.signup_id;
 

--- a/config/lib/rogue.js
+++ b/config/lib/rogue.js
@@ -6,5 +6,5 @@ module.exports = {
     baseUri: process.env.DS_ROGUE_API_BASEURI,
     apiKey: process.env.DS_ROGUE_API_KEY,
   },
-  source: process.env.DS_API_POST_SOURCE || 'sms-mobilecommons',
+  source: process.env.DS_API_POST_SOURCE || 'sms',
 };

--- a/config/lib/rogue.js
+++ b/config/lib/rogue.js
@@ -1,12 +1,10 @@
 'use strict';
 
-const helpers = require('../../lib/helpers');
-
 module.exports = {
   apiKeyHeader: 'X-DS-Rogue-API-Key',
   clientOptions: {
     baseUri: process.env.DS_ROGUE_API_BASEURI,
     apiKey: process.env.DS_ROGUE_API_KEY,
   },
-  source: helpers.getCampaignActivitySource(),
+  source: process.env.DS_API_POST_SOURCE || 'sms-mobilecommons',
 };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -397,13 +397,3 @@ module.exports.trimReportbackText = function (input) {
 
   return input;
 };
-
-/**
- * Returns source value to pass when posting Campaign Activity (Signups, Reportbacks) to DS API.
- * @return {string}
- */
-module.exports.getCampaignActivitySource = function () {
-  const source = process.env.DS_API_POST_SOURCE || 'sms-mobilecommons';
-  return source;
-};
-

--- a/lib/middleware/draft-completed.js
+++ b/lib/middleware/draft-completed.js
@@ -6,7 +6,7 @@ const replies = require('../conversation/replies');
 
 module.exports = function postDraftSubmission() {
   return (req, res) => {
-    req.signup.postDraftReportbackSubmission()
+    req.signup.createPostForReq(req)
       .then(() => {
         helpers.handleTimeout(req, res);
 

--- a/lib/rogue.js
+++ b/lib/rogue.js
@@ -56,7 +56,7 @@ module.exports.createSignupForReq = function (req) {
  * @return {Buffer}
  */
 function fetchDataForImageUrl(url) {
-  logger.debug(`getDataForImageUrl:${url}`);
+  logger.debug(`rogue.getDataForImageUrl:${url}`);
 
   // @see https://github.com/visionmedia/superagent/issues/871#issuecomment-286199206
   return superagent.get(url)

--- a/lib/rogue.js
+++ b/lib/rogue.js
@@ -5,6 +5,7 @@
  */
 const logger = require('winston');
 const superagent = require('superagent');
+const ip = require('ip');
 
 const defaultConfig = require('../config/lib/rogue');
 
@@ -19,8 +20,24 @@ function executePost(endpoint, data) {
     .post(url)
     .set(defaultConfig.apiKeyHeader, defaultConfig.clientOptions.apiKey)
     .send(data)
-    .then(res => res.body)
-    .catch(err => err);
+    .then(res => res.body);
+}
+
+/**
+ * @param {object} req
+ * @return {object}
+ */
+function getDefaultPayloadForReq(req) {
+  const campaign = req.campaign;
+  const userId = req.userId;
+  // @see https://github.com/DoSomething/rogue/blob/master/documentation/endpoints/signups.md#signups
+  const data = {
+    source: defaultConfig.source,
+    campaign_id: Number(campaign.id),
+    campaign_run_id: Number(campaign.currentCampaignRun.id),
+    northstar_id: userId,
+  };
+  return data;
 }
 
 /**
@@ -28,18 +45,45 @@ function executePost(endpoint, data) {
  * @return {Promise}
  */
 module.exports.createSignupForReq = function (req) {
-  const campaign = req.campaign;
-  const userId = req.userId;
-
-  // @see https://github.com/DoSomething/rogue/blob/master/documentation/endpoints/signups.md#signups
-  const data = {
-    source: defaultConfig.source,
-    // TODO: This should happen in Phoenix JS.
-    campaign_id: Number(campaign.id),
-    campaign_run_id: Number(campaign.currentCampaignRun.id),
-    northstar_id: userId,
-  };
+  const data = getDefaultPayloadForReq(req);
   logger.debug('rogue.createSignupForReq', { data });
 
   return executePost('signups', data);
+};
+
+/**
+ * @param {string} url
+ * @return {Buffer}
+ */
+function fetchDataForImageUrl(url) {
+  logger.debug(`getDataForImageUrl:${url}`);
+
+  // @see https://github.com/visionmedia/superagent/issues/871#issuecomment-286199206
+  return superagent.get(url)
+    .buffer(true)
+    .parse(superagent.parse.image);
+}
+
+/**
+ * @param {object} req
+ * @return {Promise}
+ */
+module.exports.createPostForReq = function (req) {
+  const data = getDefaultPayloadForReq(req);
+  const draft = req.signup.draft_reportback_submission;
+
+  // @see https://github.com/DoSomething/rogue/blob/master/documentation/endpoints/posts.md
+  data.quantity = draft.quantity;
+  data.caption = draft.caption;
+  data.remote_addr = ip.address();
+  if (draft.why_participated) {
+    data.why_participated = draft.why_participated;
+  }
+  logger.debug('rogue.createPostForReq', { data });
+
+  return fetchDataForImageUrl(draft.photo)
+    .then((res) => {
+      data.file = res.body.toString('base64');
+      return executePost('posts', data);
+    });
 };

--- a/lib/rogue.js
+++ b/lib/rogue.js
@@ -27,7 +27,7 @@ function executePost(endpoint, data) {
  * @param {object} req
  * @return {Promise}
  */
-module.exports.postSignupForReq = function (req) {
+module.exports.createSignupForReq = function (req) {
   const campaign = req.campaign;
   const userId = req.userId;
 
@@ -39,7 +39,7 @@ module.exports.postSignupForReq = function (req) {
     campaign_run_id: Number(campaign.currentCampaignRun.id),
     northstar_id: userId,
   };
-  logger.debug('rogue.postSignupForReq', { data });
+  logger.debug('rogue.createSignupForReq', { data });
 
   return executePost('signups', data);
 };

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "express": "^4.10.2",
     "file-exists": "^4.0.0",
     "html-entities": "^1.1.1",
+    "ip": "^1.1.5",
     "mongoose": "~4.6.1",
     "newrelic": "2.0.0",
     "node-request-retry": "^1.0.0",


### PR DESCRIPTION
#### What's this PR do?
* Posts a completed Reportback Submission to Rogue Posts endpoint instead of Phoenix Signups.
    * Requires passing a Base64 file string of the Reportback image

* Renames `rogue.postSignupForReq` (introduced in #974) to `rogue.createSignupForReq`, so our Reportback function can be called `rogue.createPostForReq` instead of `rogue.postPostForReq`

#### How should this be reviewed?
Complete a campaign via Consolebot, or staging upon deploy.

#### Any background context you want to provide?
Up next: 
* Remove Emoji Strip, #971 
* Fetch current Signup from Rogue instead of Phoenix (third task in #970)
 
#### Relevant tickets
Second task in #970 

#### Checklist
- [x] Tested on staging.
