### PR TITLE
Deprecates Phoenix JS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,8 +16,6 @@ DS_MESSAGING_GROUPS_API_KEY=totallysecret
 DS_NORTHSTAR_API_BASEURI=https://northstar-fake.dosomething.org/v1
 DS_NORTHSTAR_API_KEY=totallysecret
 DS_PHOENIX_API_BASEURI=https://fake.dosomething.org/api/v1
-DS_PHOENIX_API_USERNAME=puppet.sloth@dosomething.org
-DS_PHOENIX_API_PASSWORD=totallysecret
 DS_ROGUE_API_BASEURI=https://rogue-fake.dosomething.org/api/v2
 DS_ROGUE_API_KEY=totallysecret
 

--- a/config/lib/phoenix.js
+++ b/config/lib/phoenix.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+  clientOptions: {
+    baseUri: process.env.DS_PHOENIX_API_BASEURI,
+  },
+};

--- a/config/lib/phoenix.js
+++ b/config/lib/phoenix.js
@@ -2,6 +2,6 @@
 
 module.exports = {
   clientOptions: {
-    baseUri: process.env.DS_PHOENIX_API_BASEURI,
+    baseUri: process.env.DS_PHOENIX_API_BASEURI || 'https://thor.dosomething.org/api/v1',
   },
 };

--- a/lib/phoenix.js
+++ b/lib/phoenix.js
@@ -3,24 +3,52 @@
 /**
  * Imports.
  */
-const PhoenixClient = require('@dosomething/phoenix-js');
+const superagent = require('superagent');
 const logger = require('winston');
 
+const defaultConfig = require('../config/lib/phoenix');
+
 /**
- * Setup.
+ * @param {string} endpoint
+ * @param {object} query
+ * @param {object} data
  */
