### PR TITLE
Fetch askSubscriptionStatus replies from GraphQL

### DIFF
--- a/app/routes/messages/member.js
+++ b/app/routes/messages/member.js
@@ -23,6 +23,7 @@ const parseRivescriptReplyMiddleware = require('../../../lib/middleware/messages
 const forwardSupportMessageMiddleware = require('../../../lib/middleware/messages/member/support-message');
 const replyMacroMiddleware = require('../../../lib/middleware/messages/member/macro-reply');
 const getTopicMiddleware = require('../../../lib/middleware/messages/member/topic-get');
+const askSubscriptionStatusMiddleware = require('../../../lib/middleware/messages/member/topics/ask-subscription-status');
 const askVotingPlanStatusMiddleware = require('../../../lib/middleware/messages/member/topics/ask-voting-plan-status');
 const askYesNoMiddleware = require('../../../lib/middleware/messages/member/topics/ask-yes-no');
 const autoReplyMiddleware = require('../../../lib/middleware/messages/member/topics/auto-reply');
@@ -74,10 +75,13 @@ router.use(forwardSupportMessageMiddleware());
 // Otherwise, fetch the current conversation topic.
 router.use(getTopicMiddleware());
 
-// Handles replies for askVotingPlanStatus topics.
+// Handles replies for askSubscriptionStatus broadcast topics.
+router.use(askSubscriptionStatusMiddleware());
+
+// Handles replies for askVotingPlanStatus broadcast topics.
 router.use(askVotingPlanStatusMiddleware());
 
-// Handles replies for askYesNo topics.
+// Handles replies for askYesNo broadcast topics.
 router.use(askYesNoMiddleware());
 
 // Handles autoReply topics.

--- a/brain/macros.rive
+++ b/brain/macros.rive
@@ -21,10 +21,7 @@
 + join
 @ subscribe
 
-+ (week|weekly)
-- subscriptionStatusActive
-
-+ (less|month|monthly)
++ less
 - subscriptionStatusLess
 
 + stop

--- a/brain/topics/askSubscriptionStatus.rive
+++ b/brain/topics/askSubscriptionStatus.rive
@@ -16,6 +16,6 @@
 @ c
 
 + [*]
-- invalidAskSubscriptionStatusResponse
+- invalid
 
 < topic

--- a/brain/topics/askSubscriptionStatus.rive
+++ b/brain/topics/askSubscriptionStatus.rive
@@ -1,5 +1,4 @@
 // Current options are A) Weekly B) Monthly C) Need more info D) Stop
-// @see config/lib/helpers/macro
 
 > topic ask_subscription_status includes random
 

--- a/brain/topics/askSubscriptionStatus.rive
+++ b/brain/topics/askSubscriptionStatus.rive
@@ -24,6 +24,6 @@
 - subscriptionStatusNeedMoreInfo
 
 + [*]
-- invalid
+- invalidAskSubscriptionStatusResponse
 
 < topic

--- a/brain/topics/askSubscriptionStatus.rive
+++ b/brain/topics/askSubscriptionStatus.rive
@@ -1,4 +1,4 @@
-// Current options are A) Weekly B) Monthly C) Need more info
+// Current options are A) Weekly B) Monthly C) Need more info D) Stop
 // @see config/lib/helpers/macro
 
 > topic ask_subscription_status includes random
@@ -12,6 +12,9 @@
 + c [*]
 - subscriptionStatusNeedMoreInfo
 
++ d [*]
+- subscriptionStatusStop
+
 + (week|weekly)
 - subscriptionStatusActive
 
@@ -19,7 +22,7 @@
 - subscriptionStatusLess
 
 + [*] more [*]
-@ c
+- subscriptionStatusNeedMoreInfo
 
 + [*]
 - invalid

--- a/brain/topics/askSubscriptionStatus.rive
+++ b/brain/topics/askSubscriptionStatus.rive
@@ -12,6 +12,12 @@
 + c [*]
 - subscriptionStatusNeedMoreInfo
 
++ (week|weekly)
+- subscriptionStatusActive
+
++ (month|monthly)
+- subscriptionStatusLess
+
 + [*] more [*]
 @ c
 

--- a/brain/topics/askSubscriptionStatus.rive
+++ b/brain/topics/askSubscriptionStatus.rive
@@ -1,9 +1,6 @@
 // Current options are A) Weekly B) Monthly C) Need more info
 // @see config/lib/helpers/macro
 
-+ status
-- askSubscriptionStatus
-
 > topic ask_subscription_status includes random
 
 + a
@@ -19,6 +16,6 @@
 @ c
 
 + [*]
-- invalidSubscriptionStatus
+- invalidAskSubscriptionStatusResponse
 
 < topic

--- a/config/lib/graphql.js
+++ b/config/lib/graphql.js
@@ -91,6 +91,17 @@ const fetchTopicById = `
     topic(id: $id) {
       id
       contentType
+      ... on AskSubscriptionStatusBroadcastTopic {
+        saidActive
+        saidActiveTopic {
+          id
+        }
+        saidLess
+        saidLessTopic {
+          id
+        }
+        invalidAskSubscriptionStatusResponse
+      }
       ... on AskYesNoBroadcastTopic {
         invalidAskYesNoResponse
         saidNo

--- a/config/lib/graphql.js
+++ b/config/lib/graphql.js
@@ -92,6 +92,8 @@ const fetchTopicById = `
       id
       contentType
       ... on AskSubscriptionStatusBroadcastTopic {
+        invalidAskSubscriptionStatusResponse
+        saidNeedMoreInfo
         saidActive
         saidActiveTopic {
           id
@@ -100,7 +102,6 @@ const fetchTopicById = `
         saidLessTopic {
           id
         }
-        invalidAskSubscriptionStatusResponse
       }
       ... on AskYesNoBroadcastTopic {
         invalidAskYesNoResponse

--- a/config/lib/helpers/macro.js
+++ b/config/lib/helpers/macro.js
@@ -8,6 +8,7 @@ const invalidAnswerText = 'Sorry, I didn\'t get that.';
 
 // Subscription status.
 const activeSubscriptionStatusText = 'Hi I\'m Freddie from DoSomething.org! Welcome to my weekly updates (up to 8msg/month). Things to know: Msg&DataRatesApply. Text HELP for help, text STOP to stop.';
+const lessSubscriptionStatusText = 'Hi I\'m Freddie from DoSomething.org! Welcome to my monthly updates (up to 2msg/month). Things to know: Msg&DataRatesApply. Text HELP for help, text STOP to stop.';
 
 // Voting plan.
 const askVotingPlanAttendingWithText = process.env.DS_GAMBIT_CONVERSATIONS_ASK_VOTING_PLAN_ATTENDING_WITH_TEXT || 'Who are you planning on voting with? A) Alone B) Friends C) Family D) Co-workers';
@@ -146,6 +147,7 @@ module.exports = {
         field: profile.subscriptionStatus.name,
         value: profile.subscriptionStatus.values.active,
       },
+      text: activeSubscriptionStatusText,
     },
     subscriptionStatusLess: {
       name: 'subscriptionStatusLess',
@@ -153,6 +155,7 @@ module.exports = {
         field: profile.subscriptionStatus.name,
         value: profile.subscriptionStatus.values.less,
       },
+      text: lessSubscriptionStatusText,
     },
     subscriptionStatusNeedMoreInfo: {
       name: 'subscriptionStatusNeedMoreInfo',

--- a/config/lib/helpers/macro.js
+++ b/config/lib/helpers/macro.js
@@ -8,8 +8,6 @@ const invalidAnswerText = 'Sorry, I didn\'t get that.';
 
 // Subscription status.
 const activeSubscriptionStatusText = 'Hi I\'m Freddie from DoSomething.org! Welcome to my weekly updates (up to 8msg/month). Things to know: Msg&DataRatesApply. Text HELP for help, text STOP to stop.';
-const askSubscriptionStatusText = 'Do you want texts: A)Weekly B)Monthly C)I need more info';
-const newsUrl = 'https://www.dosomething.org/us/spot-the-signs-guide?source=sms&utm_source=dosomething&utm_medium=sms&utm_campaign=permissioning_weekly&user_id={{user.id}}';
 
 // Voting plan.
 const askVotingPlanAttendingWithText = process.env.DS_GAMBIT_CONVERSATIONS_ASK_VOTING_PLAN_ATTENDING_WITH_TEXT || 'Who are you planning on voting with? A) Alone B) Friends C) Family D) Co-workers';
@@ -105,17 +103,11 @@ module.exports = {
       text: askVotingPlanStatusText,
       topic: rivescriptTopics.askVotingPlanStatus,
     },
-    askSubscriptionStatus: {
-      name: 'askSubscriptionStatus',
-      text: askSubscriptionStatusText,
-      topic: rivescriptTopics.askSubscriptionStatus,
-    },
     catchAll: {
       name: 'catchAll',
     },
     invalidSubscriptionStatus: {
       name: 'invalidSubscriptionStatus',
-      text: `${invalidAnswerText} ${askSubscriptionStatusText}`,
     },
     invalidVotingPlanAttendingWith: {
       name: 'invalidVotingPlanAttendingWith',
@@ -153,8 +145,6 @@ module.exports = {
     },
     subscriptionStatusActive: {
       name: 'subscriptionStatusActive',
-      text: activeSubscriptionStatusText,
-      topic: defaultTopic,
       profileUpdate: {
         field: profile.subscriptionStatus.name,
         value: profile.subscriptionStatus.values.active,
@@ -162,8 +152,6 @@ module.exports = {
     },
     subscriptionStatusLess: {
       name: 'subscriptionStatusLess',
-      text: `Okay, great! I'll text you once a month with updates on what's happening in the news and/or easy ways for you to take action in your community! Wanna take 2 mins to learn how to spot the signs of an abusive relationship and what you can do about it? Read our guide here: ${newsUrl}`,
-      topic: defaultTopic,
       profileUpdate: {
         field: profile.subscriptionStatus.name,
         value: profile.subscriptionStatus.values.less,
@@ -171,7 +159,6 @@ module.exports = {
     },
     subscriptionStatusNeedMoreInfo: {
       name: 'subscriptionStatusNeedMoreInfo',
-      text: `Sure! Once a week, I text over 3 million young people with updates on what's happening in the news and/or easy ways to take action in your community.\n\nWant an example of an easy way to take action? Take 2 mins to learn how to spot the signs of an abusive relationship and what you can do about it. Read our guide: ${newsUrl}`,
     },
     subscriptionStatusResubscribed: {
       name: 'subscriptionStatusResubscribed',

--- a/config/lib/helpers/macro.js
+++ b/config/lib/helpers/macro.js
@@ -106,9 +106,6 @@ module.exports = {
     catchAll: {
       name: 'catchAll',
     },
-    invalidSubscriptionStatus: {
-      name: 'invalidSubscriptionStatus',
-    },
     invalidVotingPlanAttendingWith: {
       name: 'invalidVotingPlanAttendingWith',
       text: `${invalidAnswerText} ${askVotingPlanAttendingWithText}`,

--- a/config/lib/helpers/macro.js
+++ b/config/lib/helpers/macro.js
@@ -143,19 +143,21 @@ module.exports = {
     },
     subscriptionStatusActive: {
       name: 'subscriptionStatusActive',
+      text: activeSubscriptionStatusText,
+      topic: defaultTopic,
       profileUpdate: {
         field: profile.subscriptionStatus.name,
         value: profile.subscriptionStatus.values.active,
       },
-      text: activeSubscriptionStatusText,
     },
     subscriptionStatusLess: {
       name: 'subscriptionStatusLess',
+      text: lessSubscriptionStatusText,
+      topic: defaultTopic,
       profileUpdate: {
         field: profile.subscriptionStatus.name,
         value: profile.subscriptionStatus.values.less,
       },
-      text: lessSubscriptionStatusText,
     },
     subscriptionStatusNeedMoreInfo: {
       name: 'subscriptionStatusNeedMoreInfo',

--- a/config/lib/helpers/macro.js
+++ b/config/lib/helpers/macro.js
@@ -8,7 +8,7 @@ const invalidAnswerText = 'Sorry, I didn\'t get that.';
 
 // Subscription status.
 const activeSubscriptionStatusText = 'Hi I\'m Freddie from DoSomething.org! Welcome to my weekly updates (up to 8msg/month). Things to know: Msg&DataRatesApply. Text HELP for help, text STOP to stop.';
-const lessSubscriptionStatusText = 'Hi I\'m Freddie from DoSomething.org! Welcome to my monthly updates (up to 2msg/month). Things to know: Msg&DataRatesApply. Text HELP for help, text STOP to stop.';
+const lessSubscriptionStatusText = 'Great, you\'ll start to receive 1 monthly update from Freddie at DoSomething.org! Things to know: Msg&DataRatesApply. Text HELP for help, text STOP to stop.';
 
 // Voting plan.
 const askVotingPlanAttendingWithText = process.env.DS_GAMBIT_CONVERSATIONS_ASK_VOTING_PLAN_ATTENDING_WITH_TEXT || 'Who are you planning on voting with? A) Alone B) Friends C) Family D) Co-workers';

--- a/config/lib/helpers/topic.js
+++ b/config/lib/helpers/topic.js
@@ -7,6 +7,9 @@ const topicTemplates = templateConfig.templatesMap.topicTemplates;
 
 module.exports = {
   types: {
+    askSubscriptionStatus: {
+      type: 'askSubscriptionStatus',
+    },
     askVotingPlanStatus: {
       type: 'askVotingPlanStatus',
     },
@@ -38,9 +41,6 @@ module.exports = {
     },
   },
   rivescriptTopics: {
-    askSubscriptionStatus: {
-      id: 'ask_subscription_status',
-    },
     askVotingPlanAttendingWith: {
       id: 'ask_voting_plan_attending_with',
     },

--- a/lib/helpers/macro.js
+++ b/lib/helpers/macro.js
@@ -63,6 +63,30 @@ function isSaidYes(macroName) {
  * @param {String} macroName
  * @return {Boolean}
  */
+function isSubscriptionStatusActive(macroName) {
+  return macroName === getMacroForKey('subscriptionStatusActive');
+}
+
+/**
+ * @param {String} macroName
+ * @return {Boolean}
+ */
+function isSubscriptionStatusLess(macroName) {
+  return macroName === getMacroForKey('subscriptionStatusLess');
+}
+
+/**
+ * @param {String} macroName
+ * @return {Boolean}
+ */
+function isSubscriptionStatusStop(macroName) {
+  return macroName === getMacroForKey('subscriptionStatusStop');
+}
+
+/**
+ * @param {String} macroName
+ * @return {Boolean}
+ */
 function isVotingPlanStatusVoting(macroName) {
   return (macroName === module.exports.macros.votingPlanStatusVoting());
 }
@@ -90,6 +114,9 @@ module.exports = {
   isMacro,
   isSaidNo,
   isSaidYes,
+  isSubscriptionStatusActive,
+  isSubscriptionStatusLess,
+  isSubscriptionStatusStop,
   isVotingPlanStatusVoting,
   macros: {
     invalidVotingPlanStatus: () => getMacroForKey('invalidVotingPlanStatus'),

--- a/lib/helpers/macro.js
+++ b/lib/helpers/macro.js
@@ -63,30 +63,6 @@ function isSaidYes(macroName) {
  * @param {String} macroName
  * @return {Boolean}
  */
-function isSubscriptionStatusActive(macroName) {
-  return macroName === getMacroForKey('subscriptionStatusActive');
-}
-
-/**
- * @param {String} macroName
- * @return {Boolean}
- */
-function isSubscriptionStatusLess(macroName) {
-  return macroName === getMacroForKey('subscriptionStatusLess');
-}
-
-/**
- * @param {String} macroName
- * @return {Boolean}
- */
-function isSubscriptionStatusStop(macroName) {
-  return macroName === getMacroForKey('subscriptionStatusStop');
-}
-
-/**
- * @param {String} macroName
- * @return {Boolean}
- */
 function isVotingPlanStatusVoting(macroName) {
   return (macroName === module.exports.macros.votingPlanStatusVoting());
 }
@@ -114,14 +90,15 @@ module.exports = {
   isMacro,
   isSaidNo,
   isSaidYes,
-  isSubscriptionStatusActive,
-  isSubscriptionStatusLess,
-  isSubscriptionStatusStop,
   isVotingPlanStatusVoting,
   macros: {
     invalidVotingPlanStatus: () => getMacroForKey('invalidVotingPlanStatus'),
     saidNo: () => getMacroForKey('saidNo'),
     saidYes: () => getMacroForKey('saidYes'),
+    subscriptionStatusActive: () => getMacroForKey('subscriptionStatusActive'),
+    subscriptionStatusLess: () => getMacroForKey('subscriptionStatusLess'),
+    subscriptionStatusNeedMoreInfo: () => getMacroForKey('subscriptionStatusNeedMoreInfo'),
+    subscriptionStatusStop: () => getMacroForKey('subscriptionStatusStop'),
     votingPlanStatusVoting: () => getMacroForKey('votingPlanStatusVoting'),
   },
 };

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -210,7 +210,7 @@ function isTwilioStudio(req) {
 }
 
 /**
- * Updates req.macro to saidYes or saidNo if inbound message can be parsed as either.
+ * Updates req.macro per askSubscriptionStatus topic reply.
  *
  * @async
  * @param {Object} req
@@ -222,7 +222,7 @@ async function parseAskSubscriptionStatusResponse(req) {
     .parseAskSubscriptionStatusResponse(req.inboundMessage.text);
 
   module.exports.setMacro(req, macroName);
-  // Overwrite the current 'catchAll' value as our subscription status macro.
+  // Overwrite the current 'catchAll' macro value with the askSubscriptionStatus reply.
   await req.inboundMessage.updateMacro(macroName);
 }
 

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -7,8 +7,7 @@ const config = require('../../config/lib/helpers/request');
 const DraftSubmission = require('../../app/models/DraftSubmission');
 
 /**
- * Updates conversation with given topic, and updates user subscription status to pending if
- * the new topic is an askSubscriptionStatus.
+ * Sets the request topic and saves it as the request conversation topic.
  *
  * @param {Object} req
  * @param {Object} topic
@@ -16,15 +15,7 @@ const DraftSubmission = require('../../app/models/DraftSubmission');
  */
 function changeTopic(req, topic) {
   module.exports.setTopic(req, topic);
-  const topicId = topic.id;
-  let promise = Promise.resolve();
-  if (req.currentTopicId === topicId) {
-    return promise;
-  }
-  if (helpers.topic.isAskSubscriptionStatus(topic) && req.userId) {
-    promise = helpers.user.setPendingSubscriptionStatusForUserId(req.userId);
-  }
-  return promise.then(() => req.conversation.setTopic(topic));
+  return req.currentTopicId === topic.id ? Promise.resolve() : req.conversation.setTopic(topic);
 }
 
 /**

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -15,7 +15,7 @@ const DraftSubmission = require('../../app/models/DraftSubmission');
  */
 function changeTopic(req, topic) {
   module.exports.setTopic(req, topic);
-  return req.currentTopicId === topic.id ? Promise.resolve() : req.conversation.setTopic(topic);
+  return (req.currentTopicId === topic.id) ? Promise.resolve() : req.conversation.setTopic(topic);
 }
 
 /**

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -153,6 +153,39 @@ function isSaidYesMacro(req) {
  * @param {Object} req
  * @return {Boolean}
  */
+function isSubscriptionStatusActiveMacro(req) {
+  return req.macro === helpers.macro.macros.subscriptionStatusActive();
+}
+
+/**
+ * @param {Object} req
+ * @return {Boolean}
+ */
+function isSubscriptionStatusLessMacro(req) {
+  return req.macro === helpers.macro.macros.subscriptionStatusLess();
+}
+
+/**
+ * @param {Object} req
+ * @return {Boolean}
+ */
+function isSubscriptionStatusNeedMoreInfoMacro(req) {
+  return req.macro === helpers.macro.macros.subscriptionStatusNeedMoreInfo();
+}
+
+
+/**
+ * @param {Object} req
+ * @return {Boolean}
+ */
+function isSubscriptionStatusStopMacro(req) {
+  return req.macro === helpers.macro.macros.subscriptionStatusStop();
+}
+
+/**
+ * @param {Object} req
+ * @return {Boolean}
+ */
 function isStartCommand(req) {
   if (!req.inboundMessageText) {
     return false;
@@ -365,6 +398,10 @@ module.exports = {
   isSaidNoMacro,
   isSaidYesMacro,
   isStartCommand,
+  isSubscriptionStatusActiveMacro,
+  isSubscriptionStatusLessMacro,
+  isSubscriptionStatusNeedMoreInfoMacro,
+  isSubscriptionStatusStopMacro,
   isTwilio,
   isTwilioStudio,
   parseAskSubscriptionStatusResponse,

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -177,6 +177,23 @@ function isTwilioStudio(req) {
 }
 
 /**
+ * Updates req.macro to saidYes or saidNo if inbound message can be parsed as either.
+ *
+ * @async
+ * @param {Object} req
+ * @return {Promise}
+ */
+async function parseAskSubscriptionStatusResponse(req) {
+  // This gets called within the catchAll after we've already created an inbound message.
+  const macroName = await helpers.rivescript
+    .parseAskSubscriptionStatusResponse(req.inboundMessage.text);
+
+  module.exports.setMacro(req, macroName);
+  // Overwrite the current 'catchAll' value as our subscription status macro.
+  await req.inboundMessage.updateMacro(macroName);
+}
+
+/**
  * Sets req.macro per askVotingStatus topic reply.
  *
  * @async
@@ -350,6 +367,7 @@ module.exports = {
   isStartCommand,
   isTwilio,
   isTwilioStudio,
+  parseAskSubscriptionStatusResponse,
   parseAskVotingPlanStatusResponse,
   parseAskYesNoResponse,
   saveDraftSubmissionValue,

--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -250,10 +250,22 @@ async function getBotReply(userId, topicId, messageText = '') {
  * @param {String} messageText
  * @return {Promise}
  */
+function parseAskSubscriptionStatusResponse(messageText) {
+  // We call this helper's getBotReply to DRY checking that our messageText contains alphanumeric.
+  // TODO: Grab these hardcoded id's from config.
+  return module.exports.getBotReply('global', 'ask_subscription_status', messageText)
+    .then(res => res.text);
+}
+
+/**
+ * @param {String} messageText
+ * @return {Promise}
+ */
 function parseAskVotingPlanStatusResponse(messageText) {
   // We call this helper's getBotReply to DRY checking that our messageText contains alphanumeric.
   // TODO: Grab these hardcoded id's from config.
-  return module.exports.getBotReply('global', 'ask_voting_plan_status', messageText).then(res => res.text);
+  return module.exports.getBotReply('global', 'ask_voting_plan_status', messageText)
+    .then(res => res.text);
 }
 
 /**
@@ -280,6 +292,7 @@ module.exports = {
   isRivescriptCurrent,
   joinRivescriptLines,
   loadBot,
+  parseAskSubscriptionStatusResponse,
   parseAskVotingPlanStatusResponse,
   parseAskYesNoResponse,
   parseReplyRivescriptLines,

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -117,6 +117,13 @@ function getTransitionTemplateName(topic) {
 }
 
 /**
+ * @return {Object}
+ */
+function getUnsubscribedTopic() {
+  return config.rivescriptTopics.unsubscribed;
+}
+
+/**
  * @param {Object} topic
  * @return {Boolean}
  */
@@ -233,6 +240,7 @@ module.exports = {
   getSupportTopic,
   getTopicTemplateText,
   getTransitionTemplateName,
+  getUnsubscribedTopic,
   hasActiveCampaign,
   hasCampaign,
   hasClosedCampaign,

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -25,13 +25,6 @@ async function fetchById(id) {
 }
 
 /**
- * @return {Object}
- */
-function getAskSubscriptionStatusTopic() {
-  return config.rivescriptTopics.askSubscriptionStatus;
-}
-
-/**
  * @param {String} id
  * @return {Promise}
  */
@@ -154,7 +147,7 @@ function hasClosedCampaign(topic) {
  * @return {Boolean}
  */
 function isAskSubscriptionStatus(topic) {
-  return topic.id === config.rivescriptTopics.askSubscriptionStatus.id;
+  return topic.type === config.types.askSubscriptionStatus.type;
 }
 
 /**
@@ -232,7 +225,6 @@ function isDefaultTopicId(topicId) {
 
 module.exports = {
   fetchById,
-  getAskSubscriptionStatusTopic,
   getById,
   getDefaultTopic,
   getDefaultTopicId,

--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -185,15 +185,6 @@ async function fetchVotingPlan(user) {
 }
 
 /**
- * @param {String} userId
- * @return {Promise}
- */
-function setPendingSubscriptionStatusForUserId(userId) {
-  logger.debug('setPendingSubscriptionStatusForUserId', { userId });
-  return northstar.updateUser(userId, { sms_status: statuses.pending() });
-}
-
-/**
  * @param {Object} req
  * @return {Promise}
  */
@@ -323,6 +314,5 @@ module.exports = {
     }
     return true;
   },
-  setPendingSubscriptionStatusForUserId,
   updateByMemberMessageReq,
 };

--- a/lib/middleware/messages/broadcast/broadcast-get.js
+++ b/lib/middleware/messages/broadcast/broadcast-get.js
@@ -22,12 +22,7 @@ module.exports = function getBroadcast() {
         return next();
       }
 
-      if (helpers.topic.isAskVotingPlanStatus(broadcast)) {
-        return next();
-      }
-
-      // Check if our broadcast message topic has campaign, and send error if closed.
-      if (helpers.topic.hasClosedCampaign(broadcast.topic)) {
+      if (broadcast.topic && helpers.topic.hasClosedCampaign(broadcast.topic)) {
         errorMessage = 'Broadcast topic campaign has ended.';
         return helpers.sendErrorResponse(res, new UnprocessableEntityError(errorMessage));
       }

--- a/lib/middleware/messages/broadcast/broadcast-parse.js
+++ b/lib/middleware/messages/broadcast/broadcast-parse.js
@@ -12,13 +12,10 @@ module.exports = function parseBroadcast() {
         helpers.attachments.add(req, attachment, 'outbound');
       });
 
-      if (helpers.broadcast.isAskSubscriptionStatus(req.broadcast)) {
-        helpers.request.setTopic(req, helpers.topic.getAskSubscriptionStatusTopic());
-        return next();
-      }
-
-      // If the outbound message does not contain a topic, this is a broadcast with templates to use
-      // as a topic (e.g. to be used when we get to supporting an askYesNo broadcast)
+      /**
+       * If the outbound message does not contain a topic property, this broadcast is the new topic,
+       * as we'll wait for user response to determine next topic change.
+       */
       helpers.request
         .setTopic(req, req.broadcast.topic ? req.broadcast.topic : req.broadcast);
 

--- a/lib/middleware/messages/member/topics/ask-subscription-status.js
+++ b/lib/middleware/messages/member/topics/ask-subscription-status.js
@@ -46,7 +46,7 @@ module.exports = function catchAllAskSubscriptionStatus() {
         // Change topic to hardcoded unsubscribed topic.
         await helpers.request
           .executeInboundTopicChange(req, helpers.topic.getUnsubscribedTopic());
-        // Get the hardcoded unsubscribe confirmation macro text.
+        // Send hardcoded unsubscribe confirmation macro text.
         const macroConfig = helpers.macro.getMacro(req.macro);
         return helpers.replies.sendReply(req, res, macroConfig.text, req.macro);
       }

--- a/lib/middleware/messages/member/topics/ask-subscription-status.js
+++ b/lib/middleware/messages/member/topics/ask-subscription-status.js
@@ -42,6 +42,15 @@ module.exports = function catchAllAskSubscriptionStatus() {
         return helpers.replies.sendReply(req, res, broadcastTopic.saidNeedMoreInfo, req.macro);
       }
 
+      if (helpers.request.isSubscriptionStatusStopMacro(req)) {
+        // Change topic to hardcoded unsubscribed topic.
+        await helpers.request
+          .executeInboundTopicChange(req, helpers.topic.getUnsubscribedTopic());
+        // Get the hardcoded unsubscribe confirmation macro text.
+        const macroConfig = helpers.macro.getMacro(req.macro);
+        return helpers.replies.sendReply(req, res, macroConfig.text, req.macro);
+      }
+
       return helpers.replies
         .sendReply(req, res, broadcastTopic.invalidAskSubscriptionStatusResponse, req.macro);
     } catch (err) {

--- a/lib/middleware/messages/member/topics/ask-subscription-status.js
+++ b/lib/middleware/messages/member/topics/ask-subscription-status.js
@@ -17,30 +17,33 @@ module.exports = function catchAllAskSubscriptionStatus() {
       });
 
       await helpers.request.parseAskSubscriptionStatusResponse(req);
-      const templateName = req.macro;
 
-      if (helpers.macro.isSubscriptionStatusActive(templateName)) {
+      if (helpers.request.isSubscriptionStatusActiveMacro(req)) {
         const saidActiveTopic = broadcastTopic.saidActiveTopic;
         if (!saidActiveTopic.id) {
           throw new UnprocessableEntityError('saidActiveTopic is undefined');
         }
         await helpers.request
           .executeInboundTopicChange(req, saidActiveTopic);
-        return helpers.replies.sendReply(req, res, broadcastTopic.saidActive, templateName);
+        return helpers.replies.sendReply(req, res, broadcastTopic.saidActive, req.macro);
       }
 
-      if (helpers.macro.isSubscriptionStatusLess(templateName)) {
+      if (helpers.request.isSubscriptionStatusLessMacro(req)) {
         const saidLessTopic = broadcastTopic.saidLessTopic;
         if (!saidLessTopic.id) {
           throw new UnprocessableEntityError('saidLessTopic is undefined');
         }
         await helpers.request
           .executeInboundTopicChange(req, saidLessTopic);
-        return helpers.replies.sendReply(req, res, broadcastTopic.saidLess, templateName);
+        return helpers.replies.sendReply(req, res, broadcastTopic.saidLess, req.macro);
+      }
+
+      if (helpers.request.isSubscriptionStatusNeedMoreInfoMacro(req)) {
+        return helpers.replies.sendReply(req, res, broadcastTopic.saidNeedMoreInfo, req.macro);
       }
 
       return helpers.replies
-        .sendReply(req, res, broadcastTopic[templateName], templateName);
+        .sendReply(req, res, broadcastTopic.invalidAskSubscriptionStatusResponse, req.macro);
     } catch (err) {
       return helpers.sendErrorResponse(res, err);
     }

--- a/lib/middleware/messages/member/topics/ask-subscription-status.js
+++ b/lib/middleware/messages/member/topics/ask-subscription-status.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const helpers = require('../../../../helpers');
+const logger = require('../../../../logger');
+const UnprocessableEntityError = require('../../../../../app/exceptions/UnprocessableEntityError');
+
+module.exports = function catchAllAskSubscriptionStatus() {
+  return async (req, res, next) => {
+    try {
+      if (!helpers.topic.isAskSubscriptionStatus(req.topic)) {
+        return next();
+      }
+
+      const broadcastTopic = req.topic;
+      logger.debug('parsing askSubscriptionStatus response for broadcast topic', {
+        id: broadcastTopic.id,
+      });
+
+      await helpers.request.parseAskSubscriptionStatusResponse(req);
+      const templateName = req.macro;
+
+      if (helpers.macro.isSubscriptionStatusActive(templateName)) {
+        const saidActiveTopic = broadcastTopic.saidActiveTopic;
+        if (!saidActiveTopic.id) {
+          throw new UnprocessableEntityError('saidActiveTopic is undefined');
+        }
+        await helpers.request
+          .executeInboundTopicChange(req, saidActiveTopic);
+        return helpers.replies.sendReply(req, res, broadcastTopic.saidActive, templateName);
+      }
+
+      if (helpers.macro.isSubscriptionStatusLess(templateName)) {
+        const saidLessTopic = broadcastTopic.saidLessTopic;
+        if (!saidLessTopic.id) {
+          throw new UnprocessableEntityError('saidLessTopic is undefined');
+        }
+        await helpers.request
+          .executeInboundTopicChange(req, saidLessTopic);
+        return helpers.replies.sendReply(req, res, broadcastTopic.saidLess, templateName);
+      }
+
+      return helpers.replies
+        .sendReply(req, res, broadcastTopic[templateName], templateName);
+    } catch (err) {
+      return helpers.sendErrorResponse(res, err);
+    }
+  };
+};

--- a/lib/middleware/messages/member/topics/ask-subscription-status.js
+++ b/lib/middleware/messages/member/topics/ask-subscription-status.js
@@ -2,7 +2,6 @@
 
 const helpers = require('../../../../helpers');
 const logger = require('../../../../logger');
-const UnprocessableEntityError = require('../../../../../app/exceptions/UnprocessableEntityError');
 
 module.exports = function catchAllAskSubscriptionStatus() {
   return async (req, res, next) => {
@@ -19,22 +18,14 @@ module.exports = function catchAllAskSubscriptionStatus() {
       await helpers.request.parseAskSubscriptionStatusResponse(req);
 
       if (helpers.request.isSubscriptionStatusActiveMacro(req)) {
-        const saidActiveTopic = broadcastTopic.saidActiveTopic;
-        if (!saidActiveTopic.id) {
-          throw new UnprocessableEntityError('saidActiveTopic is undefined');
-        }
         await helpers.request
-          .executeInboundTopicChange(req, saidActiveTopic);
+          .executeInboundTopicChange(req, broadcastTopic.saidActiveTopic);
         return helpers.replies.sendReply(req, res, broadcastTopic.saidActive, req.macro);
       }
 
       if (helpers.request.isSubscriptionStatusLessMacro(req)) {
-        const saidLessTopic = broadcastTopic.saidLessTopic;
-        if (!saidLessTopic.id) {
-          throw new UnprocessableEntityError('saidLessTopic is undefined');
-        }
         await helpers.request
-          .executeInboundTopicChange(req, saidLessTopic);
+          .executeInboundTopicChange(req, broadcastTopic.saidLessTopic);
         return helpers.replies.sendReply(req, res, broadcastTopic.saidLess, req.macro);
       }
 
@@ -43,12 +34,11 @@ module.exports = function catchAllAskSubscriptionStatus() {
       }
 
       if (helpers.request.isSubscriptionStatusStopMacro(req)) {
-        // Change topic to hardcoded unsubscribed topic.
         await helpers.request
           .executeInboundTopicChange(req, helpers.topic.getUnsubscribedTopic());
-        // Send hardcoded unsubscribe confirmation macro text.
-        const macroConfig = helpers.macro.getMacro(req.macro);
-        return helpers.replies.sendReply(req, res, macroConfig.text, req.macro);
+        // Send the hardcoded macro text.
+        return helpers.replies
+          .sendReply(req, res, helpers.macro.getMacro(req.macro).text, req.macro);
       }
 
       return helpers.replies

--- a/test/helpers/factories/topic.js
+++ b/test/helpers/factories/topic.js
@@ -73,6 +73,19 @@ function getValidTextPostConfig() {
 /**
  * @return {Object}
  */
+function getValidAskSubscriptionStatusBroadcastTopic() {
+  return getValidTopicWithoutCampaign(config.types.askSubscriptionStatus.type, {
+    invalidAskSubscriptionStatusResponse: getTemplate(),
+    saidActive: getTemplate(),
+    saidActiveTopic: getValidTopicWithoutCampaign(),
+    saidLess: getTemplate(),
+    saidLessTopic: getValidTopicWithoutCampaign(),
+  });
+}
+
+/**
+ * @return {Object}
+ */
 function getValidAskYesNoBroadcastTopic() {
   return getValidTopicWithoutCampaign(config.types.askYesNo.type, {
     invalidAskYesNoResponse: getTemplate(),
@@ -84,6 +97,7 @@ function getValidAskYesNoBroadcastTopic() {
 }
 
 module.exports = {
+  getValidAskSubscriptionStatusBroadcastTopic,
   getValidAskYesNoBroadcastTopic,
   getValidAutoReply,
   getValidPhotoPostConfig,

--- a/test/unit/lib/lib-helpers/request.test.js
+++ b/test/unit/lib/lib-helpers/request.test.js
@@ -303,6 +303,50 @@ test('isStartCommand should return true if trimmed lowercase req.inboundMessageT
   t.truthy(requestHelper.isStartCommand(t.context.req));
 });
 
+// isSubscriptionStatusActiveMacro
+test('isSubscriptionStatusActiveMacro should return true if req.macro is subscriptionStatusActive macro', (t) => {
+  t.falsy(requestHelper.isSubscriptionStatusActiveMacro(t.context.req));
+  t.context.req.macro = stubs.getRandomWord();
+  t.falsy(requestHelper.isSubscriptionStatusActiveMacro(t.context.req));
+  t.context.req.macro = helpers.macro.macros.subscriptionStatusActive();
+  t.truthy(requestHelper.isSubscriptionStatusActiveMacro(t.context.req));
+  t.context.req.macro = helpers.macro.macros.subscriptionStatusLess();
+  t.falsy(requestHelper.isSubscriptionStatusActiveMacro(t.context.req));
+});
+
+// isSubscriptionStatusLessMacro
+test('isSubscriptionStatusLessMacro should return true if req.macro is subscriptionStatusLess macro', (t) => {
+  t.falsy(requestHelper.isSubscriptionStatusLessMacro(t.context.req));
+  t.context.req.macro = stubs.getRandomWord();
+  t.falsy(requestHelper.isSubscriptionStatusLessMacro(t.context.req));
+  t.context.req.macro = helpers.macro.macros.subscriptionStatusActive();
+  t.falsy(requestHelper.isSubscriptionStatusLessMacro(t.context.req));
+  t.context.req.macro = helpers.macro.macros.subscriptionStatusLess();
+  t.truthy(requestHelper.isSubscriptionStatusLessMacro(t.context.req));
+});
+
+// isSubscriptionStatusNeedMoreInfoMacro
+test('isSubscriptionStatusNeedMoreInfoMacro should return true if req.macro is subscriptionStatusNeedMoreInfo macro', (t) => {
+  t.falsy(requestHelper.isSubscriptionStatusNeedMoreInfoMacro(t.context.req));
+  t.context.req.macro = stubs.getRandomWord();
+  t.falsy(requestHelper.isSubscriptionStatusNeedMoreInfoMacro(t.context.req));
+  t.context.req.macro = helpers.macro.macros.subscriptionStatusActive();
+  t.falsy(requestHelper.isSubscriptionStatusNeedMoreInfoMacro(t.context.req));
+  t.context.req.macro = helpers.macro.macros.subscriptionStatusNeedMoreInfo();
+  t.truthy(requestHelper.isSubscriptionStatusNeedMoreInfoMacro(t.context.req));
+});
+
+// isSubscriptionStatusStopMacro
+test('isSubscriptionStatusStopMacro should return true if req.macro is subscriptionStatusStop macro', (t) => {
+  t.falsy(requestHelper.isSubscriptionStatusStopMacro(t.context.req));
+  t.context.req.macro = stubs.getRandomWord();
+  t.falsy(requestHelper.isSubscriptionStatusStopMacro(t.context.req));
+  t.context.req.macro = helpers.macro.macros.subscriptionStatusActive();
+  t.falsy(requestHelper.isSubscriptionStatusStopMacro(t.context.req));
+  t.context.req.macro = helpers.macro.macros.subscriptionStatusStop();
+  t.truthy(requestHelper.isSubscriptionStatusStopMacro(t.context.req));
+});
+
 // isTwilio
 test('isTwilio should return true if req.query.origin is set to twilio', (t) => {
   t.falsy(requestHelper.isTwilio(t.context.req));

--- a/test/unit/lib/lib-helpers/request.test.js
+++ b/test/unit/lib/lib-helpers/request.test.js
@@ -64,63 +64,17 @@ test('changeTopic does not call setTopic if not a topic change', async (t) => {
   conversation.setTopic.should.not.have.been.called;
 });
 
-test('changeTopic calls helpers.user.setPendingSubscriptionStatusForUserId and setTopic when topic change is askSubscriptionStatus', async (t) => {
+test('changeTopic calls setTopic when topic args is not equal to req.currentTopicId', async (t) => {
   sandbox.stub(requestHelper, 'setTopic')
     .returns(underscore.noop);
-  sandbox.stub(helpers.topic, 'isAskSubscriptionStatus')
-    .returns(true);
   sandbox.stub(conversation, 'setTopic')
     .returns(Promise.resolve());
-  sandbox.stub(helpers.user, 'setPendingSubscriptionStatusForUserId')
-    .returns(Promise.resolve(true));
   t.context.req.conversation = conversation;
   t.context.req.currentTopicId = 'abc';
-  t.context.req.userId = 'def';
 
   await requestHelper.changeTopic(t.context.req, topic);
   requestHelper.setTopic.should.have.been.calledWith(t.context.req, topic);
-  helpers.user.setPendingSubscriptionStatusForUserId
-    .should.have.been.calledWith(t.context.req.userId);
   conversation.setTopic.should.have.been.calledWith(topic);
-});
-
-test('changeTopic calls setTopic when topic change is not askSubscriptionStatus', async (t) => {
-  sandbox.stub(requestHelper, 'setTopic')
-    .returns(underscore.noop);
-  sandbox.stub(helpers.topic, 'isAskSubscriptionStatus')
-    .returns(false);
-  sandbox.stub(conversation, 'setTopic')
-    .returns(Promise.resolve());
-  sandbox.stub(helpers.user, 'setPendingSubscriptionStatusForUserId')
-    .returns(Promise.resolve(true));
-  t.context.req.conversation = conversation;
-  t.context.req.currentTopicId = 'abc';
-  t.context.req.userId = 'def';
-
-  await requestHelper.changeTopic(t.context.req, topic);
-  requestHelper.setTopic.should.have.been.calledWith(t.context.req, topic);
-  helpers.user.setPendingSubscriptionStatusForUserId.should.not.have.been.called;
-  conversation.setTopic.should.have.been.calledWith(topic);
-});
-
-test('changeTopic does not call setTopic when topic change is askSubscriptionStatus and setPendingSubscriptionStatusForUserId fails', async (t) => {
-  sandbox.stub(requestHelper, 'setTopic')
-    .returns(underscore.noop);
-  sandbox.stub(helpers.topic, 'isAskSubscriptionStatus')
-    .returns(true);
-  sandbox.stub(conversation, 'setTopic')
-    .returns(Promise.resolve());
-  const error = { message: 'Epic fail' };
-  sandbox.stub(helpers.user, 'setPendingSubscriptionStatusForUserId')
-    .returns(Promise.reject(error));
-  t.context.req.conversation = conversation;
-  t.context.req.currentTopicId = 'abc';
-  t.context.req.userId = 'def';
-
-  await t.throws(requestHelper.changeTopic(t.context.req, topic));
-  requestHelper.setTopic.should.have.been.calledWith(t.context.req, topic);
-  helpers.user.setPendingSubscriptionStatusForUserId.should.have.been.called;
-  conversation.setTopic.should.not.have.been.called;
 });
 
 // createDraftSubmission

--- a/test/unit/lib/lib-helpers/request.test.js
+++ b/test/unit/lib/lib-helpers/request.test.js
@@ -64,7 +64,7 @@ test('changeTopic does not call setTopic if not a topic change', async (t) => {
   conversation.setTopic.should.not.have.been.called;
 });
 
-test('changeTopic calls setTopic when topic args is not equal to req.currentTopicId', async (t) => {
+test('changeTopic calls setTopic when topic arg is not equal to req.currentTopicId', async (t) => {
   sandbox.stub(requestHelper, 'setTopic')
     .returns(underscore.noop);
   sandbox.stub(conversation, 'setTopic')

--- a/test/unit/lib/lib-helpers/rivescript.test.js
+++ b/test/unit/lib/lib-helpers/rivescript.test.js
@@ -344,8 +344,20 @@ test('loadBot calls getRivescripts and creates a new Rivescript bot with result'
     .calledWith(getRivescripts);
 });
 
+// parseAskSubscriptionStatusResponse
+test('parseAskSubscriptionStatusResponse should call rivescriptHelper.getBotReply with ask_subscription_status and return result text', async () => {
+  const messageText = stubs.getRandomMessageText();
+  sandbox.stub(rivescriptHelper, 'getBotReply')
+    .returns(Promise.resolve(mockRivescriptReply));
+
+  const result = await rivescriptHelper.parseAskSubscriptionStatusResponse(messageText);
+  rivescriptHelper.getBotReply
+    .should.have.been.calledWith('global', 'ask_subscription_status', messageText);
+  result.should.deep.equal(mockRivescriptReply.text);
+});
+
 // parseAskVotingPlanStatusResponse
-test('parseAskVotingPlanStatusResponse should call rivescriptHelper.getBotReply', async () => {
+test('parseAskVotingPlanStatusResponse should call rivescriptHelper.getBotReply with ask_voting_plan_status topic and return result text', async () => {
   const messageText = stubs.getRandomMessageText();
   sandbox.stub(rivescriptHelper, 'getBotReply')
     .returns(Promise.resolve(mockRivescriptReply));
@@ -357,7 +369,7 @@ test('parseAskVotingPlanStatusResponse should call rivescriptHelper.getBotReply'
 });
 
 // parseAskYesNoResponse
-test('parseAskYesNoResponse should call rivescriptHelper.getBotReply', async () => {
+test('parseAskYesNoResponse should call rivescriptHelper.getBotReply with ask_yes_no topic and return result text', async () => {
   const messageText = stubs.getRandomMessageText();
   sandbox.stub(rivescriptHelper, 'getBotReply')
     .returns(Promise.resolve(mockRivescriptReply));

--- a/test/unit/lib/lib-helpers/topic.test.js
+++ b/test/unit/lib/lib-helpers/topic.test.js
@@ -49,12 +49,6 @@ test('fetchById should return graphql.fetchTopicById', async () => {
   result.should.deep.equal(topic);
 });
 
-// getAskSubscriptionStatusTopic
-test('getAskSubscriptionStatusTopic should return config.rivescriptTopics.askSubscriptionStatus', () => {
-  const result = topicHelper.getAskSubscriptionStatusTopic();
-  result.should.deep.equal(config.rivescriptTopics.askSubscriptionStatus);
-});
-
 // getById
 test('getById should return getRivescriptTopicById if isRivescriptTopicId', async () => {
   const topicId = topicHelper.getDefaultTopicId();
@@ -186,10 +180,11 @@ test('hasClosedCampaign returns false if topic does not have campaign', (t) => {
 });
 
 // isAskSubscriptionStatus
-test('isAskSubscriptionStatus returns whether topic is rivescriptTopics.askSubscriptionStatus', (t) => {
-  const mockTopic = topicFactory.getValidTopic();
-  t.truthy(topicHelper.isAskSubscriptionStatus(config.rivescriptTopics.askSubscriptionStatus));
-  t.falsy(topicHelper.isAskSubscriptionStatus(mockTopic));
+test('isAskSubscriptionStatus returns whether topic type is askSubscriptionStatus', (t) => {
+  t.truthy(topicHelper
+    .isAskSubscriptionStatus(topicFactory.getValidAskSubscriptionStatusBroadcastTopic()));
+  t.falsy(topicHelper
+    .isAskSubscriptionStatus(topicFactory.getValidAskYesNoBroadcastTopic()));
 });
 
 // isAskVotingPlanStatus

--- a/test/unit/lib/lib-helpers/topic.test.js
+++ b/test/unit/lib/lib-helpers/topic.test.js
@@ -107,6 +107,12 @@ test('getSupportTopic should return config.rivescriptTopics.support', () => {
   result.should.deep.equal(config.rivescriptTopics.support);
 });
 
+// getUnsubscribedTopic
+test('getUnsubscribedTopic should return config.rivescriptTopics.unsubscribed', () => {
+  const result = topicHelper.getUnsubscribedTopic();
+  result.should.deep.equal(config.rivescriptTopics.unsubscribed);
+});
+
 // hasActiveCampaign
 test('hasActiveCampaign returns true if topic has campaign that is not closed', (t) => {
   sandbox.stub(topicHelper, 'hasCampaign')

--- a/test/unit/lib/lib-helpers/user.test.js
+++ b/test/unit/lib/lib-helpers/user.test.js
@@ -10,7 +10,6 @@ const httpMocks = require('node-mocks-http');
 const northstar = require('../../../../lib/northstar');
 const gateway = require('../../../../lib/gateway');
 const helpers = require('../../../../lib/helpers');
-const subscriptionHelper = require('../../../../lib/helpers/subscription');
 const config = require('../../../../config/lib/helpers/user');
 
 chai.should();
@@ -332,17 +331,6 @@ test('isPaused should return user.sms_paused', (t) => {
   const user = userFactory.getValidUser();
   const result = userHelper.isPaused(user);
   t.deepEqual(result, user.sms_paused);
-});
-
-// setPendingSubscriptionStatusForUserId
-test('setPendingSubscriptionStatusForUserId should call northstar.updateUser with pending status', async () => {
-  const userId = mockUser.id;
-  sandbox.stub(northstar, 'updateUser')
-    .returns(Promise.resolve({}));
-
-  await userHelper.setPendingSubscriptionStatusForUserId(userId);
-  northstar.updateUser.should.have.been
-    .calledWith(userId, { sms_status: subscriptionHelper.statuses.pending() });
 });
 
 // updateByMemberMessageReq

--- a/test/unit/lib/middleware/messages/broadcast/broadcast-get.test.js
+++ b/test/unit/lib/middleware/messages/broadcast/broadcast-get.test.js
@@ -94,7 +94,7 @@ test('getBroadcast should call next if askYesNo topic campaign is not closed', a
   helpers.sendErrorResponse.should.not.have.been.called;
 });
 
-test('getBroadcast should call next if broadcast type is askVotingPlanStatus', async (t) => {
+test('getBroadcast should call next if broadcast type is not legacy or askYesNo, and does not have topic', async (t) => {
   const next = sinon.stub();
   const middleware = getBroadcast();
   sandbox.stub(helpers.broadcast, 'getById')
@@ -139,7 +139,6 @@ test('getBroadcast should return next if not askYesNo and broadcast topic campai
   next.should.have.been.called;
   helpers.sendErrorResponse.should.not.have.been.called;
 });
-
 
 test('getBroadcast should call sendErrorResponse if getById fails', async (t) => {
   const next = sinon.stub();

--- a/test/unit/lib/middleware/messages/member/topics/ask-subscription-status.test.js
+++ b/test/unit/lib/middleware/messages/member/topics/ask-subscription-status.test.js
@@ -1,0 +1,190 @@
+'use strict';
+
+require('dotenv').config();
+
+const test = require('ava');
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const httpMocks = require('node-mocks-http');
+const underscore = require('underscore');
+
+const helpers = require('../../../../../../../lib/helpers');
+const stubs = require('../../../../../../helpers/stubs');
+const topicFactory = require('../../../../../../helpers/factories/topic');
+
+chai.should();
+chai.use(sinonChai);
+
+// module to be tested
+const askSubscriptionStatusCatchAll = require('../../../../../../../lib/middleware/messages/member/topics/ask-subscription-status');
+// stubs
+const askSubscriptionStatus = topicFactory.getValidAskSubscriptionStatusBroadcastTopic();
+const error = { message: 'Epic fail' };
+
+const sandbox = sinon.sandbox.create();
+
+test.beforeEach((t) => {
+  sandbox.stub(helpers.replies, 'sendReply')
+    .returns(underscore.noop);
+  sandbox.stub(helpers.request, 'changeTopic')
+    .returns(Promise.resolve(true));
+  sandbox.stub(helpers, 'sendErrorResponse')
+    .returns(underscore.noop);
+  t.context.req = httpMocks.createRequest();
+  t.context.res = httpMocks.createResponse();
+});
+
+test.afterEach((t) => {
+  sandbox.restore();
+  t.context = {};
+});
+
+test('askSubscriptionStatusCatchAll should call next if req.topic is not an askSubscriptionStatus', async (t) => {
+  const next = sinon.stub();
+  const middleware = askSubscriptionStatusCatchAll();
+  t.context.req.topic = topicFactory.getValidAutoReply();
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+
+  next.should.have.been.called;
+  helpers.replies.sendReply.should.not.have.been.called;
+});
+
+test('askSubscriptionStatusCatchAll should call sendErrorResponse if parseAskSubscriptionStatusResponse fails', async (t) => {
+  const next = sinon.stub();
+  const middleware = askSubscriptionStatusCatchAll();
+  sandbox.stub(helpers.request, 'parseAskSubscriptionStatusResponse')
+    .returns(Promise.reject(error));
+  t.context.req.topic = askSubscriptionStatus;
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+
+  next.should.not.have.been.called;
+  helpers.replies.sendReply.should.not.have.been.called;
+  helpers.sendErrorResponse.should.have.been.calledWith(t.context.res, error);
+});
+
+test('askSubscriptionStatusCatchAll should change topic to saidActiveTopic and send saidActive reply if request is subscriptionStatusActive macro', async (t) => {
+  const next = sinon.stub();
+  const macro = helpers.macro.macros.subscriptionStatusActive();
+  const middleware = askSubscriptionStatusCatchAll();
+  t.context.req.macro = macro;
+  t.context.req.topic = askSubscriptionStatus;
+  sandbox.stub(helpers.request, 'parseAskSubscriptionStatusResponse')
+    .returns(Promise.resolve());
+  sandbox.stub(helpers.request, 'executeInboundTopicChange')
+    .returns(Promise.resolve());
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+
+  next.should.not.have.been.called;
+  helpers.request.executeInboundTopicChange
+    .should.have.been.calledWith(t.context.req, askSubscriptionStatus.saidActiveTopic);
+  helpers.replies.sendReply.should.have.been.calledWith(
+    t.context.req,
+    t.context.res,
+    askSubscriptionStatus.saidActive,
+    macro,
+  );
+});
+
+test('askSubscriptionStatusCatchAll should change topic to saidLessTopic and send saidLess reply if request is subscriptionStatusLess macro', async (t) => {
+  const next = sinon.stub();
+  const macro = helpers.macro.macros.subscriptionStatusLess();
+  const middleware = askSubscriptionStatusCatchAll();
+  t.context.req.macro = macro;
+  t.context.req.topic = askSubscriptionStatus;
+  sandbox.stub(helpers.request, 'parseAskSubscriptionStatusResponse')
+    .returns(Promise.resolve());
+  sandbox.stub(helpers.request, 'executeInboundTopicChange')
+    .returns(Promise.resolve());
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+
+  next.should.not.have.been.called;
+  helpers.request.executeInboundTopicChange
+    .should.have.been.calledWith(t.context.req, askSubscriptionStatus.saidLessTopic);
+  helpers.replies.sendReply.should.have.been.calledWith(
+    t.context.req,
+    t.context.res,
+    askSubscriptionStatus.saidLess,
+    macro,
+  );
+});
+
+test('askSubscriptionStatusCatchAll should change topic to unsubscribed and send macro reply if request is subscriptionStatusStop macro', async (t) => {
+  const next = sinon.stub();
+  const macro = helpers.macro.macros.subscriptionStatusStop();
+  const middleware = askSubscriptionStatusCatchAll();
+  t.context.req.macro = macro;
+  t.context.req.topic = askSubscriptionStatus;
+  sandbox.stub(helpers.request, 'parseAskSubscriptionStatusResponse')
+    .returns(Promise.resolve());
+  sandbox.stub(helpers.request, 'executeInboundTopicChange')
+    .returns(Promise.resolve());
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+
+  next.should.not.have.been.called;
+  helpers.request.executeInboundTopicChange
+    .should.have.been.calledWith(t.context.req, helpers.topic.getUnsubscribedTopic());
+  helpers.replies.sendReply.should.have.been.calledWith(
+    t.context.req,
+    t.context.res,
+    helpers.macro.getMacro(macro).text,
+    macro,
+  );
+});
+
+
+test('askSubscriptionStatusCatchAll should not change topic and send saidNeedMoreInfo reply if request is subscriptionStatusNeedMoreInfo macro', async (t) => {
+  const next = sinon.stub();
+  const macro = helpers.macro.macros.subscriptionStatusNeedMoreInfo();
+  const middleware = askSubscriptionStatusCatchAll();
+  t.context.req.macro = macro;
+  t.context.req.topic = askSubscriptionStatus;
+  sandbox.stub(helpers.request, 'parseAskSubscriptionStatusResponse')
+    .returns(Promise.resolve());
+  sandbox.stub(helpers.request, 'executeInboundTopicChange')
+    .returns(Promise.resolve());
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+
+  next.should.not.have.been.called;
+  helpers.request.executeInboundTopicChange.should.not.have.been.called;
+  helpers.replies.sendReply.should.have.been.calledWith(
+    t.context.req,
+    t.context.res,
+    askSubscriptionStatus.saidNeedMoreInfo,
+    macro,
+  );
+});
+
+test('askSubscriptionStatusCatchAll should not change topic, sends invalidAskSubscriptionStatusResponse if not a subscription status macro', async (t) => {
+  const next = sinon.stub();
+  const macro = stubs.getRandomWord();
+  const middleware = askSubscriptionStatusCatchAll();
+  t.context.req.macro = macro;
+  t.context.req.topic = askSubscriptionStatus;
+  sandbox.stub(helpers.request, 'parseAskSubscriptionStatusResponse')
+    .returns(Promise.resolve());
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+
+  next.should.not.have.been.called;
+  helpers.request.changeTopic.should.not.have.been.called;
+  helpers.replies.sendReply.should.have.been.calledWith(
+    t.context.req,
+    t.context.res,
+    askSubscriptionStatus.invalidAskSubscriptionStatusResponse,
+    macro,
+  );
+});


### PR DESCRIPTION
#### What's this PR do?

Removes the hardcoded macro replies for an `askSubscriptionStatus` broadcast, and refactors middleware to send replies from the GraphQL fields added in https://github.com/DoSomething/graphql/pull/49 and https://github.com/DoSomething/graphql/pull/51.

Also refactors `askSubscriptionStatus` broadcasts to no longer update a user's `sms_status` as `pending` upon receiving the broadcast, per [Slack thread](https://dosomething.slack.com/archives/C03T8SDMS/p1549318310005500). 

#### How should this be reviewed?

* Verify expected behavior for the various replies defined on an `askSubscriptionStatus` broadcast (`4qLXWRSqY0ommayY2iWCwU`) per the GraphQL `topic` query response --  see https://github.com/DoSomething/graphql/pull/51#issuecomment-460359256

Example:
<img width="500" alt="screen shot 2019-02-04 at 6 38 43 pm" src="https://user-images.githubusercontent.com/1236811/52250857-a6d66600-28ae-11e9-8775-eb82962c4cd3.png">

* Verify the `less` keyword sends the hardcoded text per https://github.com/DoSomething/gambit/pull/471#discussion_r253675066

Example:
<img width="500" alt="screen shot 2019-02-04 at 7 01 47 pm" src="https://user-images.githubusercontent.com/1236811/52250976-5d3a4b00-28af-11e9-9014-adc02dd5ef18.png">


#### Any background context you want to provide?

The last broadcast type left to port over to GraphQL is `askVotingPlanStatus`. Not that we're sending one of these any time soon, but it seems worth fixing it up vs scrapping the feature from the repo entirely.  

#### Relevant tickets
Fixes https://www.pivotaltracker.com/story/show/163095523

#### Checklist
- [x] Tests added/updated for new features/bug fixes.
- [x] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
