### PR TITLE
Remove Emoji Strip, Error Occurred template

### DIFF
--- a/config/lib/contentful.js
+++ b/config/lib/contentful.js
@@ -30,15 +30,16 @@ module.exports = {
     invalidCompletedMenuCommand: 'invalidCompletedMenuCommandMessage',
     memberSupport: 'memberSupportMessage',
     campaignClosed: 'campaignClosedMessage',
-    errorOccurred: 'errorOccurredMessage',
     askSignup: 'askSignupMessage',
     declinedSignup: 'declinedSignupMessage',
     invalidAskSignupResponse: 'invalidSignupResponseMessage',
     askContinue: 'askContinueMessage',
     declinedContinue: 'declinedContinueMessage',
     invalidAskContinueResponse: 'invalidContinueResponseMessage',
-    // TODO: Remove these when Conversations goes live.
-    // They won't be used anymore, so we didn't bother to rename these.
+    // TODO: When Conversation goes live, we'll either be removing these to send messages from
+    // Customer.io, or we'll want to rename them to camelCase if we send Relative Reminders via
+    // Conversations POST /send-message.
+    // @see https://github.com/DoSomething/gambit-conversations/issues/79
     scheduled_relative_to_signup_date: 'scheduledRelativeToSignupDateMessage',
     scheduled_relative_to_reportback_date: 'scheduledRelativeToReportbackDateMessage',
   },

--- a/config/middleware/receive-message/map-request-params.js
+++ b/config/middleware/receive-message/map-request-params.js
@@ -4,7 +4,6 @@ const configVars = {};
 
 configVars.client = 'gambit-conversations';
 configVars.containerProperty = 'body';
