### PR TITLE
GET /campaigns/:id override fix

### DIFF
--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -210,23 +210,24 @@ module.exports.renderMessageForPhoenixCampaign = function (phoenixCampaign, msgT
  */
 module.exports.getAllTemplatesForCampaignId = function getAllTemplatesForCampaignId(campaignId) {
   return new Promise((resolve, reject) => {
-    const campaignFieldNames = Object.keys(config.campaignFields);
+    const templateNames = Object.keys(config.campaignFields);
     const campaignContent = {};
     const templates = {};
+    // TODO: Instead of making two Contentful requests (first: for campaignId, second: for default)
+    // use getEntries() with an IN operator get both Contentful Campaigns in a single request.
+    // @see https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters/inclusion
     return exports.fetchCampaign(campaignId)
       .then((contentfulCampaign) => {
         campaignContent.overrides = contentfulCampaign.fields;
-        // TODO: Pass the default Campaign, to avoid fetching every time we call this.
-        // GET campaigns could fetch default once, instead of every time we get each Campaign.
         return exports.fetchCampaign(defaultCampaignId);
       })
       .then((defaultContentfulCampaign) => {
         campaignContent.defaults = defaultContentfulCampaign.fields;
-        campaignFieldNames.forEach((templateName) => {
+        templateNames.forEach((templateName) => {
           const fieldName = config.campaignFields[templateName];
           templates[templateName] = {};
 
-          if (campaignContent.overrides[templateName]) {
+          if (campaignContent.overrides[fieldName]) {
             templates[templateName].override = true;
             templates[templateName].raw = campaignContent.overrides[fieldName];
           } else {


### PR DESCRIPTION
#### What's this PR do?
Fixes #981: A bug introduced by the `config.campaignFields` naming changes in #958, where the `response.data.templates` of a `GET /campaigns/:id` request doesn't include any Campaign overrides, only returns rendered templates of the default Contentful Campaign (`campaignID=default`)

#### How should this be reviewed?
Verify the `gambitSignupMenu` template is overridden in http://ds-mdata-responder-staging.herokuapp.com/v1/campaigns/7

#### Relevant tickets
Fixes #981 

#### Checklist
- [x] Tested on staging.
