### PR TITLE
WIP: Always return GET /campaigns/:id response if Phoenix Campaign ID exists

### DIFF
--- a/app/routes/campaigns-single.js
+++ b/app/routes/campaigns-single.js
@@ -6,11 +6,13 @@ const express = require('express');
 const getPhoenixCampaignMiddleware = require('../../lib/middleware/campaigns-single/phoenix-campaign');
 const getContentfulKeywordsMiddleware = require('../../lib/middleware/campaigns-single/contentful-keywords');
 const getContentfulTemplatesMiddleware = require('../../lib/middleware/campaigns-single/contentful-campaigns');
+const renderTemplatesMiddleware = require('../../lib/middleware/campaigns-single/render-templates');
 
 const router = express.Router({ mergeParams: true });
 
 router.use(getPhoenixCampaignMiddleware());
 router.use(getContentfulKeywordsMiddleware());
 router.use(getContentfulTemplatesMiddleware());
+router.use(renderTemplatesMiddleware());
 
 module.exports = router;

--- a/app/routes/campaigns-single.js
+++ b/app/routes/campaigns-single.js
@@ -5,14 +5,14 @@ const express = require('express');
 // Middleware;
 const getPhoenixCampaignMiddleware = require('../../lib/middleware/campaigns-single/phoenix-campaign');
 const getContentfulKeywordsMiddleware = require('../../lib/middleware/campaigns-single/contentful-keywords');
-const getContentfulTemplatesMiddleware = require('../../lib/middleware/campaigns-single/contentful-campaigns');
+const getContentfulCampaignsMiddleware = require('../../lib/middleware/campaigns-single/contentful-campaigns');
 const renderTemplatesMiddleware = require('../../lib/middleware/campaigns-single/render-templates');
 
 const router = express.Router({ mergeParams: true });
 
 router.use(getPhoenixCampaignMiddleware());
 router.use(getContentfulKeywordsMiddleware());
-router.use(getContentfulTemplatesMiddleware());
+router.use(getContentfulCampaignsMiddleware());
 router.use(renderTemplatesMiddleware());
 
 module.exports = router;

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -258,8 +258,10 @@ module.exports.fetchDefaultAndOverrideContentfulCampaignsForCampaignId = functio
     const campaignIds = [defaultCampaignId, campaignId];
 
     return exports.fetchCampaigns(campaignIds)
-      .then(res => Promise.resolve(parseDefaultAndOverrideContentfulCampaignsResponse(res.items)))
-      .then(data => resolve(data))
+      .then((res) => {
+        const data = parseDefaultAndOverrideContentfulCampaignsResponse(res.items);
+        return resolve(data);
+      })
       .catch(error => reject(exports.contentfulError(error)));
   });
 };

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -103,7 +103,7 @@ module.exports.fetchCampaign = function (campaignId) {
  * @param {array} entries - Assumes the Contentful Campaign with defaultCampaignId is included.
  * @return {object}
  */
-function mergeCampaignEntries(entries) {
+function mergeContentfulCampaignEntries(entries) {
   let defaultContentfulCampaign;
   let overrideContentfulCampaign;
   const templateNames = Object.keys(config.campaignFields);
@@ -172,7 +172,7 @@ module.exports.fetchTemplatesForCampaignId = function (campaignId) {
           return resolve({});
         }
 
-        return resolve(mergeCampaignEntries(res.items));
+        return resolve(mergeContentfulCampaignEntries(res.items));
       })
       .catch(error => reject(exports.contentfulError(error)));
   });

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -236,11 +236,11 @@ module.exports.fetchDefaultAndOverrideContentfulCampaignsForCampaignId = functio
   return new Promise((resolve, reject) => {
     logger.debug(`contentful.fetchContentulCampaignsForPhoenixCampaignId:${campaignId}`);
 
-    return exports.getClient()
-      .getEntries({
-        content_type: 'campaign',
-        'fields.campaignId[in]': `${defaultCampaignId},${campaignId}`,
-      })
+    const query = exports.getQueryBuilder()
+      .contentType('campaign')
+      .campaignIds([defaultCampaignId, campaignId])
+      .build();
+    return exports.getClient().getEntries(query)
       .then(res => resolve(parseDefaultAndOverrideContentfulCampaignsResponse(res.items)))
       .catch(error => reject(exports.contentfulError(error)));
   });

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -194,82 +194,50 @@ module.exports.renderMessageForPhoenixCampaign = function (phoenixCampaign, msgT
   });
 };
 
-
 /**
- * @param {array} entries - Assumes the Contentful Campaign with defaultCampaignId is included.
  * @return {object}
  */