-configVars.emojiStripParam = 'text';
 configVars.lowercaseParam = 'text';
 configVars.paramsMap = {
   keyword: 'keyword',

--- a/lib/conversation/replies.js
+++ b/lib/conversation/replies.js
@@ -63,38 +63,6 @@ function renderEndConversationMsg(fn) {
  * Decorator.
  * Returns passed function wrapped with functionality to retrieve and inject a rendered
  * version of the message given a replyTemplate string and args object as arguments.
- * It sends an error response to the user.
- *
- * @param  {function} fn function to be wrapped.
- * @return {function}    wrapped function
- */
-function renderEndConversationWithErrorMsg(fn) {
-  return (replyTemplate, args) => {
-    logger.verbose('renderEndConversationWithErrorMsg()');
-    stathat.postStat(`campaignbot:${replyTemplate}`);
-    helpers.addBlinkSuppressHeaders(args.res);
-    logger.debug(`Blink supress headers set to: ${args.res.get('x-blink-retry-suppress')}`);
-
-    if (!args.req.user) {
-      return helpers.sendErrorResponse(args.res, args.error);
-    }
-
-    return helpers.renderMessageTemplate(args.req, replyTemplate)
-      .then((replyText) => {
-        args.replyText = replyText;
-        fn(args);
-        BotRequest.log(args.req, 'campaignbot', replyTemplate, replyText);
-        return helpers.sendErrorResponse(args.res, args.error);
-      })
-      .catch(err => helpers.sendErrorResponse(args.res, err));
-  };
-}
-
-
-/**
- * Decorator.
- * Returns passed function wrapped with functionality to retrieve and inject a rendered
- * version of the message given a replyTemplate string and args object as arguments.
  * It also saves the campaignId as the user's current_campaign
  * It sends a success response to the user.
  *
@@ -322,20 +290,6 @@ module.exports.memberSupport = function memberSupport(args) {
   return new Command(
     renderEndConversationMsg(actions.endConversation),
     ['memberSupport', args]);
-};
-
-
-/**
- * Ends conversation with user.
- * It responds with a rendered errorOccurred message
- *
- * @param  {object} args
- * @return {Command}
- */
-module.exports.legacyBugErrorOcurred = function legacyBugErrorOcurred(args) {
-  return new Command(
-    renderEndConversationWithErrorMsg(actions.endConversation),
-    ['errorOccurred', args]);
 };
 
 /**

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -11,9 +11,6 @@ const underscore = require('underscore');
 
 const contentful = require('./contentful');
 const stathat = require('./stathat');
-const ReplyDispatcher = require('./conversation/reply-dispatcher');
-const replies = require('./conversation/replies');
-
 
 /**
  * addBlinkSuppressHeaders
@@ -24,16 +21,6 @@ const replies = require('./conversation/replies');
 module.exports.addBlinkSuppressHeaders = function addBlinkSuppressHeaders(res) {
   newrelic.addCustomParameters({ blinkSuppressRetry: true });
   return res.setHeader('x-blink-retry-suppress', true);
-};
-
-/**
- * Handles a Phoenix POST error, firing the legacyBugErrorOcurred reply if we shouldn't retry.
- */
-module.exports.handlePhoenixPostError = function handlePhoenixPostError(req, res, err) {
-  if (err.message.includes('API response is false')) {
-    return ReplyDispatcher.execute(replies.legacyBugErrorOcurred({ req, res, error: err }));
-  }
-  return module.exports.sendErrorResponse(res, err);
 };
 
 /**

--- a/lib/middleware/draft-completed.js
+++ b/lib/middleware/draft-completed.js
@@ -12,6 +12,6 @@ module.exports = function postDraftSubmission() {
 
         return ReplyDispatcher.execute(replies.menuCompleted({ req, res }));
       })
-      .catch(err => helpers.handlePhoenixPostError(req, res, err));
+      .catch(err => helpers.sendErrorResponse(res, err));
   };
 };

--- a/lib/middleware/map-request-params.js
+++ b/lib/middleware/map-request-params.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const emojiStrip = require('emoji-strip');
 const newrelic = require('newrelic');
 const logger = require('winston');
 const Promise = require('bluebird');
@@ -96,10 +95,6 @@ module.exports = function mapRequestParams(config = {}) {
      */
     Object.keys(config.paramsMap).forEach((param) => {
       let value = req[config.containerProperty][param];
-
-      if (value && param === config.emojiStripParam) {
-        value = emojiStrip(value || '');
-      }
 
       if (value && param === config.lowercaseParam) {
         value = value.toLowerCase();

--- a/lib/middleware/signup-create.js
+++ b/lib/middleware/signup-create.js
@@ -16,6 +16,6 @@ module.exports = function createNewSignup() {
 
         return next();
       })
-      .catch(err => helpers.handlePhoenixPostError(req, res, err));
+      .catch(err => helpers.sendErrorResponse(res, err));
   };
 };

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "connect-timeout": "^1.8.0",
     "contentful": "^3.8.0",
     "dotenv": "^4.0.0",
-    "emoji-strip": "^1.0.1",
     "express": "^4.10.2",
     "file-exists": "^4.0.0",
     "html-entities": "^1.1.1",

--- a/test/lib/helpers.test.js
+++ b/test/lib/helpers.test.js
@@ -78,16 +78,6 @@ test.afterEach((t) => {
  * Tests
  */
 
-// handlePhoenixPostError
-test('handlePhoenixPostError should send error response', (t) => {
-  // setup
-  const error = { status: 500, message: 'error' };
-
-  // test
-  helpers.handlePhoenixPostError(t.context.req, t.context.res, error);
-  helpers.sendErrorResponse.should.have.been.calledWith(t.context.res, error);
-});
-
 // replacePhoenixCampaignVars
 test('replacePhoenixCampaignVars', async () => {
   const phoenixCampaign = stubs.getPhoenixCampaign();

--- a/test/lib/middleware/map-request-params.test.js
+++ b/test/lib/middleware/map-request-params.test.js
@@ -50,25 +50,6 @@ test.afterEach((t) => {
   t.context = {};
 });
 
-test('mapRequestParams should strip emojies from the args param when mapping', async (t) => {
-  // setup
-  const next = sinon.stub();
-  const middleware = mapRequestParams(config);
-  const emojiStripParam = config.emojiStripParam;
-  const toLowerCaseParam = config.lowercaseParam;
-  const prefix = 'catdot!';
-  const emojiStripValue = `${prefix}🐱🐶`;
-  const toLowerCaseValue = 'DOSOMETHING';
-  t.context.req[config.containerProperty][emojiStripParam] = emojiStripValue;
-  t.context.req[config.containerProperty][toLowerCaseParam] = toLowerCaseValue;
-
-  // test
-  await middleware(t.context.req, t.context.res, next);
-  t.context.req[config.paramsMap[emojiStripParam]].should.be.equal(prefix);
-  t.context.req[config.paramsMap[toLowerCaseParam]].should.be.equal(toLowerCaseValue.toLowerCase());
-  next.should.have.been.called;
-});
-
 test('mapRequestParams should populate the contentful broadcast object and campaignId when it gets a broadcast_id', async (t) => {
   // setup
   const next = sinon.stub();


### PR DESCRIPTION
#### What's this PR do?
Removes the emoji strip package, and corresponding `helpers.handlePhoenixPostError`, `replies. renderEndConversationWithErrorMsg`  functions that we added to strip emoji in #912, #913 

#### How should this be reviewed?
Post emojis! Although they're showing up as ???'s in Rogue per https://dosomething.slack.com/archives/C0YGXUE01/p1507739954000299

#### Any background context you want to provide?
Now that we're no longer posting to the Phoenix proxy in #976, we no longer need to check for the cryptic [`'API response is false'` returned from Phoenix JS](https://github.com/DoSomething/phoenix-js/blob/f086c979cb1cba351512ea83e8450fd25a6cafa4/lib/phoenix-endpoint.js#L103).

Once #976 is merged, I'll update this PR to merge into `develop` instead of the `reportback` branch.

#### Relevant tickets
#970 

#### Checklist
- [x] Tested on staging.
