### PR TITLE
Catches tag rendering errors

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -27,7 +27,7 @@ module.exports.sendErrorResponse = function (res, err, retry = true) {
   if (!retry) {
     exports.addNoRetryHeaders(res);
   }
-  return this.sendResponseWithStatusCode(res, error.status, error.message);
+  return exports.sendResponseWithStatusCode(res, error.status, error.message);
 };
 
 module.exports.sendErrorResponseWithNoRetry = function (res, err) {


### PR DESCRIPTION
#### What's this PR do?

This tweak to #468 seems to fix properly catching errors in Mustache tags. I found this when testing the "Need More Info" reply to [AskSubscriptionStatusBroadcastTopic `58QNVt7wJiyu2YeeAaemgS`](https://gambit-admin-staging.herokuapp.com/broadcasts/58QNVt7wJiyu2YeeAaemgS), where I mistakenly added copy that was missing a closing curly bracket:
```
...&utm_medium=sms&utm_campaign=permissioning_weekly&user_id={{user.id}
```

#### How should this be reviewed?

I've left the incorrect tag for now to verify expected behavior when triggering the `subscriptionStatusNeedMoreInfo` reply in broadcast topic `58QNVt7wJiyu2YeeAaemgS`:


* Without the change:
```
a-4f11-844a-9e6fa94427f6 level=debug message=createMessage
(node:55646) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'sendResponseWithStatusCode' of undefined
    at module.exports.sendErrorResponse (/Users/aschachter/Development/gambit/conversations/lib/helpers.js:30:15)
    at Object.sendErrorResponse (/Users/aschachter/Development/gambit/conversations/lib/helpers/analytics.js:50:12)
    at Object.module.exports.sendReply (/Users/aschachter/Development/gambit/conversations/lib/helpers/replies.js:61:36)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
(node:55646) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 3)
(node:55646) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
``` 

* After the change:
```
[debug] createMessage pid=59496 direction=outbound-reply request_id=7d750f23-46eb-45e3-a993-ff569c5f27ea level=debug message=createMessage
[error] sendResponseWithStatusCode pid=59496 code=500 response#message="Unclosed tag at 467" request_id=7d750f23-46eb-45e3-a993-ff569c5f27ea level=error message=sendResponseWithStatusCode
```

#### Checklist
- [x] Tested on staging.
