### PR TITLE
Renames gambit-conversations to gambit

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,5 +1,5 @@
 
-[![wercker status](https://app.wercker.com/status/88e7574ecfa61c969df7bee4e035a7ad/s/master "wercker status")](https://app.wercker.com/project/byKey/88e7574ecfa61c969df7bee4e035a7ad) [![codecov](https://codecov.io/gh/DoSomething/gambit-conversations/branch/master/graph/badge.svg)](https://codecov.io/gh/DoSomething/gambit-conversations)
+[![wercker status](https://app.wercker.com/status/88e7574ecfa61c969df7bee4e035a7ad/s/master "wercker status")](https://app.wercker.com/project/byKey/88e7574ecfa61c969df7bee4e035a7ad) [![codecov](https://codecov.io/gh/DoSomething/gambit/branch/master/graph/badge.svg)](https://codecov.io/gh/DoSomething/gambit)
 
 # Gambit
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -1,9 +1,9 @@
 
 [![wercker status](https://app.wercker.com/status/88e7574ecfa61c969df7bee4e035a7ad/s/master "wercker status")](https://app.wercker.com/project/byKey/88e7574ecfa61c969df7bee4e035a7ad) [![codecov](https://codecov.io/gh/DoSomething/gambit-conversations/branch/master/graph/badge.svg)](https://codecov.io/gh/DoSomething/gambit-conversations)
 
-# Gambit Conversations
+# Gambit
 
-Gambit Conversations is our DoSomething.org [API](/documentation/README.md) for SMS conversations:
+Gambit is the DoSomething.org [API](/documentation/README.md) for SMS conversations:
 
 * Receives inbound messages, creates/updates [users](https://www.github.com/dosomething/northstar) and/or [campaign activity](https://www.github.com/dosomething/rogue), and sends an outbound reply
 
@@ -25,7 +25,7 @@ Gambit forwards support requests from users into a [Front](https://www.frontapp.
 
 ## Development
 
-Gambit Conversations is built with:
+Gambit is built with:
 * ❤️ + ☕
 * [Express](https://expressjs.com/)
 * [Redis](https://redis.io/)
@@ -49,10 +49,10 @@ Local Node, redis, and MongoDB installations are required to run this applicatio
 
 ### Localhost
 
-With Conversations running locally, test Gambit replies by opening a new terminal window and running `node shell`.
+With Gambit running locally, test Gambit replies by opening a new terminal window and running `node shell`.
 
 ```
-PuppetSloth-MacBook-Pro-2:gambit-conversations puppetsloth$ node shell
+PuppetSloth-MacBook-Pro-2:gambit puppetsloth$ node shell
 
 
  ██████╗  █████╗ ███╗   ███╗██████╗ ██╗████████╗

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "gambit-conversations",
+  "name": "gambit",
   "version": "6.0.2",
   "description": "The DoSomething.org chatbot service for multi-platform conversations.",
   "author": "DoSomething.org",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/DoSomething/gambit-conversations.git"
+    "url": "git+https://github.com/DoSomething/gambit.git"
   },
   "scripts": {
     "test-fast": "NODE_ENV=test ava --serial --fail-fast",


### PR DESCRIPTION
#### What's this PR do?

I've transferred ownership of Gambit Content over to the DoSomethingArchive -- that repo was once named `gambit`... so it seems it's about time to change this one to just `gambit` 

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
Not sure if this will break codecov and other fun things, opening this to find out.


