### PR TITLE
GET /campaigns/:id middleware

### DIFF
--- a/app/routes/campaigns-single.js
+++ b/app/routes/campaigns-single.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const express = require('express');
+
+// Middleware;
+const getPhoenixCampaignMiddleware = require('../../lib/middleware/campaigns-single/phoenix-campaign');
+const getContentfulKeywordsMiddleware = require('../../lib/middleware/campaigns-single/contentful-keywords');
+const getContentfulTemplatesMiddleware = require('../../lib/middleware/campaigns-single/contentful-campaigns');
+
+const router = express.Router({ mergeParams: true });
+
+router.use(getPhoenixCampaignMiddleware());
+router.use(getContentfulKeywordsMiddleware());
+router.use(getContentfulTemplatesMiddleware());
+
+module.exports = router;

--- a/app/routes/campaigns.js
+++ b/app/routes/campaigns.js
@@ -3,81 +3,15 @@
 const express = require('express');
 
 const router = express.Router({ mergeParams: true }); // eslint-disable-line new-cap
-const Promise = require('bluebird');
 const logger = require('winston');
 
 const ClosedCampaignError = require('../exceptions/ClosedCampaignError');
-const UnprocessibleEntityError = require('../exceptions/UnprocessibleEntityError');
-
 const contentful = require('../../lib/contentful');
 const helpers = require('../../lib/helpers');
-
 const mobilecommons = require('../../lib/mobilecommons');
 const phoenix = require('../../lib/phoenix');
 const stathat = require('../../lib/stathat');
 
-/**
- * Queries Phoenix, Contentful, and Mongo to render an object for a given Campaign id.
- * TODO: Refactor this monster chain into middleware.
- * @see https://github.com/DoSomething/gambit/issues/983
- */
-function fetchCampaign(id) {
-  let campaign;
-
-  return new Promise((resolve, reject) => {
-    logger.debug(`campaigns.fetchCampaign:${id}`);
-
-    return phoenix.fetchCampaign(id)
-      .then((phoenixCampaign) => {
-        campaign = phoenixCampaign;
-
-        return contentful.renderAllTemplatesForPhoenixCampaign(phoenixCampaign);
-      })
-      .then((renderedTemplates) => {
-        if (renderedTemplates) {
-          campaign.templates = renderedTemplates;
-        }
-
-        return contentful.fetchKeywordsForCampaignId(id);
-      })
-      .then((keywords) => {
-        campaign.keywords = keywords;
-        return resolve(campaign);
-      })
-      .catch(error => reject(error));
-  });
-}
-
-/**
- * GET single campaign.
- */
-router.get('/', (req, res) => {
-  stathat.postStat('route: v1/campaigns/{id}');
-  const campaignId = req.params.campaignId;
-  let response;
-
-  return fetchCampaign(campaignId)
-    .then((data) => {
-      response = data;
-
-      return contentful.fetchCampaign(campaignId);
-    })
-    // TODO: Querying Contentful again here to get its sys.id. We could avoid this extra query
-    // by refactoring contentful.renderAllTemplatesForPhoenixCampaign to optionally accept a loaded
-    // Contentful campaign.
-    .then((contentfulCampaign) => {
-      const spaceId = process.env.CONTENTFUL_SPACE_ID;
-      const contentfulId = contentfulCampaign.sys.id;
-      const uri = `https://app.contentful.com/spaces/${spaceId}/entries/${contentfulId}`;
-      response.contentfulUri = uri;
-
-      return res.send({ data: response });
-    })
-    // TODO: Refactor helpers.sendResponse to accept an error and know the codes based on custom
-    // error class, to DRY.
-    .catch(UnprocessibleEntityError, err => helpers.sendResponse(res, 422, err.message))
-    .catch(err => helpers.sendErrorResponse(res, err));
-});
 
 // Config
 const requiredParamsConf = require('../../config/middleware/campaigns/required-params');
@@ -93,7 +27,7 @@ router.use(requiredParamsMiddleware(requiredParamsConf));
  *
  * First check for required parameters.
  */