-let client;
-try {
-  client = new PhoenixClient({
-    baseURI: process.env.DS_PHOENIX_API_BASEURI,
-    username: process.env.DS_PHOENIX_API_USERNAME,
-    password: process.env.DS_PHOENIX_API_PASSWORD,
-  });
-} catch (err) {
-  logger.error(`phoenix error:${err.message}`);
+function executeGet(endpoint, query = {}) {
+  const baseUri = defaultConfig.clientOptions.baseUri;
+  const url = `${baseUri}/${endpoint}`;
+
+  return superagent
+    .get(url)
+    .query(query)
+    .then(res => res.body);
 }
 
-module.exports.client = client;
+/**
+ * @param {object} data
+ * @return {object}
+ */
+function parsePhoenixCampaign(data) {
+  const result = {};
+  result.id = data.id;
+  result.title = data.title;
+  result.tagline = data.tagline;
+  result.status = data.status;
+  result.currentCampaignRun = {
+    id: data.campaign_runs.current.en.id,
+  };
+  const rbInfo = data.reportback_info;
+  result.reportbackInfo = {
+    confirmationMessage: rbInfo.confirmation_message,
+    noun: rbInfo.noun,
+    verb: rbInfo.verb,
+  };
+  result.facts = {
+    problem: data.facts.problem,
+  };
+  logger.verbose('parsePhoenixCampaign', result);
+
+  return result;
+}
 
 /**
  * Returns given DS Campaign object is closed.
@@ -40,10 +68,11 @@ module.exports.isClosedCampaign = function (phoenixCampaign) {
  */
 module.exports.fetchCampaign = function (campaignId) {
   logger.debug(`phoenix.fetchCampaign:${campaignId}`);
+  const endpoint = `campaigns/${campaignId}`;
 
   return new Promise((resolve, reject) => {
-    client.Campaigns.get(campaignId)
-      .then(phoenixCampaign => resolve(phoenixCampaign))
+    executeGet(endpoint)
+      .then(res => resolve(parsePhoenixCampaign(res.data)))
       .catch((err) => {
         const scope = err;
         scope.message = `phoenix.fetchCampaign ${err.message}`;

--- a/lib/phoenix.js
+++ b/lib/phoenix.js
@@ -51,6 +51,17 @@ module.exports.parsePhoenixCampaign = function (data) {
 };
 
 /**
+ * @param {object} data
+ * @return {object}
+ */
+module.exports.parsePhoenixError = function (err) {
+  const scope = err;
+  scope.message = `phoenix ${err.message}`;
+
+  return scope;
+};
+
+/**
  * Returns given DS Campaign object is closed.
  * TODO: When Conversations goes live, this won't be needed.
  *
@@ -74,11 +85,6 @@ module.exports.fetchCampaign = function (campaignId) {
   return new Promise((resolve, reject) => {
     executeGet(endpoint)
       .then(res => resolve(exports.parsePhoenixCampaign(res.data)))
-      .catch((err) => {
-        const scope = err;
-        scope.message = `phoenix.fetchCampaign ${err.message}`;
-
-        return reject(scope);
-      });
+      .catch(err => reject(exports.parsePhoenixError(err)));
   });
 };

--- a/lib/phoenix.js
+++ b/lib/phoenix.js
@@ -27,7 +27,7 @@ function executeGet(endpoint, query = {}) {
  * @param {object} data
  * @return {object}
  */
-function parsePhoenixCampaign(data) {
+module.exports.parsePhoenixCampaign = function (data) {
   const result = {};
   result.id = data.id;
   result.title = data.title;
@@ -48,10 +48,11 @@ function parsePhoenixCampaign(data) {
   logger.verbose('parsePhoenixCampaign', result);
 
   return result;
-}
+};
 
 /**
  * Returns given DS Campaign object is closed.
+ * TODO: When Conversations goes live, this won't be needed.
  *
  * @param {Object} phoenixCampaign
  * @return {boolean}
@@ -72,7 +73,7 @@ module.exports.fetchCampaign = function (campaignId) {
 
   return new Promise((resolve, reject) => {
     executeGet(endpoint)
-      .then(res => resolve(parsePhoenixCampaign(res.data)))
+      .then(res => resolve(exports.parsePhoenixCampaign(res.data)))
       .catch((err) => {
         const scope = err;
         scope.message = `phoenix.fetchCampaign ${err.message}`;

--- a/lib/rogue.js
+++ b/lib/rogue.js
@@ -15,6 +15,7 @@ const apiKey = defaultConfig.clientOptions.apiKey;
 
 /**
  * @param {string} endpoint
+ * @param {object} query
  * @param {object} data
  */
 function executeGet(endpoint, query = {}) {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
   },
   "dependencies": {
     "@dosomething/northstar-js": "1.0.0",
-    "@dosomething/phoenix-js": "git://github.com/DoSomething/phoenix-js.git",
     "aws-sdk": "2.36.0",
     "bluebird": "^3.4.6",
     "body-parser": "^1.9.2",

--- a/test/lib/phoenix.test.js
+++ b/test/lib/phoenix.test.js
@@ -1,8 +1,35 @@
 'use strict';
 
 require('dotenv').config();
-// const phoenix = require('../../lib/phoenix');
-const test = require('ava');
-// const chai = require('chai');
 
-test.todo('placeholder');
+const test = require('ava');
+const chai = require('chai');
+const sinonChai = require('sinon-chai');
+const sinon = require('sinon');
+/*
+const config = require('../../config/lib/phoenix');
+const baseUri = config.clientOptions.baseUri;
+*/
+chai.should();
+chai.use(sinonChai);
+const sandbox = sinon.sandbox.create();
+
+// Module to test
+const phoenix = require('../../lib/phoenix');
+
+test('phoenix should respond to fetchCampaign', () => {
+  phoenix.should.respondTo('fetchCampaign');
+});
+
+test('phoenix should respond to isClosedCampaign', () => {
+  phoenix.should.respondTo('isClosedCampaign');
+});
+
+test('phoenix should call handleSuccess on successful post', async () => {
+  // setup
+  sandbox.spy(phoenix, 'parsePhoenixCampaign');
+
+  // test
+  await phoenix.fetchCampaign(7);
+  phoenix.parsePhoenixCampaign.should.have.been.called;
+});

--- a/test/lib/phoenix.test.js
+++ b/test/lib/phoenix.test.js
@@ -6,16 +6,30 @@ const test = require('ava');
 const chai = require('chai');
 const sinonChai = require('sinon-chai');
 const sinon = require('sinon');
-/*
+const nock = require('nock');
+
+// app modules
+const stubs = require('../../test/utils/stubs');
 const config = require('../../config/lib/phoenix');
+
 const baseUri = config.clientOptions.baseUri;
-*/
+const campaignId = stubs.getCampaignId();
+
 chai.should();
 chai.use(sinonChai);
 const sandbox = sinon.sandbox.create();
 
 // Module to test
 const phoenix = require('../../lib/phoenix');
+
+test.beforeEach(() => {
+  sandbox.spy(phoenix, 'parsePhoenixCampaign');
+  sandbox.spy(phoenix, 'parsePhoenixError');
+});
+
+test.afterEach(() => {
+  sandbox.restore();
+});
 
 test('phoenix should respond to fetchCampaign', () => {
   phoenix.should.respondTo('fetchCampaign');
@@ -25,11 +39,26 @@ test('phoenix should respond to isClosedCampaign', () => {
   phoenix.should.respondTo('isClosedCampaign');
 });
 
-test('phoenix should call handleSuccess on successful post', async () => {
-  // setup
-  sandbox.spy(phoenix, 'parsePhoenixCampaign');
+test('phoenix.fetchCampaign should call parsePhoenixCampaign on successt', async () => {
+  nock(baseUri)
+    .get(/$/)
+    .reply(200, stubs.phoenix.getCampaign());
 
-  // test
-  await phoenix.fetchCampaign(7);
+  await phoenix.fetchCampaign(campaignId);
   phoenix.parsePhoenixCampaign.should.have.been.called;
+});
+
+test('phoenix.fetchCampaign should call parsePhoenixError on error', async () => {
+  const message = 'Miley';
+  const status = 500;
+  nock(baseUri)
+    .get(/$/)
+    .reply(status, { error: { message } });
+
+  try {
+    await phoenix.fetchCampaign(campaignId);
+  } catch (error) {
+    error.status.should.be.equal(status);
+  }
+  phoenix.parsePhoenixError.should.have.been.called;
 });

--- a/test/stubs/phoenix/campaign.json
+++ b/test/stubs/phoenix/campaign.json
@@ -1,20 +1,172 @@
 {
-  "id": "2900",
-  "title": "Get Lucky",
-  "tagline": "Stash our fortune tellers with tips on using condoms.",
-  "status": "active",
-  "uri": "https://thor.dosomething.org/api/v1/campaigns/2900",
-  "type": "campaign",
-  "currentCampaignRun": {
-    "id": "6477"
-  },
-  "reportbackInfo": {
-    "confirmationMessage": "Score! Thanks for telling people what's up with condoms.",
-    "copy": "Show us how you stashed these fortune tellers with ninja-like stealthiness!",
-    "noun": "fortune tellers",
-    "verb": "created"
-  },
-  "facts": {
-    "problem": "There are a surprising number of ways to improperly use a condom. Seems easy, but people mess it up all the time."
+  "data": {
+    "id": "2299",
+    "title": "Two Books Blue Books",
+    "campaign_runs": {
+      "current": {
+        "en": {
+          "id": "6441",
+          "start_date": "2015-08-27 00:00:00"
+        }
+      },
+      "past": [
+        
+      ]
+    },
+    "language": {
+      "language_code": "en",
+      "prefix": "us"
+    },
+    "translations": {
+      "original": "en",
+      "en": {
+        "language_code": "en",
+        "prefix": "us"
+      }
+    },
+    "tagline": "Host a Dr. Seuss book drive to benefit kids in family shelters.",
+    "status": "active",
+    "type": "campaign",
+    "created_at": "1402932693",
+    "updated_at": "1508298360",
+    "time_commitment": 10,
+    "cover_image": {
+      "default": {
+        "uri": "https://thor.dosomething.org/sites/default/files/styles/300x300/public/images/TwoBooksBlueBooks_hero_square.jpg?itok=NodbbPi1",
+        "sizes": {
+          "landscape": {
+            "uri": "https://thor.dosomething.org/sites/default/files/styles/1440x810/public/images/TwoBooksBlueBooks_hero_landscape.jpg?itok=MJPts5Ty"
+          },
+          "square": {
+            "uri": "https://thor.dosomething.org/sites/default/files/styles/300x300/public/images/TwoBooksBlueBooks_hero_square.jpg?itok=NodbbPi1"
+          }
+        },
+        "type": "image",
+        "dark_background": true
+      },
+      "alternate": null
+    },
+    "staff_pick": false,
+    "competition": false,
+    "facts": {
+      "problem": "In some low-income neighborhoods, there is only one book for every 300 children.",
+      "solution": "Students with easy access to books tend to score higher on achievement tests. ",
+      "sources": [
+        {
+          "formatted": "<p>Addy, Sophia, William Engelhardt, and Curtis Skinner. \"Basic Facts About Low-income Children, Children Under 18 Years, 2011.\" 2013</p>\n"
+        },
+        {
+          "formatted": "<p>Susan Neuman, Access for All: Closing the Book Gap for Children in Early Education, International Reading Association, (2001)</p>\n"
+        }
+      ]
+    },
+    "solutions": {
+      "copy": {
+        "raw": "Access to books greatly increases a student's chance of success in school! ",
+        "formatted": "<p>Access to books greatly increases a student's chance of success in school!</p>\n"
+      },
+      "support_copy": {
+        "raw": "So why Dr. Seuss? Because he’s the man with the plan, the plan to familiarize young readers with valuable literary devices, like alliteration, metaphor, symbolism and, of course, rhyme!",
+        "formatted": "<p>So why Dr. Seuss? Because he’s the man with the plan, the plan to familiarize young readers with valuable literary devices, like alliteration, metaphor, symbolism and, of course, rhyme!</p>\n"
+      }
+    },
+    "pre_step": {
+      "header": "Start the Drive! ",
+      "copy": {
+        "raw": "Always keep an eye on your inventory to ensure all the books make it to the family shelter. You don't want any Grinch stealing Christmas -- er, books.",
+        "formatted": "<p>Always keep an eye on your inventory to ensure all the books make it to the family shelter. You don't want any Grinch stealing Christmas -- er, books.</p>\n"
+      }
+    },
+    "latest_news": {
+      "latest_news": null
+    },
+    "causes": {
+      "primary": {
+        "id": "2",
+        "name": "education"
+      },
+      "secondary": [
+        {
+          "id": "2",
+          "name": "education"
+        }
+      ]
+    },
+    "action_types": {
+      "primary": {
+        "id": "7",
+        "name": "donate something"
+      },
+      "secondary": [
+        {
+          "id": "7",
+          "name": "donate something"
+        }
+      ]
+    },
+    "action_guides": [
+      {
+        "id": "2322",
+        "title": "Family Shelters Script",
+        "subtitle": null,
+        "description": "This script for calling family shelters",
+        "intro": {
+          "title": null,
+          "copy": {
+            "raw": "Use this script to guide your conversation with the local family shelter that'll receive your donations:\r\n\r\n\r\nHi (name of shelter), My name is __________ . I go to school at ____________. We were looking to donate Dr. Seuss books to your organization, and had a few questions.  \r\n\r\n1.\tWhere and when should we donate items? (If donation time falls during school hours, ask if they can make an exception for a time after the school day that would be acceptable.)  \r\n2.\tIs there a limit to the amount of books we can donate, and if so, what is that quantity?  \r\n3.\tDo you need us to fill out any paperwork before we donate, and if so, where can I find those forms?  \r\n4.\tAre there any other things that you need from us before we hold our drive?  \r\n5.\tIs there a way I should reach you other than this number if we have any other questions?  \r\n\r\nThank you for your assistance, and we’re looking forward to working with you! We’ll give a call the day before the planned drop-off/pick-up to make sure everything is set. My phone number is ____________ in case you need to contact me.  \r\nTake care, and we’ll see you soon!  \r\n\r\n...No YOU hang up. Ok byeeeeee. \r\n",
+            "formatted": "<p>Use this script to guide your conversation with the local family shelter that'll receive your donations:</p>\n\n<p>Hi (name of shelter), My name is __________ . I go to school at ____________. We were looking to donate Dr. Seuss books to your organization, and had a few questions.</p>\n\n<ol>\n<li>Where and when should we donate items? (If donation time falls during school hours, ask if they can make an exception for a time after the school day that would be acceptable.)  </li>\n<li>Is there a limit to the amount of books we can donate, and if so, what is that quantity?  </li>\n<li>Do you need us to fill out any paperwork before we donate, and if so, where can I find those forms?  </li>\n<li>Are there any other things that you need from us before we hold our drive?  </li>\n<li>Is there a way I should reach you other than this number if we have any other questions?  </li>\n</ol>\n\n<p>Thank you for your assistance, and we’re looking forward to working with you! We’ll give a call the day before the planned drop-off/pick-up to make sure everything is set. My phone number is ____________ in case you need to contact me.<br />\nTake care, and we’ll see you soon!</p>\n\n<p>...No YOU hang up. Ok byeeeeee.</p>\n"
+          }
+        },
+        "additional_text": {
+          "title": null,
+          "copy": null
+        },
+        "created_at": "1403016998",
+        "updated_at": "1446067420"
+      }
+    ],
+    "attachments": [
+      
+    ],
+    "issue": {
+      "id": "720",
+      "name": "achievement gap"
+    },
+    "tags": [
+      {
+        "id": "1302",
+        "name": "crafts"
+      }
+    ],
+    "timing": {
+      "high_season": {
+        "start": "2015-02-15T00:00:00+0000",
+        "end": "2015-03-15T00:00:00+0000"
+      },
+      "low_season": null
+    },
+    "services": {
+      "mobile_commons": {
+        "opt_in_path_id": null,
+        "friends_opt_in_path_id": null
+      },
+      "mailchimp": {
+        "grouping_id": null,
+        "group_name": null
+      }
+    },
+    "affiliates": {
+      "partners": [
+        
+      ]
+    },
+    "reportback_info": {
+      "copy": "Submit your pic to us, and do it now. You did it well, so tell us how!",
+      "confirmation_message": "Thanks for running your book drive!",
+      "noun": "Books",
+      "verb": "Collected"
+    },
+    "uri": "https://thor.dosomething.org/api/v1/campaigns/2299",
+    "magic_link_copy": null
   }
 }

--- a/test/utils/stubs.js
+++ b/test/utils/stubs.js
@@ -116,12 +116,9 @@ module.exports = {
       title: 'Two Books Blue Books',
       tagline: 'Host a Dr. Seuss book drive to benefit kids in family shelters.',
       status: 'active',
-      uri: 'https://thor.dosomething.org/api/v1/campaigns/2299',
-      type: 'campaign',
       currentCampaignRun: { id: '6441' },
       reportbackInfo: {
         confirmationMessage: 'Thanks for running your book drive!',
-        copy: 'Submit your pic to us, and do it now. You did it well, so tell us how!',
         noun: 'Books',
         verb: 'Collected',
       },
@@ -266,5 +263,10 @@ module.exports = {
     const path = `../stubs/${category}/`;
     const result = require(`${path}${name}.json`);
     return result;
+  },
+  phoenix: {
+    getCampaign: function getCampaign() {
+      return module.exports.getJSONstub('campaign', 'phoenix');
+    },
   },
 };


### PR DESCRIPTION
#### What's this PR do?

Refactors `lib/phoenix` to use `superagent` to make GET requests, instead using the [Phoenix JS](https://github.com/dosomething/phoenix-js) package. This repo is the only live project that uses Phoenix JS, it's easier maintain and debug when the code lives in the repo itself.
 
* Removes Phoenix auth credentials from `.env.example`- not needed now that #970 is live

* Starts on tests, doesn't add unit tests for `parsePhoenixCampaign` or `parsePhoenixError` for sake of keeping this PR easier to review


#### How should this be reviewed?
Sanity check a few `POST /chatbot`, `GET /campaigns`, and `GET /campaigns/:id` requests to verify a Campaign is still fetched from the Phoenix API.

#### Any background context you want to provide?
When we get around to #983, we'll want to use the Phoenix `GET /campaigns?ids=` index query to retrieve multiple Phoenix Campaigns instead of making multiple `GET /campaigns/:id` requests.

#### Relevant tickets
#983, #970 

#### Checklist
- [x] Tested on staging.
