### PR TITLE
Update askVotingPlanStatus topic replies

### DIFF
--- a/brain/topics/askVotingPlanStatus.rive
+++ b/brain/topics/askVotingPlanStatus.rive
@@ -43,7 +43,7 @@
 - votingPlanStatusCantVote
 
 + [*]
-- invalidVotingPlanStatus
+- invalidAskVotingPlanStatusResponse
 
 < topic
 

--- a/config/lib/graphql.js
+++ b/config/lib/graphql.js
@@ -103,6 +103,20 @@ const fetchTopicById = `
           id
         }
       }
+      ... on AskVotingPlanStatusBroadcastTopic {
+        saidCantVote
+        saidCantVoteTopic {
+          id
+        }
+        saidNotVoting
+        saidNotVotingTopic {
+          id
+        }
+        saidVoted
+        saidVotedTopic {
+          id
+        }
+      }
       ... on AskYesNoBroadcastTopic {
         invalidAskYesNoResponse
         saidNo

--- a/config/lib/helpers/macro.js
+++ b/config/lib/helpers/macro.js
@@ -94,10 +94,15 @@ function votingPlanMethodOfTransport(valueKey) {
   };
 }
 
+/**
+ * Macros are configured with the following properties:
+ * name - Matches the Rivescript reply used to execute the macro
+ * text - If set, the outbound message text (may be defined/overridden on a topic)
+ * topic - If set, to topic to change conversation topic to
+ * profileUpdate - If set, the field name and value to update a user with
+ */
 module.exports = {
   completedVotingPlanMacro,
-  // If a macro contains a text property, it's sent as the reply to the inbound message.
-  // If it doesn't, the reply text is sourced from the current topic.
   macros: {
     askVotingPlanStatus: {
       name: 'askVotingPlanStatus',

--- a/config/lib/helpers/macro.js
+++ b/config/lib/helpers/macro.js
@@ -107,6 +107,10 @@ module.exports = {
     catchAll: {
       name: 'catchAll',
     },
+    invalidAskVotingPlanStatusResponse: {
+      name: 'invalidAskVotingPlanStatusResponse',
+      text: `${invalidAnswerText} ${askVotingPlanStatusText}`,
+    },
     invalidVotingPlanAttendingWith: {
       name: 'invalidVotingPlanAttendingWith',
       text: `${invalidAnswerText} ${askVotingPlanAttendingWithText}`,
@@ -114,10 +118,6 @@ module.exports = {
     invalidVotingPlanMethodOfTransport: {
       name: 'invalidVotingPlanMethodOfTransport',
       text: `${invalidAnswerText} ${askVotingPlanMethodOfTransportText}`,
-    },
-    invalidVotingPlanStatus: {
-      name: 'invalidVotingPlanStatus',
-      text: `${invalidAnswerText} ${askVotingPlanStatusText}`,
     },
     invalidVotingPlanTimeOfDay: {
       name: 'invalidVotingPlanTimeOfDay',
@@ -208,6 +208,7 @@ module.exports = {
       },
     },
     votingPlanStatusVoted: {
+      name: 'votingPlanStatusVoted',
       profileUpdate: {
         field: profile.votingPlanStatus.name,
         value: profile.votingPlanStatus.values.voted,

--- a/config/lib/helpers/macro.js
+++ b/config/lib/helpers/macro.js
@@ -96,9 +96,9 @@ function votingPlanMethodOfTransport(valueKey) {
 
 /**
  * Macros are configured with the following properties:
- * name - Matches the Rivescript reply used to execute the macro
+ * name - Matches the Rivescript reply text used to execute the macro
  * text - If set, the outbound message text (may be defined/overridden on a topic)
- * topic - If set, to topic to change conversation topic to
+ * topic - If set, the topic to change conversation topic to
  * profileUpdate - If set, the field name and value to update a user with
  */
 module.exports = {

--- a/lib/helpers/macro.js
+++ b/lib/helpers/macro.js
@@ -39,14 +39,6 @@ function isCompletedVotingPlan(macroName) {
  * @param {String} macroName
  * @return {Boolean}
  */
-function isInvalidVotingPlanStatus(macroName) {
-  return (macroName === module.exports.macros.invalidVotingPlanStatus());
-}
-
-/**
- * @param {String} macroName
- * @return {Boolean}
- */
 function isSaidNo(macroName) {
   return (macroName === module.exports.macros.saidNo());
 }
@@ -86,19 +78,21 @@ module.exports = {
   getMacro,
   getProfileUpdate,
   isCompletedVotingPlan,
-  isInvalidVotingPlanStatus,
   isMacro,
   isSaidNo,
   isSaidYes,
   isVotingPlanStatusVoting,
   macros: {
-    invalidVotingPlanStatus: () => getMacroForKey('invalidVotingPlanStatus'),
+    invalidAskVotingPlanStatusResponse: () => getMacroForKey('invalidAskVotingPlanStatusResponse'),
     saidNo: () => getMacroForKey('saidNo'),
     saidYes: () => getMacroForKey('saidYes'),
     subscriptionStatusActive: () => getMacroForKey('subscriptionStatusActive'),
     subscriptionStatusLess: () => getMacroForKey('subscriptionStatusLess'),
     subscriptionStatusNeedMoreInfo: () => getMacroForKey('subscriptionStatusNeedMoreInfo'),
     subscriptionStatusStop: () => getMacroForKey('subscriptionStatusStop'),
+    votingPlanStatusCantVote: () => getMacroForKey('votingPlanStatusCantVote'),
+    votingPlanStatusNotVoting: () => getMacroForKey('votingPlanStatusNotVoting'),
+    votingPlanStatusVoted: () => getMacroForKey('votingPlanStatusVoted'),
     votingPlanStatusVoting: () => getMacroForKey('votingPlanStatusVoting'),
   },
 };

--- a/lib/helpers/macro.js
+++ b/lib/helpers/macro.js
@@ -51,14 +51,6 @@ function isSaidYes(macroName) {
   return (macroName === module.exports.macros.saidYes());
 }
 
-/**
- * @param {String} macroName
- * @return {Boolean}
- */
-function isVotingPlanStatusVoting(macroName) {
-  return (macroName === module.exports.macros.votingPlanStatusVoting());
-}
-
 function getMacro(macroName) {
   return config.macros[macroName];
 }
@@ -81,7 +73,6 @@ module.exports = {
   isMacro,
   isSaidNo,
   isSaidYes,
-  isVotingPlanStatusVoting,
   macros: {
     invalidAskVotingPlanStatusResponse: () => getMacroForKey('invalidAskVotingPlanStatusResponse'),
     saidNo: () => getMacroForKey('saidNo'),

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -164,13 +164,44 @@ function isSubscriptionStatusNeedMoreInfoMacro(req) {
   return req.macro === helpers.macro.macros.subscriptionStatusNeedMoreInfo();
 }
 
-
 /**
  * @param {Object} req
  * @return {Boolean}
  */
 function isSubscriptionStatusStopMacro(req) {
   return req.macro === helpers.macro.macros.subscriptionStatusStop();
+}
+
+/**
+ * @param {Object} req
+ * @return {Boolean}
+ */
+function isVotingPlanStatusCantVoteMacro(req) {
+  return req.macro === helpers.macro.macros.votingPlanStatusCantVote();
+}
+
+/**
+ * @param {Object} req
+ * @return {Boolean}
+ */
+function isVotingPlanStatusNotVotingMacro(req) {
+  return req.macro === helpers.macro.macros.votingPlanStatusNotVoting();
+}
+
+/**
+ * @param {Object} req
+ * @return {Boolean}
+ */
+function isVotingPlanStatusVotedMacro(req) {
+  return req.macro === helpers.macro.macros.votingPlanStatusVoted();
+}
+
+/**
+ * @param {Object} req
+ * @return {Boolean}
+ */
+function isVotingPlanStatusVotingMacro(req) {
+  return req.macro === helpers.macro.macros.votingPlanStatusVoting();
 }
 
 /**
@@ -393,6 +424,10 @@ module.exports = {
   isSubscriptionStatusLessMacro,
   isSubscriptionStatusNeedMoreInfoMacro,
   isSubscriptionStatusStopMacro,
+  isVotingPlanStatusCantVoteMacro,
+  isVotingPlanStatusNotVotingMacro,
+  isVotingPlanStatusVotedMacro,
+  isVotingPlanStatusVotingMacro,
   isTwilio,
   isTwilioStudio,
   parseAskSubscriptionStatusResponse,

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -60,6 +60,10 @@ function getDraftSubmission(req) {
  * @return {Promise}
  */
 async function getRivescriptReply(req) {
+  logger.debug('Getting rivescript reply', {}, req);
+  if (!helpers.rivescript.isBotReady()) {
+    await helpers.rivescript.loadBot();
+  }
   const isRivescriptTopic = helpers.topic.isRivescriptTopicId(req.currentTopicId);
   // If Rivescript bot receives a message in a topic that it doesn't know about, it logs a
   // "User x was in an empty topic Y" message to the console. This avoids that message.

--- a/lib/middleware/messages/member/topics/ask-voting-plan-status.js
+++ b/lib/middleware/messages/member/topics/ask-voting-plan-status.js
@@ -10,23 +10,34 @@ module.exports = function catchAllAskVotingPlanStatus() {
         return next();
       }
 
+      const broadcastTopic = req.topic;
       logger.debug('parsing askVotingPlanStatus response for topic', { topicId: req.topic.id });
+
       await helpers.request.parseAskVotingPlanStatusResponse(req);
+
+      if (helpers.request.isVotingPlanStatusCantVoteMacro(req)) {
+        await helpers.request.changeTopic(req, broadcastTopic.saidCantVoteTopic);
+        return helpers.replies.sendReply(req, res, broadcastTopic.saidCantVote, req.macro);
+      }
+
+      if (helpers.request.isVotingPlanStatusNotVotingMacro(req)) {
+        await helpers.request.changeTopic(req, broadcastTopic.saidNotVotingTopic);
+        return helpers.replies.sendReply(req, res, broadcastTopic.saidNotVoting, req.macro);
+      }
+
+      if (helpers.request.isVotingPlanStatusVotedMacro(req)) {
+        await helpers.request.changeTopic(req, broadcastTopic.saidVotedTopic);
+        return helpers.replies.sendReply(req, res, broadcastTopic.saidVoted, req.macro);
+      }
+
+      // If we've made it this far, this macro reply is hardcoded.
       const macroConfig = helpers.macro.getMacro(req.macro);
 
-      if (helpers.macro.isInvalidVotingPlanStatus(req.macro)) {
-        return await helpers.replies.sendReply(req, res, macroConfig.text, req.macro);
-      }
-
-      if (helpers.macro.isVotingPlanStatusVoting(req.macro)) {
+      if (macroConfig.topic) {
         await helpers.request.changeTopic(req, macroConfig.topic);
-        return await helpers.replies.sendReply(req, res, macroConfig.text, req.macro);
       }
 
-      const reply = req.topic.templates[req.macro];
-      await helpers.request.changeTopic(req, reply.topic);
-
-      return await helpers.replies.sendReply(req, res, reply.text, req.macro);
+      return helpers.replies.sendReply(req, res, macroConfig.text, req.macro);
     } catch (err) {
       return helpers.sendErrorResponse(res, err);
     }

--- a/test/helpers/factories/broadcast.js
+++ b/test/helpers/factories/broadcast.js
@@ -41,25 +41,6 @@ function getValidAskYesNo() {
   });
 }
 
-function getValidAskVotingPlanStatus() {
-  const broadcast = getBroadcast(config.types.askVotingPlanStatus);
-  broadcast.templates = {
-    votingPlanStatusCantVote: {
-      text: stubs.getRandomMessageText(),
-      topic: topicFactory.getValidAutoReply(),
-    },
-    votingPlanStatusNotVoting: {
-      text: stubs.getRandomMessageText(),
-      topic: topicFactory.getValidTopicWithoutCampaign(),
-    },
-    votingPlanStatusVoted: {
-      text: stubs.getRandomMessageText(),
-      topic: topicFactory.getValidTopicWithoutCampaign(),
-    },
-  };
-  return broadcast;
-}
-
 function getValidLegacyCampaignBroadcast() {
   const broadcast = getBroadcast(config.types.legacy);
   broadcast.topic = null;
@@ -81,7 +62,6 @@ module.exports = {
   getBroadcast,
   getValidAutoReplyBroadcast,
   getValidAskSubscriptionStatus,
-  getValidAskVotingPlanStatus,
   getValidAskYesNo,
   getValidLegacyCampaignBroadcast,
   getValidLegacyRivescriptTopicBroadcast,

--- a/test/helpers/factories/topic.js
+++ b/test/helpers/factories/topic.js
@@ -86,6 +86,20 @@ function getValidAskSubscriptionStatusBroadcastTopic() {
 /**
  * @return {Object}
  */
+function getValidAskVotingPlanStatusBroadcastTopic() {
+  return getValidTopicWithoutCampaign(config.types.askVotingPlanStatus.type, {
+    saidCantVote: getTemplate(),
+    saidCantVoteTopic: getValidTopicWithoutCampaign(),
+    saidNotVoting: getTemplate(),
+    saidNotVotingTopic: getValidTopicWithoutCampaign(),
+    saidVoting: getTemplate(),
+    saidVotingTopic: getValidTopicWithoutCampaign(),
+  });
+}
+
+/**
+ * @return {Object}
+ */
 function getValidAskYesNoBroadcastTopic() {
   return getValidTopicWithoutCampaign(config.types.askYesNo.type, {
     invalidAskYesNoResponse: getTemplate(),
@@ -98,6 +112,7 @@ function getValidAskYesNoBroadcastTopic() {
 
 module.exports = {
   getValidAskSubscriptionStatusBroadcastTopic,
+  getValidAskVotingPlanStatusBroadcastTopic,
   getValidAskYesNoBroadcastTopic,
   getValidAutoReply,
   getValidPhotoPostConfig,

--- a/test/unit/lib/lib-helpers/macro.test.js
+++ b/test/unit/lib/lib-helpers/macro.test.js
@@ -85,10 +85,3 @@ test('isSaidNo should return boolean', (t) => {
   t.true(macroHelper.isSaidNo(macros.saidNo.name));
   t.falsy(macroHelper.isSaidNo(undefinedMacroName));
 });
-
-// isVotingPlanStatusVoting
-test('isVotingPlanStatusVoting should return boolean', (t) => {
-  t.falsy(macroHelper.isVotingPlanStatusVoting(null));
-  t.true(macroHelper.isVotingPlanStatusVoting(macros.votingPlanStatusVoting.name));
-  t.falsy(macroHelper.isVotingPlanStatusVoting(undefinedMacroName));
-});

--- a/test/unit/lib/lib-helpers/macro.test.js
+++ b/test/unit/lib/lib-helpers/macro.test.js
@@ -61,12 +61,6 @@ test('isCompletedVotingPlan should return boolean', (t) => {
   t.falsy(macroHelper.isCompletedVotingPlan(undefinedMacroName));
 });
 
-// isInvalidVotingPlanStatus
-test('isInvalidVotingPlanStatus should return boolean', (t) => {
-  t.true(macroHelper.isInvalidVotingPlanStatus(macros.invalidVotingPlanStatus.name));
-  t.falsy(macroHelper.isInvalidVotingPlanStatus(undefinedMacroName));
-});
-
 // isMacro
 test('isMacro returns whether text exists for given macro', (t) => {
   const macro = config.macros.subscriptionStatusStop;

--- a/test/unit/lib/lib-helpers/request.test.js
+++ b/test/unit/lib/lib-helpers/request.test.js
@@ -290,6 +290,39 @@ test('isSubscriptionStatusNeedMoreInfoMacro should return true if req.macro is s
   t.truthy(requestHelper.isSubscriptionStatusNeedMoreInfoMacro(t.context.req));
 });
 
+// isVotingPlanStatusCantVoteMacro
+test('isVotingPlanStatusCantVoteMacro should return true if req.macro is votingPlanStatusCantVote macro', (t) => {
+  t.falsy(requestHelper.isVotingPlanStatusCantVoteMacro(t.context.req));
+  t.context.req.macro = stubs.getRandomWord();
+  t.falsy(requestHelper.isVotingPlanStatusCantVoteMacro(t.context.req));
+  t.context.req.macro = helpers.macro.macros.votingPlanStatusVoted();
+  t.falsy(requestHelper.isVotingPlanStatusCantVoteMacro(t.context.req));
+  t.context.req.macro = helpers.macro.macros.votingPlanStatusCantVote();
+  t.truthy(requestHelper.isVotingPlanStatusCantVoteMacro(t.context.req));
+});
+
+// isVotingPlanStatusNotVotingMacro
+test('isVotingPlanStatusNotVotingMacro should return true if req.macro is votingPlanStatusNotVoting macro', (t) => {
+  t.falsy(requestHelper.isVotingPlanStatusNotVotingMacro(t.context.req));
+  t.context.req.macro = stubs.getRandomWord();
+  t.falsy(requestHelper.isVotingPlanStatusNotVotingMacro(t.context.req));
+  t.context.req.macro = helpers.macro.macros.votingPlanStatusVoted();
+  t.falsy(requestHelper.isVotingPlanStatusNotVotingMacro(t.context.req));
+  t.context.req.macro = helpers.macro.macros.votingPlanStatusNotVoting();
+  t.truthy(requestHelper.isVotingPlanStatusNotVotingMacro(t.context.req));
+});
+
+// isVotingPlanStatusVotedMacro
+test('isVotingPlanStatusVotedMacro should return true if req.macro is votingPlanStatusVoted macro', (t) => {
+  t.falsy(requestHelper.isVotingPlanStatusVotedMacro(t.context.req));
+  t.context.req.macro = stubs.getRandomWord();
+  t.falsy(requestHelper.isVotingPlanStatusVotedMacro(t.context.req));
+  t.context.req.macro = helpers.macro.macros.votingPlanStatusVoted();
+  t.truthy(requestHelper.isVotingPlanStatusVotedMacro(t.context.req));
+  t.context.req.macro = helpers.macro.macros.votingPlanStatusCantVote();
+  t.falsy(requestHelper.isVotingPlanStatusVotedMacro(t.context.req));
+});
+
 // isSubscriptionStatusStopMacro
 test('isSubscriptionStatusStopMacro should return true if req.macro is subscriptionStatusStop macro', (t) => {
   t.falsy(requestHelper.isSubscriptionStatusStopMacro(t.context.req));

--- a/test/unit/lib/lib-helpers/request.test.js
+++ b/test/unit/lib/lib-helpers/request.test.js
@@ -170,17 +170,45 @@ test('getRivescriptReply should call helpers.rivescript.getBotReply with req var
   const mockRivescriptTopicId = 'random';
   const mockRivescriptTopic = { id: mockRivescriptTopicId };
   const botReply = { text: stubs.getRandomMessageText(), match: '@hello' };
+  sandbox.stub(helpers.rivescript, 'isBotReady')
+    .returns(true);
+  sandbox.stub(helpers.rivescript, 'loadBot')
+    .returns(Promise.resolve());
   sandbox.stub(helpers.rivescript, 'getBotReply')
     .returns(Promise.resolve(botReply));
   sandbox.stub(helpers.topic, 'getRivescriptTopicById')
     .returns(mockRivescriptTopic);
+
   const result = await requestHelper.getRivescriptReply(t.context.req);
   helpers.rivescript.getBotReply.should.have.been
     .calledWith(userId, mockRivescriptTopicId, t.context.req.inboundMessageText);
   result.text.should.equal(botReply.text);
   result.match.should.equal(botReply.match);
+  helpers.rivescript.loadBot.should.not.have.been.called;
   // TODO: Add tests for various topic changes.
   // result.topicId.should.deep.equal(mockRivescriptTopic);
+});
+
+test('getRivescriptReply should call helpers.rivescript.loadBot if bot is not ready', async (t) => {
+  t.context.req.userId = userId;
+  t.context.req.conversation = conversation;
+  t.context.req.currentTopicId = stubs.getContentfulId();
+  t.context.req.inboundMessageText = stubs.getRandomMessageText();
+  // TODO: This should be renamed as default topic the way we're using it -- stub getDefaultTopicId.
+  const mockRivescriptTopicId = 'random';
+  const mockRivescriptTopic = { id: mockRivescriptTopicId };
+  const botReply = { text: stubs.getRandomMessageText(), match: '@hello' };
+  sandbox.stub(helpers.rivescript, 'isBotReady')
+    .returns(false);
+  sandbox.stub(helpers.rivescript, 'loadBot')
+    .returns(Promise.resolve());
+  sandbox.stub(helpers.rivescript, 'getBotReply')
+    .returns(Promise.resolve(botReply));
+  sandbox.stub(helpers.topic, 'getRivescriptTopicById')
+    .returns(mockRivescriptTopic);
+
+  await requestHelper.getRivescriptReply(t.context.req);
+  helpers.rivescript.loadBot.should.have.been.called;
 });
 
 // hasCampaign

--- a/test/unit/lib/lib-helpers/topic.test.js
+++ b/test/unit/lib/lib-helpers/topic.test.js
@@ -196,7 +196,8 @@ test('isAskSubscriptionStatus returns whether topic type is askSubscriptionStatu
 // isAskVotingPlanStatus
 test('isAskVotingPlanStatus returns whether topic is rivescriptTopics.askVotingPlanStatus', (t) => {
   const mockTopic = topicFactory.getValidTopic();
-  t.truthy(topicHelper.isAskVotingPlanStatus(broadcastFactory.getValidAskVotingPlanStatus()));
+  const askVotingPlanStatusTopic = topicFactory.getValidAskVotingPlanStatusBroadcastTopic();
+  t.truthy(topicHelper.isAskVotingPlanStatus(askVotingPlanStatusTopic));
   t.falsy(topicHelper.isAskVotingPlanStatus(mockTopic));
 });
 
@@ -215,7 +216,7 @@ test('isAutoReply returns whether topic type is autoReply', (t) => {
 // isBroadcastable
 test('isBroadcastable returns whether topic is rivescriptTopics.askVotingPlanStatus', (t) => {
   const mockTopic = topicFactory.getValidTopic();
-  t.truthy(topicHelper.isBroadcastable(broadcastFactory.getValidAskVotingPlanStatus()));
+  t.truthy(topicHelper.isBroadcastable(topicFactory.getValidAskVotingPlanStatusBroadcastTopic()));
   t.falsy(topicHelper.isBroadcastable(mockTopic));
 });
 

--- a/test/unit/lib/middleware/messages/member/topics/ask-voting-plan-status.test.js
+++ b/test/unit/lib/middleware/messages/member/topics/ask-voting-plan-status.test.js
@@ -70,11 +70,12 @@ test('askVotingPlanStatusCatchAll should call sendErrorResponse if parseAskVotin
 
 test('askVotingPlanStatusCatchAll should not call changeTopic, sends invalidAskVotingPlanStatusResponse macro reply if request is not a votingPlanStatus macro', async (t) => {
   const next = sinon.stub();
+  const macro = helpers.macro.macros.invalidAskVotingPlanStatusResponse();
   const middleware = askVotingPlanStatusCatchAll();
   sandbox.stub(helpers.request, 'parseAskVotingPlanStatusResponse')
     .returns(Promise.resolve(true));
   t.context.req.topic = askVotingPlanStatus;
-  t.context.req.macro = helpers.macro.macros.invalidAskVotingPlanStatusResponse();
+  t.context.req.macro = macro;
 
   // test
   await middleware(t.context.req, t.context.res, next);
@@ -84,32 +85,31 @@ test('askVotingPlanStatusCatchAll should not call changeTopic, sends invalidAskV
   helpers.replies.sendReply.should.have.been.calledWith(
     t.context.req,
     t.context.res,
-    helpers.macro.getMacro(t.context.req.macro).text,
-    t.context.req.macro,
+    helpers.macro.getMacro(macro).text,
+    macro,
   );
 });
 
-test('askVotingPlanStatusCatchAll should change topic to macro topic and send macro text if status is voting', async (t) => {
+test('askVotingPlanStatusCatchAll should change topic to hardcoded macro topic and send macro text if macro is votingPlanStatusVoting', async (t) => {
   const next = sinon.stub();
-  const macro = 'votingPlanStatusVoting';
+  const macro = helpers.macro.macros.votingPlanStatusVoting();
   const middleware = askVotingPlanStatusCatchAll();
   const topic = topicFactory.getValidAutoReply();
   sandbox.stub(helpers.request, 'parseAskVotingPlanStatusResponse')
     .returns(Promise.resolve(true));
-  sandbox.stub(helpers.macro, 'isVotingPlanStatusVoting')
-    .returns(true);
   sandbox.stub(helpers.macro, 'getMacro')
     .returns({ text: messageText, topic });
   t.context.req.topic = askVotingPlanStatus;
   t.context.req.macro = macro;
+  const config = helpers.macro.getMacro(macro);
 
   // test
   await middleware(t.context.req, t.context.res, next);
 
   next.should.not.have.been.called;
-  helpers.request.changeTopic.should.have.been.calledWith(t.context.req, topic);
+  helpers.request.changeTopic.should.have.been.calledWith(t.context.req, config.topic);
   helpers.replies.sendReply
-    .should.have.been.calledWith(t.context.req, t.context.res, messageText, macro);
+    .should.have.been.calledWith(t.context.req, t.context.res, config.text, macro);
 });
 
 test('askVotingPlanStatusCatchAll should change topic to saidVotedTopic and send saidVoted reply if macro is votingPlanStatusVoted', async (t) => {

--- a/test/unit/lib/middleware/messages/member/topics/ask-voting-plan-status.test.js
+++ b/test/unit/lib/middleware/messages/member/topics/ask-voting-plan-status.test.js
@@ -106,21 +106,20 @@ test('askVotingPlanStatusCatchAll should change topic to macro topic and send ma
   // test
   await middleware(t.context.req, t.context.res, next);
 
-  helpers.topic.isAskVotingPlanStatus.should.have.been.calledWith(t.context.req.topic);
   next.should.not.have.been.called;
   helpers.request.changeTopic.should.have.been.calledWith(t.context.req, topic);
   helpers.replies.sendReply
     .should.have.been.calledWith(t.context.req, t.context.res, messageText, macro);
 });
 
-test('askVotingPlanStatusCatchAll should change topic to saidVoted topic and send saidVoted reply if macro is votingPlanStatusVoted', async (t) => {
+test('askVotingPlanStatusCatchAll should change topic to saidVotedTopic and send saidVoted reply if macro is votingPlanStatusVoted', async (t) => {
   const next = sinon.stub();
-  const macro = 'votingPlanStatusVoted';
+  const macro = helpers.macro.macros.votingPlanStatusVoted();
   const middleware = askVotingPlanStatusCatchAll();
   sandbox.stub(helpers.request, 'parseAskVotingPlanStatusResponse')
     .returns(Promise.resolve(true));
   t.context.req.topic = askVotingPlanStatus;
-  t.context.req.macro = helpers.macro.macros.votingPlanStatusVoted();
+  t.context.req.macro = macro;
 
   // test
   await middleware(t.context.req, t.context.res, next);
@@ -132,6 +131,52 @@ test('askVotingPlanStatusCatchAll should change topic to saidVoted topic and sen
     t.context.req,
     t.context.res,
     askVotingPlanStatus.saidActive,
+    macro,
+  );
+});
+
+test('askVotingPlanStatusCatchAll should change topic to cantVoteTopic and send cantVote reply if macro is votingPlanStatusCantVote', async (t) => {
+  const next = sinon.stub();
+  const macro = helpers.macro.macros.votingPlanStatusCantVote();
+  const middleware = askVotingPlanStatusCatchAll();
+  sandbox.stub(helpers.request, 'parseAskVotingPlanStatusResponse')
+    .returns(Promise.resolve(true));
+  t.context.req.topic = askVotingPlanStatus;
+  t.context.req.macro = macro;
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+
+  next.should.not.have.been.called;
+  helpers.request.changeTopic
+    .should.have.been.calledWith(t.context.req, askVotingPlanStatus.saidCantVoteTopic);
+  helpers.replies.sendReply.should.have.been.calledWith(
+    t.context.req,
+    t.context.res,
+    askVotingPlanStatus.saidCantVote,
+    macro,
+  );
+});
+
+test('askVotingPlanStatusCatchAll should change topic to notVotingTopic and send notVoting reply if macro is votingPlanStatusNotVoting', async (t) => {
+  const next = sinon.stub();
+  const macro = helpers.macro.macros.votingPlanStatusNotVoting();
+  const middleware = askVotingPlanStatusCatchAll();
+  sandbox.stub(helpers.request, 'parseAskVotingPlanStatusResponse')
+    .returns(Promise.resolve(true));
+  t.context.req.topic = askVotingPlanStatus;
+  t.context.req.macro = macro;
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+
+  next.should.not.have.been.called;
+  helpers.request.changeTopic
+    .should.have.been.calledWith(t.context.req, askVotingPlanStatus.saidNotVotingTopic);
+  helpers.replies.sendReply.should.have.been.calledWith(
+    t.context.req,
+    t.context.res,
+    askVotingPlanStatus.saidNotVoting,
     macro,
   );
 });


### PR DESCRIPTION
#### What's this PR do?

This PR fixes the `askVotingPlanStatus` topic middleware, which was broken by fetching topics from GraphQL in #461. 

#### How should this be reviewed?

Verify expected replies for a voting plan broadcast, `4LJn0P1LeoUauC0CkESYKE`. Note that answering with a `'voting'` status will send the reply to send a photo, but changes topic to one with a campaign that has ended (so the next reply will be "Sorry, this campaign is no longer available")

#### Any background context you want to provide?

It was a bit confusing to be referencing this code while building out #471, so it felt like it was time to finally finish porting over all broadcast types so there isn't broken code hanging out in the repo.

#### Checklist
- [x] Tests added/updated for new features/bug fixes.
- [x] Tested on staging.