-router.post('/message', (req, res, next) => {
+router.post('/', (req, res, next) => {
   logger.debug(`campaigns/:id/message post:${JSON.stringify(req.body)}`);
   // Check required parameters.
   /* eslint-disable no-param-reassign */
@@ -111,7 +45,7 @@ router.post('/message', (req, res, next) => {
 /**
  * Fetch Campaign from Phoenix API and validate its Campaign Status active.
  */
-router.post('/message', (req, res, next) => {
+router.post('/', (req, res, next) => {
   phoenix.fetchCampaign(req.campaignId)
     .then((phoenixCampaign) => {
       if (req.timedout) {
@@ -133,7 +67,7 @@ router.post('/message', (req, res, next) => {
 /**
  * Fetch Campaign Keywords from Contentful to validate its running on Gambit.
  */
-router.post('/message', (req, res, next) => {
+router.post('/', (req, res, next) => {
   contentful.fetchKeywordsForCampaignId(req.campaignId)
     .then((keywords) => {
       if (req.timedout) {
@@ -153,7 +87,7 @@ router.post('/message', (req, res, next) => {
 /**
  * Render our campaign message to send.
  */
-router.post('/message', (req, res, next) => {
+router.post('/', (req, res, next) => {
   contentful.renderMessageForPhoenixCampaign(req.campaign, req.messageType)
     .then((message) => {
       if (req.timedout) {
@@ -170,7 +104,7 @@ router.post('/message', (req, res, next) => {
 /**
  * Post to Mobile Commons to send the message.
  */
-router.post('/message', (req, res) => {
+router.post('/', (req, res) => {
   const statName = `campaignbot:${req.messageType}`;
 
   try {

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -1,10 +1,13 @@
 'use strict';
 
 // Routes
-const campaignsRoute = require('./campaigns');
 const campaignsIndexRoute = require('./campaigns-index');
-const chatbotRoute = require('./chatbot');
+const campaignsSingleRoute = require('./campaigns-single');
 const receiveMessageRoute = require('./receive-message');
+
+// To be deprecated:
+const chatbotRoute = require('./chatbot');
+const sendMessageRoute = require('./campaigns');
 const signupsRoute = require('./signups');
 const statusRoute = require('./status');
 const homeRoute = require('./home');
@@ -31,8 +34,10 @@ module.exports = function init(app) {
   app.get('/', homeRoute);
   app.use('/v1/status', statusRoute);
 
+  app.use('/v1/campaigns/:campaignId/message', sendMessageRoute);
+
   // Provides keywords and templates for a single Campaign.
-  app.use('/v1/campaigns/:campaignId', campaignsRoute);
+  app.use('/v1/campaigns/:campaignId', campaignsSingleRoute);
 
   // Provides list of Campaigns configured for Gambit.
   app.use('/v1/campaigns', campaignsIndexRoute);

--- a/lib/middleware/campaigns-single/contentful-campaigns.js
+++ b/lib/middleware/campaigns-single/contentful-campaigns.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const contentful = require('../../contentful');
+const helpers = require('../../helpers');
+
+module.exports = function getTemplates() {
+  return (req, res) => {
+    contentful.renderAllTemplatesForPhoenixCampaign(req.campaign)
+      .then((contentfulRes) => {
+        req.campaign.templates = contentfulRes;
+        return res.send({ data: req.campaign });
+      })
+      .catch(err => helpers.sendErrorResponse(res, err));
+  };
+};

--- a/lib/middleware/campaigns-single/contentful-keywords.js
+++ b/lib/middleware/campaigns-single/contentful-keywords.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const contentful = require('../../contentful');
+const helpers = require('../../helpers');
+
+module.exports = function getKeywords() {
+  return (req, res, next) => {
+    contentful.fetchKeywordsForCampaignId(req.campaign.id)
+      .then((contentfulRes) => {
+        req.campaign.keywords = contentfulRes;
+        return next();
+      })
+      .catch(err => helpers.sendErrorResponse(res, err));
+  };
+};

--- a/lib/middleware/campaigns-single/phoenix-campaign.js
+++ b/lib/middleware/campaigns-single/phoenix-campaign.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const phoenix = require('../../phoenix');
+const helpers = require('../../helpers');
+
+module.exports = function getPhoenixCampaign() {
+  return (req, res, next) => {
+    const campaignId = req.params.campaignId;
+
+    return phoenix.fetchCampaign(campaignId)
+      .then((phoenixRes) => {
+        req.campaign = phoenixRes;
+        return next();
+      })
+      .catch(err => helpers.sendErrorResponse(res, err));
+  };
+};


### PR DESCRIPTION
#### What's this PR do?
Splits out the `fetchCampaign` function defined in `app/routes/campaigns` into middleware.

#### How should this be reviewed?
Make GET requests for various Campaign Id's (ones that exist, ones that don't)

#### Any background context you want to provide?
* Removes the Contentful URI for now, which is only used internally by the Gambit Slackbot.
* Nice to refactor: Make a single request to the Contentful API to get both the default Campaign and the target Campaign, instead of 2 separate Contentful requests

#### Relevant tickets
Fixes #983 

#### Checklist
- [x] Tested on staging.
