### PR TITLE
Fetch Signups from Rogue

### DIFF
--- a/app/models/Signup.js
+++ b/app/models/Signup.js
@@ -94,14 +94,16 @@ signupSchema.statics.lookupById = function (id) {
  */
 signupSchema.statics.lookupCurrent = function (userId, campaignRunId) {
   const model = this;
-  const statName = 'rogue: GET signups';
 
   return new Promise((resolve, reject) => {
     logger.debug(`Signup.lookupCurrent(${userId}, ${campaignRunId})`);
 
     return rogue.fetchActivityForUserIdAndCampaignRunId(userId, campaignRunId)
       .then((res) => {
-        stathat.postStat(`${statName} 200`);
+        if (res.data.length < 1) {
+          return resolve(false);
+        }
+
         const signupData = parseActivityResponse(res);
         const signupId = signupData.id;
         logger.info(`Signup.lookupCurrent signup:${signupId}`);
@@ -112,7 +114,6 @@ signupSchema.statics.lookupCurrent = function (userId, campaignRunId) {
       })
       .then(signupDoc => resolve(signupDoc))
       .catch((err) => {
-        stathat.postStatWithError(statName, err);
         const scope = err;
         scope.message = `Signup.lookupCurrent error:${err.message}`;
 

--- a/app/models/Signup.js
+++ b/app/models/Signup.js
@@ -131,7 +131,6 @@ signupSchema.statics.lookupCurrentSignupForReq = function (req) {
  */
 signupSchema.statics.createSignupForReq = function (req) {
   const model = this;
-  const statName = 'phoenix: POST signups';
   const keyword = req.keyword;
   const userId = req.userId;
   const campaignId = req.campaignId;
@@ -143,8 +142,6 @@ signupSchema.statics.createSignupForReq = function (req) {
     return rogue.createSignupForReq(req)
       .then((signup) => {
         const signupId = signup.data.signup_id;
-
-        stathat.postStat(`${statName} 200`);
         if (keyword) {
           stathat.postStat(`signup: ${keyword}`);
         }
@@ -168,7 +165,6 @@ signupSchema.statics.createSignupForReq = function (req) {
       })
       .then(signupDoc => resolve(signupDoc))
       .catch((err) => {
-        stathat.postStatWithError(statName, err);
         const scope = err;
         scope.message = `Signup.post error:${err.message}`;
 
@@ -221,15 +217,12 @@ signupSchema.methods.createPostForReq = function (req) {
   const signup = this;
   const submission = signup.draft_reportback_submission;
   logger.debug(`Signup.createPostForReq signup:${this._id}`);
-
   const dateSubmitted = Date.now();
-  const statName = 'phoenix: POST reportbacks';
 
   return new Promise((resolve, reject) => {
     rogue.createPostForReq(req)
       .then((res) => {
         const reportbackId = res.data.id;
-        stathat.postStat(`${statName} 200`);
 
         signup.reportback = reportbackId;
         signup.total_quantity_submitted = Number(submission.quantity);

--- a/app/models/Signup.js
+++ b/app/models/Signup.js
@@ -92,8 +92,10 @@ signupSchema.statics.lookupById = function (id) {
  * @param {string} userId
  * @param {number} campaignId.
  */
-signupSchema.statics.lookupCurrent = function (userId, campaignRunId) {
+signupSchema.statics.lookupCurrentSignupForReq = function (req) {
   const model = this;
+  const userId = req.userId;
+  const campaignRunId = req.campaign.currentCampaignRun.id;
 
   return new Promise((resolve, reject) => {
     logger.debug(`Signup.lookupCurrent(${userId}, ${campaignRunId})`);

--- a/app/models/Signup.js
+++ b/app/models/Signup.js
@@ -48,7 +48,7 @@ const signupSchema = new mongoose.Schema({
  * @param {object} activityData - Rogue API response.data
  * @return {object}
  */
-function parseActivityResponse(activityData) {
+function parseActivityData(activityData) {
   const data = activityData[0];
   const result = {
     id: data.signup_id,
@@ -78,7 +78,7 @@ signupSchema.statics.lookupById = function (id) {
         if (res.data.length < 1) {
           throw new Error(notFoundMessage);
         }
-        const signupData = parseActivityResponse(res.data);
+        const signupData = parseActivityData(res.data);
         const signupId = signupData.id;
 
         return model.findOneAndUpdate({ _id: signupId }, signupData, upsertOptions).exec();
@@ -114,7 +114,7 @@ signupSchema.statics.lookupCurrentSignupForReq = function (req) {
           return resolve(false);
         }
 
-        const signupData = parseActivityResponse(res);
+        const signupData = parseActivityData(res.data);
         const signupId = signupData.id;
         logger.info(`Signup.lookupCurrent signup:${signupId}`);
 

--- a/lib/middleware/signup-get.js
+++ b/lib/middleware/signup-get.js
@@ -4,8 +4,10 @@ const helpers = require('../helpers');
 const Signup = require('../../app/models/Signup.js');
 
 module.exports = function getSignup() {
-  return (req, res, next) => { // eslint-disable-line arrow-body-style
-    return Signup.lookupCurrent(req.userId, req.campaignId)
+  return (req, res, next) => {
+    const campaignRunId = req.campaign.currentCampaignRun.id;
+
+    return Signup.lookupCurrent(req.userId, campaignRunId)
       .then((signup) => {
         helpers.handleTimeout(req, res);
 

--- a/lib/middleware/signup-get.js
+++ b/lib/middleware/signup-get.js
@@ -4,10 +4,10 @@ const helpers = require('../helpers');
 const Signup = require('../../app/models/Signup.js');
 
 module.exports = function getSignup() {
-  return (req, res, next) => {
-    const campaignRunId = req.campaign.currentCampaignRun.id;
-
-    return Signup.lookupCurrent(req.userId, campaignRunId)
+  return (req, res, next) => { // eslint-disable-line arrow-body-style
+    // TODO: Our middleware test fails with 'helpers.sendErrorResponse.should.have.been.called' if
+    // we don't explicitly use return here.
+    return Signup.lookupCurrentSignupForReq(req)
       .then((signup) => {
         helpers.handleTimeout(req, res);
 

--- a/lib/rogue.js
+++ b/lib/rogue.js
@@ -9,16 +9,34 @@ const ip = require('ip');
 
 const defaultConfig = require('../config/lib/rogue');
 
+const baseUri = defaultConfig.clientOptions.baseUri;
+const apiHeader = defaultConfig.apiKeyHeader;
+const apiKey = defaultConfig.clientOptions.apiKey;
+
+/**
+ * @param {string} endpoint
+ * @param {object} data
+ */
+function executeGet(endpoint, query = {}) {
+  const url = `${baseUri}/${endpoint}`;
+
+  return superagent
+    .get(url)
+    .query(query)
+    .set(apiHeader, apiKey)
+    .then(res => res.body);
+}
+
 /**
  * @param {string} endpoint
  * @param {object} data
  */
 function executePost(endpoint, data) {
-  const url = `${defaultConfig.clientOptions.baseUri}/${endpoint}`;
+  const url = `${baseUri}/${endpoint}`;
 
   return superagent
     .post(url)
-    .set(defaultConfig.apiKeyHeader, defaultConfig.clientOptions.apiKey)
+    .set(apiHeader, apiKey)
     .send(data)
     .then(res => res.body);
 }
@@ -86,4 +104,10 @@ module.exports.createPostForReq = function (req) {
       data.file = res.body.toString('base64');
       return executePost('posts', data);
     });
+};
+
+module.exports.fetchActivityForUserIdAndCampaignRunId = function (userId, campaignRunId) {
+  const query = `filter[northstar_id]=${userId}&filter[campaign_run_id]=${campaignRunId}`;
+
+  return executeGet('activity', query);
 };

--- a/lib/rogue.js
+++ b/lib/rogue.js
@@ -19,7 +19,6 @@ const apiKey = defaultConfig.clientOptions.apiKey;
  */
 function executeGet(endpoint, query = {}) {
   const url = `${baseUri}/${endpoint}`;
-  logger.debug('executeGet', { url, query });
 
   return superagent
     .get(url)
@@ -112,6 +111,7 @@ module.exports.createPostForReq = function (req) {
  * return {Promise}
  */
 module.exports.fetchActivityForSignupId = function (signupId) {
+  logger.debug(`rogue.fetchActivity signupId=${signupId}`);
   const query = `filter[id]=${signupId}`;
 
   return executeGet('activity', query);
@@ -123,6 +123,7 @@ module.exports.fetchActivityForSignupId = function (signupId) {
  * return {Promise}
  */
 module.exports.fetchActivityForUserIdAndCampaignRunId = function (userId, campaignRunId) {
+  logger.debug(`rogue.fetchActivity userId=${userId} campaignRunId=${campaignRunId}`);
   const query = `filter[northstar_id]=${userId}&filter[campaign_run_id]=${campaignRunId}`;
 
   return executeGet('activity', query);

--- a/lib/rogue.js
+++ b/lib/rogue.js
@@ -19,6 +19,7 @@ const apiKey = defaultConfig.clientOptions.apiKey;
  */
 function executeGet(endpoint, query = {}) {
   const url = `${baseUri}/${endpoint}`;
+  logger.debug('executeGet', { url, query });
 
   return superagent
     .get(url)
@@ -106,6 +107,21 @@ module.exports.createPostForReq = function (req) {
     });
 };
 
+/**
+ * @param {number} signupId
+ * return {Promise}
+ */
+module.exports.fetchActivityForSignupId = function (signupId) {
+  const query = `filter[id]=${signupId}`;
+
+  return executeGet('activity', query);
+};
+
+/**
+ * @param {string} userId
+ * @param {number} campaignRunId
+ * return {Promise}
+ */
 module.exports.fetchActivityForUserIdAndCampaignRunId = function (userId, campaignRunId) {
   const query = `filter[northstar_id]=${userId}&filter[campaign_run_id]=${campaignRunId}`;
 

--- a/test/lib/middleware/signup-get.test.js
+++ b/test/lib/middleware/signup-get.test.js
@@ -52,7 +52,7 @@ test('getSignup should inject signup, draftSubmission into the req object', asyn
   const next = sinon.stub();
   const middleware = getSignup();
   const signup = stubs.getSignupWithDraft();
-  sandbox.stub(Signup, 'lookupCurrent').returns(signupLookupStub);
+  sandbox.stub(Signup, 'lookupCurrentSignupForReq').returns(signupLookupStub);
 
   // test
   await middleware(t.context.req, t.context.res, next);
@@ -66,7 +66,7 @@ test('getSignup should resolve to false if a Signup was not found', async (t) =>
   // setup
   const next = sinon.stub();
   const middleware = getSignup();
-  sandbox.stub(Signup, 'lookupCurrent').returns(signupLookupNotFoundStub);
+  sandbox.stub(Signup, 'lookupCurrentSignupForReq').returns(signupLookupNotFoundStub);
 
   // test
   await middleware(t.context.req, t.context.res, next);
@@ -79,7 +79,7 @@ test('getSignup should resolve to false if a Signup was not found', async (t) =>
 test('getSignup should call sendErrorResponse when an error occurs', async (t) => {
   // setup
   const next = sinon.stub();
-  sandbox.stub(Signup, 'lookupCurrent').returns(signupLookupFailStub);
+  sandbox.stub(Signup, 'lookupCurrentSignupForReq').returns(signupLookupFailStub);
   sandbox.stub(helpers, 'sendErrorResponse').returns(sendErrorResponseStub);
   const middleware = getSignup();
 


### PR DESCRIPTION
#### What's this PR do?
Refactors the Phoenix `GET /signups` request to Rogue `GET /activity`

This PR is to merge into the `issue-971` branch, will update to `develop` once #977 is merged.

#### How should this be reviewed?

* Consolebot: Signup, reportback, repeat for a different Campaign.
* `POST /signups` with valid Signup ID (signup message is sent), invalid Signup ID's (404 is returned)

#### Any background context you want to provide?
Farewell, Phoenix Ashes proxy 👋 

#### Relevant tickets
Fixes #970 

#### Checklist
- [x] Tested on staging.

