### PR TITLE
Fix keyword replacement per #986

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -171,9 +171,9 @@ module.exports.generatePassword = function (text) {
 };
 
 /**
- * Replaces given input string with variables from given phoenixCampaign and signupKeyword.
+ * Replaces given input string with variables from given phoenixCampaign.
  */
-module.exports.replacePhoenixCampaignVars = function (input, phoenixCampaign, signupKeyword) {
+module.exports.replacePhoenixCampaignVars = function (input, phoenixCampaign) {
   return new Promise((resolve, reject) => {
     logger.debug(`helpers.replacePhoenixCampaignVars campaignId:${phoenixCampaign.id}`);
     if (!input) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -197,16 +197,6 @@ module.exports.replacePhoenixCampaignVars = function (input, phoenixCampaign, si
       }
     } catch (err) { return reject(err); }
 
-    /*
-    * TODO: Why is this branch here?
-    * There seems to be no code that makes the function take this path
-    * Is this here just for testing or future manual override?
-    */
-    if (signupKeyword) {
-      scope = scope.replace(/{{keyword}}/i, signupKeyword);
-      return resolve(scope);
-    }
-
     // If we've made it this far, we need to render a keyword by finding the first keyword
     // for the Campaign defined in Contentful.
     return contentful.fetchKeywordsForCampaignId(phoenixCampaign.id)
@@ -214,9 +204,7 @@ module.exports.replacePhoenixCampaignVars = function (input, phoenixCampaign, si
         if (!keywords.length) {
           return resolve(scope);
         }
-        // Note: We might want to add a "primary" boolean to denote which keyword should be used
-        // as the default keyword when there are multiple. For now, we'll return the first to KISS.
-        const keyword = keywords[0].keyword;
+        const keyword = keywords[0];
         scope = scope.replace(/{{keyword}}/i, keyword);
 
         return resolve(scope);

--- a/test/lib/helpers.test.js
+++ b/test/lib/helpers.test.js
@@ -105,7 +105,7 @@ test('replacePhoenixCampaignVars a message that makes a contentful request to ge
     .replacePhoenixCampaignVars(relativeToSignUpMsg, phoenixCampaign);
 
   contentful.fetchKeywordsForCampaignId.should.have.been.called;
-  renderedMessage.should.have.string(keywords[0].keyword);
+  renderedMessage.should.have.string(keywords[0]);
 });
 
 test('replacePhoenixCampaignVars failure to retrieve keywords should throw', async (t) => {


### PR DESCRIPTION
#### What's this PR do?
* Fixes the keyword variable in `helpers.replacePhoenixCampaignVars` per changes in #986
* Removes code we never ended up implementing (render the user's signup keyword if they signed up via keyword). 

#### How should this be reviewed?
In Consolebot, make sure you're signed up for a Campaign and send the Q keyword. Verify you receive the support message with the Campaign keyword rendered.

#### Checklist
- [x] Tested on staging.