-function mergeContentfulCampaignEntries(entries) {
-  let defaultContentfulCampaign;
-  let overrideContentfulCampaign;
-  const templateNames = Object.keys(config.campaignFields);
+module.exports.getContentfulCampaignFieldsByTemplateName = function () {
+  return config.campaignFields;
+};
 
+/**
+ * @param {array} entries - Array of Contentful Campaign entries.
+ * @return {object}
+ */
+function parseDefaultAndOverrideContentfulCampaignsResponse(entries) {
+  const data = {};
+  if (entries.length === 0) {
+    return data;
+  }
   if (entries.length === 1) {
-    const result = {};
-    defaultContentfulCampaign = entries[0].fields;
-    templateNames.forEach((templateName) => {
-      const fieldName = config.campaignFields[templateName];
-      result[templateName] = {
-        override: false,
-        raw: defaultContentfulCampaign[fieldName],
-      };
-    });
-    return result;
+    data.default = entries[0];
   }
-
   if (entries[0].fields.campaignId === defaultCampaignId) {
-    defaultContentfulCampaign = entries[0].fields;
-    overrideContentfulCampaign = entries[1].fields;
+    data.default = entries[0];
+    data.override = entries[1];
   } else {
-    defaultContentfulCampaign = entries[1].fields;
-    overrideContentfulCampaign = entries[0].fields;
+    data.override = entries[1];
+    data.default = entries[0];
   }
 
-  const result = {};
-
-  templateNames.forEach((templateName) => {
-    result[templateName] = {};
-    const fieldName = config.campaignFields[templateName];
-    const overrideValue = overrideContentfulCampaign[fieldName];
-
-    if (overrideValue) {
-      result[templateName] = {
-        override: true,
-        raw: overrideValue,
-      };
-    } else {
-      result[templateName] = {
-        override: false,
-        raw: defaultContentfulCampaign[fieldName],
-      };
-    }
-  });
-
-  return result;
+  return data;
 }
 
 /**
  * @param {number} campaignId
+ * @return {Promise}
  */
-module.exports.fetchTemplatesForCampaignId = function (campaignId) {
+module.exports.fetchDefaultAndOverrideContentfulCampaignsForCampaignId = function (campaignId) {
   return new Promise((resolve, reject) => {
-    logger.debug(`contentful.fetchTemplatesForCampaignId:${campaignId}`);
+    logger.debug(`contentful.fetchContentulCampaignsForPhoenixCampaignId:${campaignId}`);
 
     return exports.getClient()
       .getEntries({
         content_type: 'campaign',
         'fields.campaignId[in]': `${defaultCampaignId},${campaignId}`,
       })
-      .then((res) => {
-        logger.debug('fetchTemplatesForCampaignId', res);
-        // This shouldn't ever happen, otherwise our default Campaign was deleted and that's sad.
-        // But just in case, we'll return an empty object.
-        if (res.items.length === 0) {
-          return resolve({});
-        }
-
-        return resolve(mergeContentfulCampaignEntries(res.items));
-      })
+      .then(res => resolve(parseDefaultAndOverrideContentfulCampaignsResponse(res.items)))
       .catch(error => reject(exports.contentfulError(error)));
   });
 };

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -99,6 +99,85 @@ module.exports.fetchCampaign = function (campaignId) {
   return exports.fetchSingleEntry(query);
 };
 
+/**
+ * @param {array} entries - Assumes the Contentful Campaign with defaultCampaignId is included.
+ * @return {object}
+ */
+function mergeCampaignEntries(entries) {
+  let defaultContentfulCampaign;
+  let overrideContentfulCampaign;
+  const templateNames = Object.keys(config.campaignFields);
+
+  if (entries.length === 1) {
+    const result = {};
+    defaultContentfulCampaign = entries[0].fields;
+    templateNames.forEach((templateName) => {
+      const fieldName = config.campaignFields[templateName];
+      result[templateName] = {
+        override: false,
+        raw: defaultContentfulCampaign[fieldName],
+      };
+    });
+    return result;
+  }
+
+  if (entries[0].fields.campaignId === defaultCampaignId) {
+    defaultContentfulCampaign = entries[0].fields;
+    overrideContentfulCampaign = entries[1].fields;
+  } else {
+    defaultContentfulCampaign = entries[1].fields;
+    overrideContentfulCampaign = entries[0].fields;
+  }
+
+  const result = {};
+
+  templateNames.forEach((templateName) => {
+    result[templateName] = {};
+    const fieldName = config.campaignFields[templateName];
+    const overrideValue = overrideContentfulCampaign[fieldName];
+
+    if (overrideValue) {
+      result[templateName] = {
+        override: true,
+        raw: overrideValue,
+      };
+    } else {
+      result[templateName] = {
+        override: false,
+        raw: defaultContentfulCampaign[fieldName],
+      };
+    }
+  });
+
+  return result;
+}
+
+/**
+ * @param {number} campaignId
+ */
+module.exports.fetchTemplatesForCampaignId = function (campaignId) {
+  return new Promise((resolve, reject) => {
+    logger.debug(`contentful.fetchTemplatesForCampaignId:${campaignId}`);
+
+    return exports.getClient()
+      .getEntries({
+        content_type: 'campaign',
+        'fields.campaignId[in]': `${defaultCampaignId},${campaignId}`,
+      })
+      .then((res) => {
+        logger.debug('fetchTemplatesForCampaignId', res);
+        // This shouldn't ever happen, otherwise our default Campaign was deleted and that's sad.
+        // But just in case, we'll return an empty object.
+        if (res.items.length === 0) {
+          return resolve({});
+        }
+
+        return resolve(mergeCampaignEntries(res.items));
+      })
+      .catch(error => reject(exports.contentfulError(error)));
+  });
+};
+
 module.exports.fetchKeyword = function (keyword) {
   logger.debug(`contentful.fetchKeyword:${keyword}`);
 
@@ -120,7 +199,6 @@ module.exports.fetchKeywords = function fetchKeywords() {
   .then(response => response.items.map(item => exports.formatKeywordFromResponse(item)))
   .catch(error => exports.contentfulError(error));
 };
-
 
 module.exports.fetchKeywordsForCampaignId = function (campaignId) {
   logger.debug(`contentful.fetchKeywordsForCampaignId:${campaignId}`);

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -221,8 +221,8 @@ function parseDefaultAndOverrideContentfulCampaignsResponse(entries) {
     data.default = entries[0];
     data.override = entries[1];
   } else {
-    data.override = entries[1];
-    data.default = entries[0];
+    data.default = entries[1];
+    data.override = entries[0];
   }
 
   return data;

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -187,7 +187,7 @@ module.exports.renderMessageForPhoenixCampaign = function (phoenixCampaign, msgT
           return reject(err);
         }
 
-        return helpers.replacePhoenixCampaignVars(message, phoenixCampaign);
+        return helpers.replacePhoenixCampaignVarsAndFindKeyword(message, phoenixCampaign);
       })
       .then(renderedMessage => resolve(renderedMessage))
       .catch(err => reject(err));

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -99,85 +99,6 @@ module.exports.fetchCampaign = function (campaignId) {
   return exports.fetchSingleEntry(query);
 };
 
-/**
- * @param {array} entries - Assumes the Contentful Campaign with defaultCampaignId is included.
- * @return {object}
- */
-function mergeContentfulCampaignEntries(entries) {
-  let defaultContentfulCampaign;
-  let overrideContentfulCampaign;
-  const templateNames = Object.keys(config.campaignFields);
-
-  if (entries.length === 1) {
-    const result = {};
-    defaultContentfulCampaign = entries[0].fields;
-    templateNames.forEach((templateName) => {
-      const fieldName = config.campaignFields[templateName];
-      result[templateName] = {
-        override: false,
-        raw: defaultContentfulCampaign[fieldName],
-      };
-    });
-    return result;
-  }
-
-  if (entries[0].fields.campaignId === defaultCampaignId) {
-    defaultContentfulCampaign = entries[0].fields;
-    overrideContentfulCampaign = entries[1].fields;
-  } else {
-    defaultContentfulCampaign = entries[1].fields;
-    overrideContentfulCampaign = entries[0].fields;
-  }
-
-  const result = {};
-
-  templateNames.forEach((templateName) => {
-    result[templateName] = {};
-    const fieldName = config.campaignFields[templateName];
-    const overrideValue = overrideContentfulCampaign[fieldName];
-
-    if (overrideValue) {
-      result[templateName] = {
-        override: true,
-        raw: overrideValue,
-      };
-    } else {
-      result[templateName] = {
-        override: false,
-        raw: defaultContentfulCampaign[fieldName],
-      };
-    }
-  });
-
-  return result;
-}
-
-/**
- * @param {number} campaignId
- */
-module.exports.fetchTemplatesForCampaignId = function (campaignId) {
-  return new Promise((resolve, reject) => {
-    logger.debug(`contentful.fetchTemplatesForCampaignId:${campaignId}`);
-
-    return exports.getClient()
-      .getEntries({
-        content_type: 'campaign',
-        'fields.campaignId[in]': `${defaultCampaignId},${campaignId}`,
-      })
-      .then((res) => {
-        logger.debug('fetchTemplatesForCampaignId', res);
-        // This shouldn't ever happen, otherwise our default Campaign was deleted and that's sad.
-        // But just in case, we'll return an empty object.
-        if (res.items.length === 0) {
-          return resolve({});
-        }
-
-        return resolve(mergeContentfulCampaignEntries(res.items));
-      })
-      .catch(error => reject(exports.contentfulError(error)));
-  });
-};
-
 module.exports.fetchKeyword = function (keyword) {
   logger.debug(`contentful.fetchKeyword:${keyword}`);
 
@@ -275,82 +196,83 @@ module.exports.renderMessageForPhoenixCampaign = function (phoenixCampaign, msgT
 
 
 /**
- * Gets all fields for the campaign together with the default fields in the default campaign.
- *
- * @param  {type} campaignId
- * @return {Promise}
+ * @param {array} entries - Assumes the Contentful Campaign with defaultCampaignId is included.
+ * @return {object}
  */
-module.exports.getAllTemplatesForCampaignId = function getAllTemplatesForCampaignId(campaignId) {
-  return new Promise((resolve, reject) => {
-    const templateNames = Object.keys(config.campaignFields);
-    const campaignContent = {};
-    const templates = {};
-    // TODO: Instead of making two Contentful requests (first: for campaignId, second: for default)
-    // use getEntries() with an IN operator get both Contentful Campaigns in a single request.
-    // @see https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters/inclusion
-    return exports.fetchCampaign(campaignId)
-      .then((contentfulCampaign) => {
-        campaignContent.overrides = contentfulCampaign.fields;
-        return exports.fetchCampaign(defaultCampaignId);
-      })
-      .then((defaultContentfulCampaign) => {
-        campaignContent.defaults = defaultContentfulCampaign.fields;
-        templateNames.forEach((templateName) => {
-          const fieldName = config.campaignFields[templateName];
-          templates[templateName] = {};
+function mergeContentfulCampaignEntries(entries) {
+  let defaultContentfulCampaign;
+  let overrideContentfulCampaign;
+  const templateNames = Object.keys(config.campaignFields);
 
-          if (campaignContent.overrides[fieldName]) {
-            templates[templateName].override = true;
-            templates[templateName].raw = campaignContent.overrides[fieldName];
-          } else {
-            templates[templateName].override = false;
-            templates[templateName].raw = campaignContent.defaults[fieldName];
-          }
-        });
-        return resolve(templates);
-      })
-      .catch(err => reject(err));
+  if (entries.length === 1) {
+    const result = {};
+    defaultContentfulCampaign = entries[0].fields;
+    templateNames.forEach((templateName) => {
+      const fieldName = config.campaignFields[templateName];
+      result[templateName] = {
+        override: false,
+        raw: defaultContentfulCampaign[fieldName],
+      };
+    });
+    return result;
+  }
+
+  if (entries[0].fields.campaignId === defaultCampaignId) {
+    defaultContentfulCampaign = entries[0].fields;
+    overrideContentfulCampaign = entries[1].fields;
+  } else {
+    defaultContentfulCampaign = entries[1].fields;
+    overrideContentfulCampaign = entries[0].fields;
+  }
+
+  const result = {};
+
+  templateNames.forEach((templateName) => {
+    result[templateName] = {};
+    const fieldName = config.campaignFields[templateName];
+    const overrideValue = overrideContentfulCampaign[fieldName];
+
+    if (overrideValue) {
+      result[templateName] = {
+        override: true,
+        raw: overrideValue,
+      };
+    } else {
+      result[templateName] = {
+        override: false,
+        raw: defaultContentfulCampaign[fieldName],
+      };
+    }
   });
-};
+
+  return result;
+}
 
 /**
- * Returns all rendered messages for given phoenixCampaign, using defaults when no override defined.
+ * @param {number} campaignId
  */
-module.exports.renderAllTemplatesForPhoenixCampaign = function (phoenixCampaign) {
-  logger.debug(`renderAllTemplatesForPhoenixCampaign:${phoenixCampaign.id}`);
-  return new Promise((resolve, reject) =>
-    // get all fields, overrides and default
-    exports.getAllTemplatesForCampaignId(phoenixCampaign.id)
-      .then(campaignFields => Promise.map(
-          /**
-           * Iterator
-           */
-          Object.keys(campaignFields),
-          /**
-           * Mapper fn: calls helpers.replacePhoenixCampaignVars for each campaign field raw message
-           * NOTE Disabling arrow-body-style because we need to create a function scope to
-           * remember `fieldName`. Disabling max-len for better readability
-           */
-          (fieldName) => { // eslint-disable-line arrow-body-style
-            return helpers.replacePhoenixCampaignVars(campaignFields[fieldName].raw, phoenixCampaign) // eslint-disable-line max-len
-              /**
-               * Let's add the rendered message to the campaignFields object under the rendered prop
-               */
-              .then((msg) => {
-                campaignFields[fieldName].rendered = msg; // eslint-disable-line no-param-reassign
-              });
-          })
-        /**
-         * When all promises have been fulfilled, we resolve our Promise with the campaignFields
-         * rendered
-         */
-        .then(() => {
-          resolve(campaignFields);
-        })
-        .catch(err => reject(err)))
-      .catch(err => reject(err)));
-};
+module.exports.fetchTemplatesForCampaignId = function (campaignId) {
+  return new Promise((resolve, reject) => {
+    logger.debug(`contentful.fetchTemplatesForCampaignId:${campaignId}`);
 
+    return exports.getClient()
+      .getEntries({
+        content_type: 'campaign',
+        'fields.campaignId[in]': `${defaultCampaignId},${campaignId}`,
+      })
+      .then((res) => {
+        logger.debug('fetchTemplatesForCampaignId', res);
+        // This shouldn't ever happen, otherwise our default Campaign was deleted and that's sad.
+        // But just in case, we'll return an empty object.
+        if (res.items.length === 0) {
+          return resolve({});
+        }
+
+        return resolve(mergeContentfulCampaignEntries(res.items));
+      })
+      .catch(error => reject(exports.contentfulError(error)));
+  });
+};
 // Utility functions
 
 module.exports.formatKeywordFromResponse = function formatKeywordFromResponse(contentfulKeyword,

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -187,7 +187,11 @@ module.exports.renderMessageForPhoenixCampaign = function (phoenixCampaign, msgT
           return reject(err);
         }
 
-        return helpers.replacePhoenixCampaignVarsAndFindKeyword(message, phoenixCampaign);
+        const rendered = helpers.replacePhoenixCampaignVars(message, phoenixCampaign);
+        if (rendered.includes('{{keyword}}')) {
+          return helpers.findAndReplaceKeywordVarForCampaignId(rendered, phoenixCampaign.id);
+        }
+        return Promise.resolve(rendered);
       })
       .then(renderedMessage => resolve(renderedMessage))
       .catch(err => reject(err));

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -79,6 +79,7 @@ module.exports.fetchSingleEntry = function fetchSingleEntry(query) {
   });
 };
 
+
 module.exports.fetchBroadcast = function (broadcastId) {
   logger.debug(`contentful.fetchBroadcast:${broadcastId}`);
 
@@ -89,6 +90,11 @@ module.exports.fetchBroadcast = function (broadcastId) {
   return exports.fetchSingleEntry(query);
 };
 
+/**
+ * Fetches a Contentful Campaign by its campaignId field
+ * Although Phoenix Campaign ID's are numeric, the Contentful campaignId is a string.
+ * @param {string} campaignId
+ */
 module.exports.fetchCampaign = function (campaignId) {
   logger.debug(`contentful.fetchCampaign:${campaignId}`);
 
@@ -97,6 +103,20 @@ module.exports.fetchCampaign = function (campaignId) {
     .campaignId(campaignId)
     .build();
   return exports.fetchSingleEntry(query);
+};
+
+/**
+ * Fetches a list of Contentful Campaigns by given array of campaignId field values
+ * Although Phoenix Campaign ID's are numeric, the Contentful campaignId is a string.
+ * @param {array} campaignIds
+ */
+module.exports.fetchCampaigns = function (campaignIds) {
+  const query = exports.getQueryBuilder()
+    .contentType('campaign')
+    .campaignIds(campaignIds)
+    .build();
+
+  return exports.getClient().getEntries(query);
 };
 
 module.exports.fetchKeyword = function (keyword) {
@@ -235,16 +255,15 @@ function parseDefaultAndOverrideContentfulCampaignsResponse(entries) {
 module.exports.fetchDefaultAndOverrideContentfulCampaignsForCampaignId = function (campaignId) {
   return new Promise((resolve, reject) => {
     logger.debug(`contentful.fetchContentulCampaignsForPhoenixCampaignId:${campaignId}`);
+    const campaignIds = [defaultCampaignId, campaignId];
 
-    const query = exports.getQueryBuilder()
-      .contentType('campaign')
-      .campaignIds([defaultCampaignId, campaignId])
-      .build();
-    return exports.getClient().getEntries(query)
-      .then(res => resolve(parseDefaultAndOverrideContentfulCampaignsResponse(res.items)))
+    return exports.fetchCampaigns(campaignIds)
+      .then(res => Promise.resolve(parseDefaultAndOverrideContentfulCampaignsResponse(res.items)))
+      .then(data => resolve(data))
       .catch(error => reject(exports.contentfulError(error)));
   });
 };
+
 // Utility functions
 
 module.exports.formatKeywordFromResponse = function formatKeywordFromResponse(contentfulKeyword,

--- a/lib/contentfulQueryBuilder.js
+++ b/lib/contentfulQueryBuilder.js
@@ -19,6 +19,13 @@ class QueryBuilder {
     this.query['fields.campaignId'] = id;
     return this;
   }
+  /**
+   * @param {array} ids
+   */
+  campaignIds(ids) {
+    this.query['fields.campaignId[in]'] = ids.join(',');
+    return this;
+  }
   keyword(keyword) {
     this.query['fields.keyword'] = keyword;
     return this;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -175,7 +175,7 @@ module.exports.generatePassword = function (text) {
  */
 module.exports.replacePhoenixCampaignVars = function (input, phoenixCampaign) {
   return new Promise((resolve, reject) => {
-    logger.debug(`helpers.replacePhoenixCampaignVars campaignId:${phoenixCampaign.id}`);
+    logger.trace(`helpers.replacePhoenixCampaignVars campaignId:${phoenixCampaign.id}`);
     if (!input) {
       return resolve('');
     }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -171,9 +171,36 @@ module.exports.generatePassword = function (text) {
 };
 
 /**
- * Replaces given input string with variables from given phoenixCampaign.
+ * Replaces mustache tags used in raw Campaign Template strings with given variables.
+ * @param {string} input
+ * @param {object} phoenixCampaign
+ * @return string.
  */
 module.exports.replacePhoenixCampaignVars = function (input, phoenixCampaign) {
+  if (!input) {
+    return '';
+  }
+
+  let scope = input;
+  scope = scope.replace(/{{title}}/gi, phoenixCampaign.title);
+  scope = scope.replace(/{{tagline}}/i, phoenixCampaign.tagline);
+  scope = scope.replace(/{{fact_problem}}/gi, phoenixCampaign.facts.problem);
+  const reportbackInfo = phoenixCampaign.reportbackInfo;
+  scope = scope.replace(/{{rb_noun}}/gi, reportbackInfo.noun);
+  scope = scope.replace(/{{rb_verb}}/gi, reportbackInfo.verb);
+  scope = scope.replace(/{{rb_confirmation_msg}}/i, reportbackInfo.confirmationMessage);
+  scope = scope.replace(/{{cmd_reportback}}/i, process.env.GAMBIT_CMD_REPORTBACK);
+  scope = scope.replace(/{{cmd_member_support}}/i, process.env.GAMBIT_CMD_MEMBER_SUPPORT);
+  if (phoenixCampaign.keywords) {
+    scope = scope.replace(/{{keyword}}/gi, phoenixCampaign.keywords[0]);
+  }
+  return scope;
+};
+
+/**
+ * Replaces given input string with variables from given phoenixCampaign.
+ */
+module.exports.replacePhoenixCampaignVarsAndFindKeyword = function (input, phoenixCampaign) {
   return new Promise((resolve, reject) => {
     logger.trace(`helpers.replacePhoenixCampaignVars campaignId:${phoenixCampaign.id}`);
     if (!input) {
@@ -181,17 +208,8 @@ module.exports.replacePhoenixCampaignVars = function (input, phoenixCampaign) {
     }
 
     let scope = input;
-
     try {
-      scope = scope.replace(/{{title}}/gi, phoenixCampaign.title);
-      scope = scope.replace(/{{tagline}}/i, phoenixCampaign.tagline);
-      scope = scope.replace(/{{fact_problem}}/gi, phoenixCampaign.facts.problem);
-      const reportbackInfo = phoenixCampaign.reportbackInfo;
-      scope = scope.replace(/{{rb_noun}}/gi, reportbackInfo.noun);
-      scope = scope.replace(/{{rb_verb}}/gi, reportbackInfo.verb);
-      scope = scope.replace(/{{rb_confirmation_msg}}/i, reportbackInfo.confirmationMessage);
-      scope = scope.replace(/{{cmd_reportback}}/i, process.env.GAMBIT_CMD_REPORTBACK);
-      scope = scope.replace(/{{cmd_member_support}}/i, process.env.GAMBIT_CMD_MEMBER_SUPPORT);
+      scope = exports.replacePhoenixCampaignVars(input, phoenixCampaign);
       if (scope.indexOf('{{keyword}}') === -1) {
         return resolve(scope);
       }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -200,32 +200,22 @@ module.exports.replacePhoenixCampaignVars = function (input, phoenixCampaign) {
 /**
  * Replaces given input string with variables from given phoenixCampaign.
  */
-module.exports.replacePhoenixCampaignVarsAndFindKeyword = function (input, phoenixCampaign) {
+module.exports.findAndReplaceKeywordVarForCampaignId = function (input, campaignId) {
   return new Promise((resolve, reject) => {
-    logger.trace(`helpers.replacePhoenixCampaignVars campaignId:${phoenixCampaign.id}`);
+    logger.debug(`helpers.findAndReplaceKeywordVarForCampaignId:${campaignId}`);
     if (!input) {
       return resolve('');
     }
 
-    let scope = input;
-    try {
-      scope = exports.replacePhoenixCampaignVars(input, phoenixCampaign);
-      if (scope.indexOf('{{keyword}}') === -1) {
-        return resolve(scope);
-      }
-    } catch (err) { return reject(err); }
-
-    // If we've made it this far, we need to render a keyword by finding the first keyword
-    // for the Campaign defined in Contentful.
-    return contentful.fetchKeywordsForCampaignId(phoenixCampaign.id)
+    return contentful.fetchKeywordsForCampaignId(campaignId)
       .then((keywords) => {
         if (!keywords.length) {
-          return resolve(scope);
+          return resolve(input);
         }
         const keyword = keywords[0];
-        scope = scope.replace(/{{keyword}}/i, keyword);
+        const result = input.replace(/{{keyword}}/i, keyword);
 
-        return resolve(scope);
+        return resolve(result);
       })
       .catch(err => reject(err));
   });

--- a/lib/middleware/campaigns-single/contentful-campaigns.js
+++ b/lib/middleware/campaigns-single/contentful-campaigns.js
@@ -4,11 +4,11 @@ const contentful = require('../../contentful');
 const helpers = require('../../helpers');
 
 module.exports = function getTemplates() {
-  return (req, res) => {
+  return (req, res, next) => {
     contentful.fetchTemplatesForCampaignId(req.campaign.id)
       .then((contentfulRes) => {
         req.campaign.templates = contentfulRes;
-        return res.send({ data: req.campaign });
+        return next();
       })
       .catch(err => helpers.sendErrorResponse(res, err));
   };

--- a/lib/middleware/campaigns-single/contentful-campaigns.js
+++ b/lib/middleware/campaigns-single/contentful-campaigns.js
@@ -3,11 +3,11 @@
 const contentful = require('../../contentful');
 const helpers = require('../../helpers');
 
-module.exports = function getTemplates() {
+module.exports = function getContentfulCampaigns() {
   return (req, res, next) => {
-    contentful.fetchTemplatesForCampaignId(req.campaign.id)
-      .then((contentfulRes) => {
-        req.campaign.templates = contentfulRes;
+    contentful.fetchDefaultAndOverrideContentfulCampaignsForCampaignId(req.campaignId)
+      .then((contentfulCampaigns) => {
+        req.contentfulCampaigns = contentfulCampaigns;
         return next();
       })
       .catch(err => helpers.sendErrorResponse(res, err));

--- a/lib/middleware/campaigns-single/contentful-campaigns.js
+++ b/lib/middleware/campaigns-single/contentful-campaigns.js
@@ -5,7 +5,7 @@ const helpers = require('../../helpers');
 
 module.exports = function getTemplates() {
   return (req, res) => {
-    contentful.renderAllTemplatesForPhoenixCampaign(req.campaign)
+    contentful.fetchTemplatesForCampaignId(req.campaign.id)
       .then((contentfulRes) => {
         req.campaign.templates = contentfulRes;
         return res.send({ data: req.campaign });

--- a/lib/middleware/campaigns-single/phoenix-campaign.js
+++ b/lib/middleware/campaigns-single/phoenix-campaign.js
@@ -5,9 +5,9 @@ const helpers = require('../../helpers');
 
 module.exports = function getPhoenixCampaign() {
   return (req, res, next) => {
-    const campaignId = req.params.campaignId;
+    req.campaignId = req.params.campaignId;
 
-    return phoenix.fetchCampaign(campaignId)
+    return phoenix.fetchCampaign(req.campaignId)
       .then((phoenixRes) => {
         req.campaign = phoenixRes;
         return next();

--- a/lib/middleware/campaigns-single/render-templates.js
+++ b/lib/middleware/campaigns-single/render-templates.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = function renderTemplates() {
+  return (req, res) => {
+    const templateNames = Object.keys(req.campaign.templates);
+    templateNames.forEach((templateName) => {
+      const template = req.campaign.templates[templateName];
+      template.rendered = template.raw;
+    });
+
+    return res.send({ data: req.campaign });
+  };
+};

--- a/lib/middleware/campaigns-single/render-templates.js
+++ b/lib/middleware/campaigns-single/render-templates.js
@@ -1,11 +1,33 @@
 'use strict';
 
-module.exports = function renderTemplates() {
+const contentful = require('../../contentful');
+
+module.exports = function setCampaignTemplates() {
   return (req, res) => {
-    const templateNames = Object.keys(req.campaign.templates);
+    req.campaign.templates = {};
+    if (!req.contentfulCampaigns) {
+      return res.send({ data: req.campaign });
+    }
+
+    const contentfulFields = contentful.getContentfulCampaignFieldsByTemplateName();
+    const templateNames = Object.keys(contentfulFields);
+    const override = req.contentfulCampaigns.override;
+
     templateNames.forEach((templateName) => {
-      const template = req.campaign.templates[templateName];
-      template.rendered = template.raw;
+      const fieldName = contentfulFields[templateName];
+      let template;
+      if (override && override.fields[fieldName]) {
+        template = {
+          override: true,
+          raw: override.fields[fieldName],
+        };
+      } else {
+        template = {
+          override: false,
+          raw: req.contentfulCampaigns.default.fields[fieldName],
+        };
+      }
+      req.campaign.templates[templateName] = template;
     });
 
     return res.send({ data: req.campaign });

--- a/lib/middleware/campaigns-single/render-templates.js
+++ b/lib/middleware/campaigns-single/render-templates.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const contentful = require('../../contentful');
+const helpers = require('../../helpers');
 
 module.exports = function setCampaignTemplates() {
   return (req, res) => {
@@ -16,6 +17,7 @@ module.exports = function setCampaignTemplates() {
     templateNames.forEach((templateName) => {
       const fieldName = contentfulFields[templateName];
       let template;
+
       if (override && override.fields[fieldName]) {
         template = {
           override: true,
@@ -27,6 +29,8 @@ module.exports = function setCampaignTemplates() {
           raw: req.contentfulCampaigns.default.fields[fieldName],
         };
       }
+
+      template.rendered = helpers.replacePhoenixCampaignVars(template.raw, req.campaign);
       req.campaign.templates[templateName] = template;
     });
 

--- a/test/lib/contentful.test.js
+++ b/test/lib/contentful.test.js
@@ -36,7 +36,6 @@ const broadcastStub = Promise.resolve(stubs.contentful.getEntries('broadcast'));
 const campaignStub = Promise.resolve(stubs.contentful.getEntries('campaign'));
 const defaultCampaignStub = Promise.resolve(stubs.contentful.getEntries('default-campaign'));
 const campaignWithOverridesStub = Promise.resolve(stubs.contentful.getEntries('campaign-with-overrides'));
-const templatesForCampaignIdStub = Promise.resolve(stubs.contentful.getAllTemplatesForCampaignId());
 const failStub = Promise.reject({ status: 500 });
 const contentfulAPIStub = {
   getEntries: () => {},
@@ -299,23 +298,24 @@ async () => {
   contentful.fetchMessageForCampaignId.should.have.been.calledOnce;
 });
 
-/*
+
 // fetchDefaultAndOverrideContentfulCampaignsForCampaignId
 test('fetchDefaultAndOverrideContentfulCampaignsForCampaignId should return object with default and override properties', async () => {
   // setup
   sandbox.spy(contentful, 'fetchCampaigns');
   const stub = sinon.stub();
-  stub.onCall(0).returns([]);
+  stub.onCall(0).returns(campaignStub);
   contentful.__set__('client', {
-    getEntries: sinon.stub(),
+    getEntries: stub,
   });
 
   // test
-  const res = await contentful.fetchDefaultAndOverrideContentfulCampaignsForCampaignId(stubs.getCampaignId());
+  const campaignId = stubs.getCampaignId();
+  const res = await contentful.fetchDefaultAndOverrideContentfulCampaignsForCampaignId(campaignId);
   contentful.fetchCampaigns.should.have.been.called;
   res.should.include.keys(['default', 'override']);
 });
-*/
+
 
 test('fetchDefaultAndOverrideContentfulCampaignsForCampaignId should throw when fetchCampaign fails', async () => {
   // setup
@@ -329,35 +329,6 @@ test('fetchDefaultAndOverrideContentfulCampaignsForCampaignId should throw when 
   }
 });
 
-/**
-// TODO: Move this into middleware test for lib/middleware/campaigns-single/render-templates
-
-// renderAllTemplatesForPhoenixCampaign
-test('renderAllTemplatesForPhoenixCampaign should inject a rendered property to each campaign field', async () => {
-  // setup
-  const renderedMessageStub = 'rendered!';
-  sandbox.stub(contentful, 'getAllTemplatesForCampaignId').returns(templatesForCampaignIdStub);
-  sandbox.stub(helpers, 'replacePhoenixCampaignVars').returns(Promise.resolve(renderedMessageStub));
-
-  // test
-  const fields = await contentful.renderAllTemplatesForPhoenixCampaign(stubs.getPhoenixCampaign());
-  Object.keys(fields).forEach((fieldName) => {
-    fields[fieldName].rendered.should.be.equal(renderedMessageStub);
-  });
-});
-
-test('renderAllTemplatesForPhoenixCampaign should return and error if getAllTemplatesForCampaignId fails', async () => {
-  // setup
-  sandbox.stub(contentful, 'getAllTemplatesForCampaignId').returns(failStub);
-
-  // test
-  try {
-    await contentful.renderAllTemplatesForPhoenixCampaign(stubs.getPhoenixCampaign());
-  } catch (error) {
-    error.status.should.be.equal(500);
-  }
-});
-*/
 
 test('getFieldNameForCampaignMessageTemplate should return a config.campaignFields value', (t) => {
   // setup

--- a/test/lib/contentful.test.js
+++ b/test/lib/contentful.test.js
@@ -299,38 +299,38 @@ async () => {
   contentful.fetchMessageForCampaignId.should.have.been.calledOnce;
 });
 
-// getAllTemplatesForCampaignId
-test('getAllTemplatesForCampaignId should return fields with raw and override properties', async () => {
+/*
+// fetchDefaultAndOverrideContentfulCampaignsForCampaignId
+test('fetchDefaultAndOverrideContentfulCampaignsForCampaignId should return object with default and override properties', async () => {
   // setup
-  sandbox.spy(contentful, 'fetchCampaign');
+  sandbox.spy(contentful, 'fetchCampaigns');
   const stub = sinon.stub();
-  // return a campaign with no overrides
-  stub.onCall(0).returns(campaignWithOverridesStub);
-  // return the default campaign in contentful wich has all default overrides
-  stub.onCall(1).returns(defaultCampaignStub);
+  stub.onCall(0).returns([]);
   contentful.__set__('client', {
-    getEntries: stub,
+    getEntries: sinon.stub(),
   });
 
   // test
-  const fields = await contentful.getAllTemplatesForCampaignId(stubs.getCampaignId());
-  contentful.fetchCampaign.should.have.been.calledTwice;
-  Object.keys(fields).forEach((fieldName) => {
-    fields[fieldName].should.include.keys(['raw', 'override']);
-  });
+  const res = await contentful.fetchDefaultAndOverrideContentfulCampaignsForCampaignId(stubs.getCampaignId());
+  contentful.fetchCampaigns.should.have.been.called;
+  res.should.include.keys(['default', 'override']);
 });
+*/
 
-test('getAllTemplatesForCampaignId should throw when fetchCampaign fails', async () => {
+test('fetchDefaultAndOverrideContentfulCampaignsForCampaignId should throw when fetchCampaign fails', async () => {
   // setup
-  sandbox.stub(contentful, 'fetchCampaign').returns(failStub);
+  sandbox.stub(contentful, 'fetchCampaigns').returns(failStub);
 
   // test
   try {
-    await contentful.getAllTemplatesForCampaignId(stubs.getCampaignId());
+    await contentful.fetchDefaultAndOverrideContentfulCampaignsForCampaignId(stubs.getCampaignId());
   } catch (error) {
     error.status.should.be.equal(500);
   }
 });
+
+/**
+// TODO: Move this into middleware test for lib/middleware/campaigns-single/render-templates
 
 // renderAllTemplatesForPhoenixCampaign
 test('renderAllTemplatesForPhoenixCampaign should inject a rendered property to each campaign field', async () => {
@@ -357,6 +357,7 @@ test('renderAllTemplatesForPhoenixCampaign should return and error if getAllTemp
     error.status.should.be.equal(500);
   }
 });
+*/
 
 test('getFieldNameForCampaignMessageTemplate should return a config.campaignFields value', (t) => {
   // setup

--- a/test/lib/helpers.test.js
+++ b/test/lib/helpers.test.js
@@ -126,8 +126,8 @@ test('replacePhoenixCampaignVars with no message should return empty string', ()
 test('replacePhoenixCampaignVars on a campaign object missing reportbackInfo should throw', (t) => {
   const phoenixCampaign = stubs.getPhoenixCampaign();
   delete phoenixCampaign.reportbackInfo;
-  const memberSupportMsg = stubs.getDefaultContenfulCampaignMessage('gambitSignupMenu');
-  const error = t.throws(() => helpers.replacePhoenixCampaignVars(memberSupportMsg, phoenixCampaign));
+  const text = stubs.getDefaultContenfulCampaignMessage('gambitSignupMenu');
+  t.throws(() => helpers.replacePhoenixCampaignVars(text, phoenixCampaign));
 });
 
 // sendTimeoutResponse

--- a/test/lib/helpers.test.js
+++ b/test/lib/helpers.test.js
@@ -96,40 +96,38 @@ test('replacePhoenixCampaignVars', async () => {
   // TODO: test more messages!
 });
 
-test('replacePhoenixCampaignVars a message that makes a contentful request to get keywords', async () => {
+test('findAndReplaceKeywordVarForCampaignId a message that makes a contentful request to get keywords', async () => {
   const keywords = stubs.contentful.getKeywords();
   let renderedMessage = '';
   const phoenixCampaign = stubs.getPhoenixCampaign();
   const relativeToSignUpMsg = stubs.getDefaultContenfulCampaignMessage('scheduled_relative_to_signup_date');
   renderedMessage = await helpers
-    .replacePhoenixCampaignVars(relativeToSignUpMsg, phoenixCampaign);
+    .findAndReplaceKeywordVarForCampaignId(relativeToSignUpMsg, phoenixCampaign.id);
 
   contentful.fetchKeywordsForCampaignId.should.have.been.called;
   renderedMessage.should.have.string(keywords[0]);
 });
 
-test('replacePhoenixCampaignVars failure to retrieve keywords should throw', async (t) => {
-  const phoenixCampaign = stubs.getPhoenixCampaign();
+test('findAndReplaceKeywordVarForCampaignId failure to retrieve keywords should throw', async (t) => {
   // will trigger fetchKeywordsForCampaignIdStubFail stub
-  phoenixCampaign.id = 'fail';
+  const campaignId = 'fail';
   const memberSupportMsg = stubs.getDefaultContenfulCampaignMessage('memberSupport');
 
-  await t.throws(helpers.replacePhoenixCampaignVars(memberSupportMsg, phoenixCampaign));
+  await t.throws(helpers.findAndReplaceKeywordVarForCampaignId(memberSupportMsg, campaignId));
   contentful.fetchKeywordsForCampaignId.should.have.been.called;
 });
 
-test('replacePhoenixCampaignVars with no message should return empty string', async () => {
+test('replacePhoenixCampaignVars with no message should return empty string', () => {
   const phoenixCampaign = stubs.getPhoenixCampaign();
-  const renderedMessage = await helpers
-    .replacePhoenixCampaignVars(undefined, phoenixCampaign);
+  const renderedMessage = helpers.replacePhoenixCampaignVars(undefined, phoenixCampaign);
   renderedMessage.should.equal('');
 });
 
-test('replacePhoenixCampaignVars on a campaign object missing reportbackInfo should throw', async (t) => {
+test('replacePhoenixCampaignVars on a campaign object missing reportbackInfo should throw', (t) => {
   const phoenixCampaign = stubs.getPhoenixCampaign();
   delete phoenixCampaign.reportbackInfo;
   const memberSupportMsg = stubs.getDefaultContenfulCampaignMessage('gambitSignupMenu');
-  await t.throws(helpers.replacePhoenixCampaignVars(memberSupportMsg, phoenixCampaign));
+  const error = t.throws(() => helpers.replacePhoenixCampaignVars(memberSupportMsg, phoenixCampaign));
 });
 
 // sendTimeoutResponse

--- a/test/stubs/contentful/get-entries-campaign.json
+++ b/test/stubs/contentful/get-entries-campaign.json
@@ -2,7 +2,7 @@
   "sys": {
     "type": "Array"
   },
-  "total": 1,
+  "total": 2,
   "skip": 0,
   "limit": 100,
   "items": [
@@ -31,6 +31,33 @@
       },
       "fields": {
         "campaignId": "2299"
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "owik07lyerdj"
+          }
+        },
+        "id": "98Oy1FcaR2EiaMieicaool",
+        "type": "Entry",
+        "createdAt": "2017-02-15T19:19:34.100Z",
+        "updatedAt": "2017-02-15T19:19:34.100Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "campaign"
+          }
+        },
+        "locale": "en-US"
+      },
+      "fields": {
+        "campaignId": "default"
       }
     }
   ]


### PR DESCRIPTION
#### What's this PR do?
Resolves #990 by always returning a response regardless of whether a Phoenix Campaign has a corresponding Contentful campaign. If it doesn't have a Contentful Campaign, we return the `templates` property rendered with the default Contentful Campaign data.

I can deploy to GamCam Staging to confirm expected behavior for both the `GET /campaigns/:id` and `POST /chatbot` endpoints, and that we stop seeing the errors in #990 from web signups on Campaigns without keywords -- but this breaks a bunch of tests, which is why it's not ready to merge just yet. It might be easier to review at this point, as it'd just be less lines of code to review... 

#### Any background context you want to provide?
Next up in this branch:
* removing or preferably fixing failing tests
* Improving documentation for endpoints:
    * `GET /campaigns` - Returns all Phoenix Campaigns that have published Gambini Keywords (regardless of Phoenix Campaign Status)
    * `GET /campaigns/:id` - Returns to rendered Gambit templates to be used for given Phoenix Campaign ID if it's open on Gambit (has Phoenix Campaign status `active` and at least one published Keyword) 

#### Relevant tickets
Fixes #990 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [x] Tested on staging.
