### PR TITLE
TGM: Helpers cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ GAMBIT_CMD_REPORTBACK=P
 CONTENTFUL_ACCESS_TOKEN=totallysecret
 CONTENTFUL_SPACE_ID=puP43Ts70tH
 
-DS_API_POST_SOURCE=sms-mobilecommons
+DS_API_POST_SOURCE=sms
 DS_PHOENIX_API_BASEURI=https://fake.dosomething.org/api/v1
 DS_ROGUE_API_BASEURI=https://rogue-fake.dosomething.org/api/v2
 DS_ROGUE_API_KEY=totallysecret
@@ -22,7 +22,6 @@ STATHAT_EZ_KEY=puppet.sloth@dosomething.org
 
 ## Optional settings
 
-GAMBIT_CHATBOT_RESPONSE_PREFIX=@dev:
 GAMBIT_TIMEOUT_NUM_SECONDS=20
 GAMBIT_CAMPAIGNS_CACHE_TTL=3600
 

--- a/app/models/Signup.js
+++ b/app/models/Signup.js
@@ -5,6 +5,8 @@
  */
 const mongoose = require('mongoose');
 const Promise = require('bluebird');
+const underscore = require('underscore');
+const camelCaseKeys = require('camelcase-keys-deep');
 const logger = require('winston');
 
 const ReportbackSubmission = require('./ReportbackSubmission');
@@ -223,6 +225,41 @@ signupSchema.methods.createPostForReq = function (req) {
         return reject(scope);
       });
   });
+};
+
+/**
+ * Returns formatted object to use in API responses.
+ */
+signupSchema.methods.formatForApi = function () {
+  const draft = this.draft_reportback_submission;
+  let draftId;
+  if (draft && draft._id) {
+    draftId = draft._id.toString();
+  }
+
+  const signupObject = this.toObject();
+  const omitKeys = ['__v'];
+  const formattedSignup = camelCaseKeys(underscore.omit(signupObject, omitKeys));
+  formattedSignup.id = Number(formattedSignup.id);
+
+  if (draft) {
+    const draftObject = formattedSignup.draftReportbackSubmission;
+    // We don't need to repeat the Campaign property inside our draft Reportback Submission, it's
+    // defined on the Signup.
+    omitKeys.push('campaign');
+    formattedSignup.draftReportbackSubmission = underscore.omit(draftObject, omitKeys);
+    // A Mongo ObjectId gets converted to an id object, we just want an ID string.
+    formattedSignup.draftReportbackSubmission.id = draftId;
+  }
+
+  // Return ID properties as objects instead.
+  formattedSignup.campaign = { id: formattedSignup.campaign };
+  formattedSignup.user = { id: formattedSignup.user };
+  if (formattedSignup.reportback) {
+    formattedSignup.reportback = { id: formattedSignup.reportback };
+  }
+
+  return formattedSignup;
 };
 
 module.exports = mongoose.model('signups', signupSchema);

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -5,9 +5,6 @@
  */
 const logger = require('winston');
 const newrelic = require('newrelic');
-const camelCaseKeys = require('camelcase-keys-deep');
-const underscore = require('underscore');
-
 const contentful = require('./contentful');
 const stathat = require('./stathat');
 
