### PR TITLE
Fixes the bug of listening to ready event to bind the app

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -47,9 +47,4 @@ configVars.mongooseConnection = require('./mongoose')({
   dbUri: configVars.dbUri,
 });
 
-/**
- * Redis Cache setup
- */
-configVars.redisClient = require('./redis')();
-
 module.exports = configVars;

--- a/server.js
+++ b/server.js
@@ -90,19 +90,17 @@ function start(processId) {
     next();
   });
 
-  config.redisClient.on('ready', () => {
-    config.mongooseConnection
-      .then(() => {
-        logger.info(`config.mongooseConnection.connection.readyState:${config.mongooseConnection.connection.readyState}`);
-        return app.listen(config.port, () => {
-          logger.info(`Gambit is listening on port:${config.port} env:${config.environment}.`);
-        });
-      })
-      .catch((error) => {
-        logger.error(`Gambit could not connect to port:${config.port} env:${config.environment}.`);
-        logger.error(error.message);
+  config.mongooseConnection
+    .then(() => {
+      logger.info(`config.mongooseConnection.connection.readyState:${config.mongooseConnection.connection.readyState}`);
+      return app.listen(config.port, () => {
+        logger.info(`Gambit is listening on port:${config.port} env:${config.environment}.`);
       });
-  });
+    })
+    .catch((error) => {
+      logger.error(`Gambit could not connect to port:${config.port} env:${config.environment}.`);
+      logger.error(error.message);
+    });
 }
 
 // Initialize Concurrency


### PR DESCRIPTION
#### What's this PR do?
It removes the app.listen binding from inside the redisClient `ready`. This event fires every time the redisClient reconnects and it's ready. The redisClient reconnects when it has been idle for more than the allowed time (60s).

#### How should this be reviewed?
- Follow README to have Redis working in localhost.
- Run `redis-cli`.
    - Inside the Redis CLI shell, run `CONFIG SET TIMEOUT 60`. This will set your Redis instance to disconnect clients after 60 seconds.
- Run `heroku local` in a different tab.
    - Every 60 seconds of idling time, you should see a `debug: redisClient is reconnecting` log message.


#### Any background context you want to provide?
This PR fixes this error:
```
2017-11-01T13:13:00.978604+00:00 app[web.4]: events.js:160
2017-11-01T13:13:00.978607+00:00 app[web.4]:       throw er; // Unhandled 'error' event
2017-11-01T13:13:00.978608+00:00 app[web.4]:       ^
2017-11-01T13:13:00.978608+00:00 app[web.4]: 
2017-11-01T13:13:00.978609+00:00 app[web.4]: Error: bind EADDRINUSE null:21103
2017-11-01T13:13:00.978610+00:00 app[web.4]:     at Object.exports._errnoException (util.js:1020:11)
2017-11-01T13:13:00.978611+00:00 app[web.4]:     at exports._exceptionWithHostPort (util.js:1043:20)
2017-11-01T13:13:00.978611+00:00 app[web.4]:     at cb (net.js:1327:16)
2017-11-01T13:13:00.978612+00:00 app[web.4]:     at rr (cluster.js:625:14)
2017-11-01T13:13:00.978613+00:00 app[web.4]:     at Worker.<anonymous> (cluster.js:594:9)
2017-11-01T13:13:00.978613+00:00 app[web.4]:     at process.<anonymous> (cluster.js:766:8)
2017-11-01T13:13:00.978614+00:00 app[web.4]:     at emitTwo (events.js:111:20)
2017-11-01T13:13:00.978614+00:00 app[web.4]:     at process.emit (events.js:191:7)
2017-11-01T13:13:00.978616+00:00 app[web.4]:     at process.wrappedEmit [as emit] (/app/node_modules/newrelic/lib/instrumentation/core/globals.js:61:27)
2017-11-01T13:13:00.978617+00:00 app[web.4]:     at process.nextTick (internal/child_process.js:787:12)
2017-11-01T13:13:00.978617+00:00 app[web.4]:     at _combinedTickCallback (internal/process/next_tick.js:73:7)
2017-11-01T13:13:00.978621+00:00 app[web.4]:     at process._tickDomainCallback [as _tickCallback] (internal/process/next_tick.js:128:9)
```

#### Checklist
- [x] Tested on staging.
