### PR TITLE
Display campaignId in Phoenix API errors

### DIFF
--- a/lib/phoenix.js
+++ b/lib/phoenix.js
@@ -45,7 +45,6 @@ module.exports.parsePhoenixCampaign = function (data) {
   result.facts = {
     problem: data.facts.problem,
   };
-  logger.verbose('parsePhoenixCampaign', result);
 
   return result;
 };
@@ -54,9 +53,9 @@ module.exports.parsePhoenixCampaign = function (data) {
  * @param {object} data
  * @return {object}
  */
-module.exports.parsePhoenixError = function (err) {
+module.exports.parsePhoenixError = function (err, campaignId) {
   const scope = err;
-  scope.message = `phoenix ${err.message}`;
+  scope.message = `phoenix campaignId=${campaignId} error=${err.message}`;
 
   return scope;
 };
@@ -85,6 +84,6 @@ module.exports.fetchCampaign = function (campaignId) {
   return new Promise((resolve, reject) => {
     executeGet(endpoint)
       .then(res => resolve(exports.parsePhoenixCampaign(res.data)))
-      .catch(err => reject(exports.parsePhoenixError(err)));
+      .catch(err => reject(exports.parsePhoenixError(err, campaignId)));
   });
 };


### PR DESCRIPTION
#### What's this PR do?
Adds the `campaignId` to a Phoenix `GET /campaigns/:id` request to make it easier to fix Contentful keyword misconfigurations (#980)

#### Any background context you want to provide?
Real fix will be to exclude any Contentful keywords that don't have matching Phoenix Campaigns, to be handled by #983 