@@ -142,58 +139,20 @@ module.exports.sendResponse = function (res, code, messageText) {
 };
 
 /**
- * Converts a Signup document (and its nested draft Reportback Submission) into an object with
- * camelCase keys.
- * @param {Signup} signupDoc
- * @return {object}
- */
-module.exports.formatSignupResponse = function (signupDoc) {
-  if (!signupDoc) {
-    return null;
-  }
-  const draftDoc = signupDoc.draft_reportback_submission;
-  let draftId;
-  if (draftDoc && draftDoc._id) {
-    draftId = draftDoc._id.toString();
-  }
-
-  const signupObject = signupDoc.toObject();
-  const omitKeys = ['__v'];
-  const formattedSignup = camelCaseKeys(underscore.omit(signupObject, omitKeys));
-  formattedSignup.id = Number(formattedSignup.id);
-
-  if (draftDoc) {
-    const draft = formattedSignup.draftReportbackSubmission;
-    // We don't need to repeat the Campaign property inside our draft Reportback Submission, it's
-    // defined on the Signup.
-    omitKeys.push('campaign');
-    formattedSignup.draftReportbackSubmission = underscore.omit(draft, omitKeys);
-    // A Mongo ObjectId gets converted to an id object, we just want an ID string.
-    formattedSignup.draftReportbackSubmission.id = draftId;
-  }
-
-  // Return ID properties as objects instead.
-  formattedSignup.campaign = { id: formattedSignup.campaign };
-  formattedSignup.user = { id: formattedSignup.user };
-  if (formattedSignup.reportback) {
-    formattedSignup.reportback = { id: formattedSignup.reportback };
-  }
-
-  return formattedSignup;
-};
-
-/**
  * Sends response with the request Signup and the template to reply with.
  * @param {object} res - Express response
  * @param {Signup} signup
  * @param {string} replyTemplate
  */
 module.exports.sendResponseForSignup = function (res, signup, replyTemplate) {
-  const data = {
-    replyTemplate,
-    signup: exports.formatSignupResponse(signup),
-  };
-  const signupId = data.signup ? data.signup.id : null;
+  const data = { replyTemplate };
+  let signupId = null;
+  if (signup) {
+    data.signup = signup.formatForApi();
+    signupId = data.signup.id;
+  } else {
+    data.signup = null;
+  }
   logger.info('helpers.sendResponseForSignup', { signupId, replyTemplate });
   logger.verbose('helpers.sendResponseForSignup', { data });
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -3,7 +3,6 @@
 /**
  * Imports.
  */
-const crypto = require('crypto');
 const logger = require('winston');
 const newrelic = require('newrelic');
 const camelCaseKeys = require('camelcase-keys-deep');
@@ -24,74 +23,9 @@ module.exports.addBlinkSuppressHeaders = function addBlinkSuppressHeaders(res) {
 };
 
 /**
- * Renders message for given request and messageTemplate.
- * @param {object} req - Express request
- * @param {string} messageTemplate
+ * @param {string} message
+ * @return {string}
  */
-module.exports.renderMessageTemplate = function renderMessageTemplate(req, messageTemplate) {
-  newrelic.addCustomParameters({ outboundMessageTemplate: messageTemplate });
-
-  return contentful.renderMessageForPhoenixCampaign(req.campaign, messageTemplate)
-    .then((renderedMessage) => {
-      let message = renderedMessage;
-
-      // Possible for edge cases like closed campaign messages.
-      if (!req.signup) {
-        return module.exports.addSenderPrefix(message);
-      }
-
-      let quantity = req.signup.total_quantity_submitted;
-      if (req.signup.draft_reportback_submission) {
-        quantity = req.signup.draft_reportback_submission.quantity;
-      }
-      if (quantity) {
-        message = message.replace(/{{quantity}}/gi, quantity);
-      }
-
-      const revisiting = req.keyword && req.signup.draft_reportback_submission;
-      if (revisiting) {
-        const continuingMessage = 'Picking up where you left off on';
-        const campaignTitle = req.campaign.title;
-        message = `${continuingMessage} ${campaignTitle}...\n\n${message}`;
-      }
-
-      return module.exports.addSenderPrefix(message);
-    })
-    .catch(err => err);
-};
-
-module.exports.getKeyword = function getKeyword(req, res) {
-  return contentful.fetchKeyword(req.keyword)
-    .then((keyword) => {
-      const environment = req.app.get('environment');
-      module.exports.handleTimeout(req, res);
-
-      if (!keyword) {
-        return module.exports.sendResponse(res, 404, `Keyword ${req.keyword} not found.`);
-      }
-
-      if (keyword.fields.environment !== environment) {
-        const msg = `Keyword ${req.keyword} environment error: defined as ${keyword.environment} ` +
-                    `but sent to ${environment}.`;
-        return module.exports.sendUnproccessibleEntityResponse(res, msg);
-      }
-      return keyword;
-    })
-    .catch(err => module.exports.sendErrorResponse(res, err));
-};
-
-/**
- * Prepends the Sender Prefix config variable if it exists.
- */
-module.exports.addSenderPrefix = function (string) {
-  const senderPrefix = process.env.GAMBIT_CHATBOT_RESPONSE_PREFIX;
-  if (!senderPrefix) {
-    return string;
-  }
-
-  return `${senderPrefix} ${string}`;
-};
-
 module.exports.getFirstWord = function (message) {
   if (!message) {
     return null;
@@ -104,6 +38,10 @@ module.exports.getFirstWord = function (message) {
   return trimmed;
 };
 
+/**
+ * @param {string} message
+ * @return {boolean}
+ */
 module.exports.hasLetters = function (message) {
   return RegExp(/[a-zA-Z]/g).test(message);
 };
@@ -126,13 +64,6 @@ module.exports.isValidReportbackQuantity = function (input) {
  */
 module.exports.isValidReportbackText = function (input) {
   return !!(input && input.trim().length > 3 && this.hasLetters(input));
-};
-
-module.exports.generatePassword = function (text) {
-  return crypto.createHmac('sha1', process.env.DS_API_PASSWORD_KEY)
-    .update(text)
-    .digest('hex')
-    .substring(0, 6);
 };
 
 /**
@@ -315,7 +246,6 @@ module.exports.upsertOptions = function () {
 
   return options;
 };
-
 
 /**
  * Determines if given incomingMessage matches given Gambit command type.

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -180,7 +180,7 @@ module.exports.formatSignupResponse = function (signupDoc) {
   }
 
   return formattedSignup;
-}
+};
 
 /**
  * Sends response with the request Signup and the template to reply with.

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -122,9 +122,8 @@ module.exports.findAndReplaceKeywordVarForCampaignId = function (input, campaign
  * @param {object} res - Express response
  * @param {number} code - HTTP status code to return
  * @param {string} messageText
- * @param {string} messageTemplate
  */
-module.exports.sendResponse = function (res, code, messageText, messageTemplate) {
+module.exports.sendResponse = function (res, code, messageText) {
   let type = 'success';
   if (code > 200) {
     type = 'error';
@@ -137,9 +136,6 @@ module.exports.sendResponse = function (res, code, messageText, messageTemplate)
     code,
     message: messageText,
   };
-  if (messageTemplate) {
-    response[type].template = messageTemplate;
-  }
   logger.verbose(response);
 
   return res.status(code).send(response);

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -147,7 +147,10 @@ module.exports.sendResponse = function (res, code, messageText) {
  * @param {Signup} signupDoc
  * @return {object}
  */
-function formatSignupResponse(signupDoc) {
+module.exports.formatSignupResponse = function (signupDoc) {
+  if (!signupDoc) {
+    return null;
+  }
   const draftDoc = signupDoc.draft_reportback_submission;
   let draftId;
   if (draftDoc && draftDoc._id) {
@@ -188,9 +191,10 @@ function formatSignupResponse(signupDoc) {
 module.exports.sendResponseForSignup = function (res, signup, replyTemplate) {
   const data = {
     replyTemplate,
-    signup: formatSignupResponse(signup),
+    signup: exports.formatSignupResponse(signup),
   };
-  logger.info('helpers.sendResponseForSignup', { signupId: data.signup.id, replyTemplate });
+  const signupId = data.signup ? data.signup.id : null;
+  logger.info('helpers.sendResponseForSignup', { signupId, replyTemplate });
   logger.verbose('helpers.sendResponseForSignup', { data });
 
   return res.send({ data });

--- a/test/lib/helpers.test.js
+++ b/test/lib/helpers.test.js
@@ -8,7 +8,6 @@ const Promise = require('bluebird');
 const test = require('ava');
 const chai = require('chai');
 const expect = require('chai').expect;
-const crypto = require('crypto');
 const newrelic = require('newrelic');
 const logger = require('winston');
 const sinonChai = require('sinon-chai');
@@ -24,16 +23,8 @@ const stathat = require('../../lib/stathat');
 const helpers = require('../../lib/helpers');
 
 // Stub functions
-const fetchKeywordStub = Promise.resolve(stubs.getJSONstub('fetchKeyword'));
-const fetchKeywordStubEmpty = Promise.resolve('');
-const fetchKeywordStubFail = Promise.reject(false);
 const fetchKeywordsForCampaignIdStub = () => Promise.resolve(stubs.contentful.getKeywords());
 const fetchKeywordsForCampaignIdStubFail = () => Promise.reject({ status: 500 });
-const cryptoCreateHmacStub = {
-  update() { return this; },
-  digest() { return this; },
-  substring() { return this; },
-};
 
 // setup "x.should.y" assertion style
 chai.should();
@@ -52,7 +43,6 @@ test.beforeEach((t) => {
     .returns(Promise.resolve([]));
   sandbox.stub(newrelic, 'addCustomParameters');
   sandbox.stub(stathat, 'postStat');
-  sandbox.stub(crypto, 'createHmac').returns(cryptoCreateHmacStub);
 
   // setup spies
   sandbox.spy(helpers, 'sendErrorResponse');
@@ -134,70 +124,6 @@ test('sendTimeoutResponse', (t) => {
   t.context.res.status.should.have.been.calledWith(504);
 });
 
-// getKeyword
-test('getKeyword should return a promise that will resolve in a keyword when found', async (t) => {
-  // setup
-  sandbox.stub(contentful, 'fetchKeyword').returns(fetchKeywordStub);
-  sandbox.spy(helpers, 'sendUnproccessibleEntityResponse');
-  t.context.req.app = {
-    get: sinon.stub().returns('thor'),
-  };
-
-  // test
-  const keyword = await helpers.getKeyword(t.context.req, t.context.res);
-  helpers.sendResponse.should.not.have.been.called;
-  helpers.sendUnproccessibleEntityResponse.should.not.have.been.called;
-  keyword.should.not.be.empty;
-});
-
-test('getKeyword should send a 404 response when no broadcast is found', async (t) => {
-  // setup
-  sandbox.stub(contentful, 'fetchKeyword').returns(fetchKeywordStubEmpty);
-  t.context.req.app = {
-    get: sinon.stub().returns('thor'),
-  };
-
-  // test
-  await helpers.getKeyword(t.context.req, t.context.res);
-  helpers.sendResponse.should.have.been.calledWith(t.context.res, 404);
-});
-
-
-test('getKeyword should send Error response when it fails retrieving a broadcast', async (t) => {
-  // setup
-  sandbox.stub(contentful, 'fetchKeyword').returns(fetchKeywordStubFail);
-
-  // test
-  await helpers.getKeyword(t.context.req, t.context.res);
-  helpers.sendErrorResponse.should.have.been.called;
-});
-
-test('getKeyword should send an unprocessable entity error response when environments don\'t match for keyword', async (t) => {
-  // setup
-
-  // The fetchKeywordStub response is a thor environment keyword
-  sandbox.stub(contentful, 'fetchKeyword').returns(fetchKeywordStub);
-  sandbox.spy(helpers, 'sendUnproccessibleEntityResponse');
-  t.context.req.app = {
-    get: sinon.stub().returns('test'),
-  };
-
-  // test
-  await helpers.getKeyword(t.context.req, t.context.res);
-  helpers.sendUnproccessibleEntityResponse.should.have.been.called;
-});
-
-// addSenderPrefix
-test('addSenderPrefix', () => {
-  const prefix = process.env.GAMBIT_CHATBOT_RESPONSE_PREFIX;
-  const text = 'taco';
-  const string = `${prefix} ${text}`;
-  helpers.addSenderPrefix(text).should.be.equal(string);
-
-  process.env.GAMBIT_CHATBOT_RESPONSE_PREFIX = '';
-  helpers.addSenderPrefix(text).should.be.equal(text);
-});
-
 // getFirstWord
 test('getFirstWord should return null if no message is passed', () => {
   const result = helpers.getFirstWord(undefined);
@@ -219,12 +145,6 @@ test('isValidReportbackText', () => {
   helpers.isValidReportbackText('123').should.be.false;
   helpers.isValidReportbackText('hi     ').should.be.false;
   helpers.isValidReportbackText('').should.be.false;
-});
-
-// generatePassword
-test('generatePassword', () => {
-  helpers.generatePassword('taco');
-  crypto.createHmac.should.have.been.calledWithExactly('sha1', process.env.DS_API_PASSWORD_KEY);
 });
 
 // isCommand

--- a/test/lib/helpers.test.js
+++ b/test/lib/helpers.test.js
@@ -16,6 +16,7 @@ const sinon = require('sinon');
 
 // App Modules
 const stubs = require('../../test/utils/stubs');
+const signupFactory = require('../utils/factories/signup');
 const contentful = require('../../lib/contentful.js');
 const stathat = require('../../lib/stathat');
 
@@ -117,11 +118,25 @@ test('replacePhoenixCampaignVars on a campaign object missing reportbackInfo sho
 });
 
 // sendResponseForSignup
-test('sendResponseForSignup', (t) => {
+test('sendResponseForSignup should call signup.formatForApi', (t) => {
   sandbox.spy(t.context.res, 'send');
-  sandbox.spy(helpers, 'formatSignupResponse');
-  helpers.sendResponseForSignup(t.context.res);
-  helpers.formatSignupResponse.should.have.been.called;
+  const signup = signupFactory.getValidSignup();
+  sandbox.stub(signup, 'formatForApi').returns({ id: signup.id });
+  t.context.req.signup = signup;
+
+  helpers.sendResponseForSignup(t.context.res, signup);
+  signup.formatForApi.should.have.been.called;
+  t.context.res.send.should.have.been.called;
+});
+
+test('sendResponseForSignup should not call signup.formatForApi if signup arg undefined', (t) => {
+  sandbox.spy(t.context.res, 'send');
+  const signup = signupFactory.getValidSignup();
+  sandbox.stub(signup, 'formatForApi').returns({ id: signup.id });
+  t.context.req.signup = signup;
+
+  helpers.sendResponseForSignup(t.context.res, null);
+  signup.formatForApi.should.not.have.been.called;
   t.context.res.send.should.have.been.called;
 });
 

--- a/test/lib/helpers.test.js
+++ b/test/lib/helpers.test.js
@@ -116,6 +116,15 @@ test('replacePhoenixCampaignVars on a campaign object missing reportbackInfo sho
   t.throws(() => helpers.replacePhoenixCampaignVars(text, phoenixCampaign));
 });
 
+// sendResponseForSignup
+test('sendResponseForSignup', (t) => {
+  sandbox.spy(t.context.res, 'send');
+  sandbox.spy(helpers, 'formatSignupResponse');
+  helpers.sendResponseForSignup(t.context.res);
+  helpers.formatSignupResponse.should.have.been.called;
+  t.context.res.send.should.have.been.called;
+});
+
 // sendTimeoutResponse
 test('sendTimeoutResponse', (t) => {
   sandbox.spy(t.context.res, 'status');


### PR DESCRIPTION
#### What's this PR do?
* Removes deprecated `helpers` functions and their tests
* Adds tests for `helpers.sendResponseForSignup`
* Refactors `helpers.formatSignupResponse(signupDoc)` as a Signup instance method 

#### How should this be reviewed?
Verify all POST and GET requests work as expected. Will deploy to staging to confirm via Conversations.

#### Any background context you want to provide?
Next up:
- Add tests for `Signup` model
- Move `generatePassword` helper and test into Gambit Conversations

#### Relevant tickets
#989 

#### Checklist
- [x] Tested on staging.
