### PR TITLE
Multiple choice broadcasts

### DIFF
--- a/app/routes/messages/member.js
+++ b/app/routes/messages/member.js
@@ -23,6 +23,7 @@ const parseRivescriptReplyMiddleware = require('../../../lib/middleware/messages
 const forwardSupportMessageMiddleware = require('../../../lib/middleware/messages/member/support-message');
 const replyMacroMiddleware = require('../../../lib/middleware/messages/member/macro-reply');
 const getTopicMiddleware = require('../../../lib/middleware/messages/member/topic-get');
+const askMultipleChoiceMiddleware = require('../../../lib/middleware/messages/member/topics/ask-multiple-choice');
 const askSubscriptionStatusMiddleware = require('../../../lib/middleware/messages/member/topics/ask-subscription-status');
 const askVotingPlanStatusMiddleware = require('../../../lib/middleware/messages/member/topics/ask-voting-plan-status');
 const askYesNoMiddleware = require('../../../lib/middleware/messages/member/topics/ask-yes-no');
@@ -74,6 +75,9 @@ router.use(forwardSupportMessageMiddleware());
 
 // Otherwise, fetch the current conversation topic.
 router.use(getTopicMiddleware());
+
+// Handles replies for askMultipleChoice broadcast topics.
+router.use(askMultipleChoiceMiddleware());
 
 // Handles replies for askSubscriptionStatus broadcast topics.
 router.use(askSubscriptionStatusMiddleware());

--- a/brain/topics/askMultipleChoice.rive
+++ b/brain/topics/askMultipleChoice.rive
@@ -1,0 +1,26 @@
+// Current options are A) B) C)
+
+> topic ask_multiple_choice includes random
+
++ a [*]
+- saidFirstChoice
+
++ b [*]
+- saidSecondChoice
+
++ c [*]
+- saidThirdChoice
+
++ 1 [*]
+- saidFirstChoice
+
++ 2 [*]
+- saidSecondChoice
+
++ 3 [*]
+- saidThirdChoice
+
++ [*]
+- invalidAskMultipleChoiceResponse
+
+< topic

--- a/config/lib/graphql.js
+++ b/config/lib/graphql.js
@@ -15,13 +15,10 @@ const campaignTopicFields = `
   }
 `;
 
-const saidYesTopicFields = `
-  saidYesTopic {
-    id
-    ...autoReplySignupCampaign
-    ...photoPostCampaign
-    ...textPostCampaign
-  }
+const campaignTopicTypes = `
+  ...autoReplySignupCampaign
+  ...photoPostCampaign
+  ...textPostCampaign
 `;
 
 const campaignTopicFragments = `
@@ -36,6 +33,17 @@ const campaignTopicFragments = `
   }
 `;
 
+const saidYesTopicFields = `
+  saidYesTopic {
+    id
+    ${campaignTopicTypes}
+  }
+`;
+
+/**
+ * TODO: Fetch the AskMultipleChoiceBroadcastTopic choice topics to validate that they don't change
+ * topic to a campaign that has ended.
+ */
 const fetchBroadcastById = `
   query getBroadcastById($id: String!) {
     broadcast(id: $id) {
@@ -91,6 +99,24 @@ const fetchTopicById = `
     topic(id: $id) {
       id
       contentType
+      ... on AskMultipleChoiceBroadcastTopic {
+        invalidAskMultipleChoiceResponse
+        saidFirstChoice
+        saidFirstChoiceTopic {
+          id
+          ${campaignTopicTypes}
+        }
+        saidSecondChoice
+        saidSecondChoiceTopic {
+          id
+          ${campaignTopicTypes}
+        }
+        saidThirdChoice
+        saidThirdChoiceTopic {
+          id
+          ${campaignTopicTypes}
+        }
+      }
       ... on AskSubscriptionStatusBroadcastTopic {
         invalidAskSubscriptionStatusResponse
         saidNeedMoreInfo

--- a/config/lib/helpers/broadcast.js
+++ b/config/lib/helpers/broadcast.js
@@ -2,6 +2,7 @@
 
 module.exports = {
   types: {
+    askMultipleChoice: 'askMultipleChoice',
     askSubscriptionStatus: 'askSubscriptionStatus',
     askVotingPlanStatus: 'askVotingPlanStatus',
     askYesNo: 'askYesNo',

--- a/config/lib/helpers/macro.js
+++ b/config/lib/helpers/macro.js
@@ -112,6 +112,9 @@ module.exports = {
     catchAll: {
       name: 'catchAll',
     },
+    invalidAskMultipleChoiceResponse: {
+      name: 'invalidAskMultipleChoiceResponse',
+    },
     invalidAskVotingPlanStatusResponse: {
       name: 'invalidAskVotingPlanStatusResponse',
       text: `${invalidAnswerText} ${askVotingPlanStatusText}`,
@@ -132,8 +135,17 @@ module.exports = {
       name: 'noReply',
       text: '',
     },
+    saidFirstChoice: {
+      name: 'saidFirstChoice',
+    },
     saidNo: {
       name: 'saidNo',
+    },
+    saidSecondChoice: {
+      name: 'saidSecondChoice',
+    },
+    saidThirdChoice: {
+      name: 'saidThirdChoice',
     },
     saidYes: {
       name: 'saidYes',

--- a/config/lib/helpers/topic.js
+++ b/config/lib/helpers/topic.js
@@ -7,6 +7,9 @@ const topicTemplates = templateConfig.templatesMap.topicTemplates;
 
 module.exports = {
   types: {
+    askMultipleChoice: {
+      type: 'askMultipleChoice',
+    },
     askSubscriptionStatus: {
       type: 'askSubscriptionStatus',
     },

--- a/lib/helpers/macro.js
+++ b/lib/helpers/macro.js
@@ -74,8 +74,12 @@ module.exports = {
   isSaidNo,
   isSaidYes,
   macros: {
+    invalidAskMultipleChoiceResponse: () => getMacroForKey('invalidAskMultipleChoiceResponse'),
     invalidAskVotingPlanStatusResponse: () => getMacroForKey('invalidAskVotingPlanStatusResponse'),
+    saidFirstChoice: () => getMacroForKey('saidFirstChoice'),
     saidNo: () => getMacroForKey('saidNo'),
+    saidSecondChoice: () => getMacroForKey('saidSecondChoice'),
+    saidThirdChoice: () => getMacroForKey('saidThirdChoice'),
     saidYes: () => getMacroForKey('saidYes'),
     subscriptionStatusActive: () => getMacroForKey('subscriptionStatusActive'),
     subscriptionStatusLess: () => getMacroForKey('subscriptionStatusLess'),

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -236,6 +236,23 @@ function isTwilioStudio(req) {
 }
 
 /**
+ * Updates req.macro per askMultipleChoice topic reply.
+ *
+ * @async
+ * @param {Object} req
+ * @return {Promise}
+ */
+async function parseAskMultipleChoiceResponse(req) {
+  // This gets called within the catchAll after we've already created an inbound message.
+  const macroName = await helpers.rivescript
+    .parseAskMultipleChoiceResponse(req.inboundMessage.text);
+
+  module.exports.setMacro(req, macroName);
+  // Overwrite the current 'catchAll' macro value with the askSubscriptionStatus reply.
+  await req.inboundMessage.updateMacro(macroName);
+}
+
+/**
  * Updates req.macro per askSubscriptionStatus topic reply.
  *
  * @async
@@ -434,6 +451,7 @@ module.exports = {
   isVotingPlanStatusVotingMacro,
   isTwilio,
   isTwilioStudio,
+  parseAskMultipleChoiceResponse,
   parseAskSubscriptionStatusResponse,
   parseAskVotingPlanStatusResponse,
   parseAskYesNoResponse,

--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -250,6 +250,17 @@ async function getBotReply(userId, topicId, messageText = '') {
  * @param {String} messageText
  * @return {Promise}
  */
+function parseAskMultipleChoiceResponse(messageText) {
+  // We call this helper's getBotReply to DRY checking that our messageText contains alphanumeric.
+  // TODO: Grab these hardcoded id's from config.
+  return module.exports.getBotReply('global', 'ask_multiple_choice', messageText)
+    .then(res => res.text);
+}
+
+/**
+ * @param {String} messageText
+ * @return {Promise}
+ */
 function parseAskSubscriptionStatusResponse(messageText) {
   // We call this helper's getBotReply to DRY checking that our messageText contains alphanumeric.
   // TODO: Grab these hardcoded id's from config.
@@ -292,6 +303,7 @@ module.exports = {
   isRivescriptCurrent,
   joinRivescriptLines,
   loadBot,
+  parseAskMultipleChoiceResponse,
   parseAskSubscriptionStatusResponse,
   parseAskVotingPlanStatusResponse,
   parseAskYesNoResponse,

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -148,6 +148,12 @@ function hasClosedCampaign(topic) {
 }
 
 /**
+ * @param {Object} topic
+ * @return {Boolean}
+ */
+function isAskMultipleChoice(topic) {
+  return topic.type === config.types.askMultipleChoice.type;
+}
 
 /**
  * @param {Object} topic
@@ -244,6 +250,7 @@ module.exports = {
   hasActiveCampaign,
   hasCampaign,
   hasClosedCampaign,
+  isAskMultipleChoice,
   isAskSubscriptionStatus,
   isAskVotingPlanStatus,
   isAskYesNo,

--- a/lib/middleware/messages/broadcast/broadcast-get.js
+++ b/lib/middleware/messages/broadcast/broadcast-get.js
@@ -22,6 +22,11 @@ module.exports = function getBroadcast() {
         return next();
       }
 
+      /**
+       * TODO: If the broadcast is askMultipleChoice, validate that the firstChoice, secondChoice,
+       * and thirdChoice topic campaigns have not ended if set.
+       */
+
       if (broadcast.topic && helpers.topic.hasClosedCampaign(broadcast.topic)) {
         errorMessage = 'Broadcast topic campaign has ended.';
         return helpers.sendErrorResponse(res, new UnprocessableEntityError(errorMessage));

--- a/lib/middleware/messages/member/topics/ask-multiple-choice.js
+++ b/lib/middleware/messages/member/topics/ask-multiple-choice.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const helpers = require('../../../../helpers');
+const logger = require('../../../../logger');
 
 module.exports = function catchAllAskMultipleChoice() {
   return async (req, res, next) => {
@@ -9,7 +10,15 @@ module.exports = function catchAllAskMultipleChoice() {
         return next();
       }
       const broadcastTopic = req.topic;
-      const template = 'saidFirstChoice';
+      logger.debug('parsing askMultipleChoice response for topic', { topicId: req.topic.id });
+
+      await helpers.request.parseAskMultipleChoiceResponse(req);
+
+      const template = req.macro;
+      const newTopic = broadcastTopic[`${template}Topic`];
+      if (newTopic) {
+        await helpers.request.changeTopic(req, newTopic);
+      }
 
       return helpers.replies.sendReply(req, res, broadcastTopic[template], template);
     } catch (err) {

--- a/lib/middleware/messages/member/topics/ask-multiple-choice.js
+++ b/lib/middleware/messages/member/topics/ask-multiple-choice.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const helpers = require('../../../../helpers');
+
+module.exports = function catchAllAskMultipleChoice() {
+  return async (req, res, next) => {
+    try {
+      if (!helpers.topic.isAskMultipleChoice(req.topic)) {
+        return next();
+      }
+      const broadcastTopic = req.topic;
+      const template = 'saidFirstChoice';
+
+      return helpers.replies.sendReply(req, res, broadcastTopic[template], template);
+    } catch (err) {
+      return helpers.sendErrorResponse(res, err);
+    }
+  };
+};

--- a/lib/middleware/messages/member/topics/ask-multiple-choice.js
+++ b/lib/middleware/messages/member/topics/ask-multiple-choice.js
@@ -17,7 +17,7 @@ module.exports = function catchAllAskMultipleChoice() {
       const template = req.macro;
       const newTopic = broadcastTopic[`${template}Topic`];
       if (newTopic) {
-        await helpers.request.changeTopic(req, newTopic);
+        await helpers.request.executeInboundTopicChange(req, newTopic);
       }
 
       return helpers.replies.sendReply(req, res, broadcastTopic[template], template);

--- a/test/helpers/factories/broadcast.js
+++ b/test/helpers/factories/broadcast.js
@@ -31,6 +31,10 @@ function getValidAskSubscriptionStatus() {
   return getBroadcast(config.types.askSubscriptionStatus);
 }
 
+function getValidAskVotingPlanStatus() {
+  return getBroadcast(config.types.askVotingPlanStatus);
+}
+
 function getValidAskYesNo() {
   return getBroadcast(config.types.askYesNo, {
     invalidAskYesNoResponse: stubs.getRandomMessageText(),
@@ -62,6 +66,7 @@ module.exports = {
   getBroadcast,
   getValidAutoReplyBroadcast,
   getValidAskSubscriptionStatus,
+  getValidAskVotingPlanStatus,
   getValidAskYesNo,
   getValidLegacyCampaignBroadcast,
   getValidLegacyRivescriptTopicBroadcast,

--- a/test/helpers/factories/topic.js
+++ b/test/helpers/factories/topic.js
@@ -73,6 +73,21 @@ function getValidTextPostConfig() {
 /**
  * @return {Object}
  */
+function getValidAskMultipleChoiceBroadcastTopic() {
+  return getValidTopicWithoutCampaign(config.types.askMultipleChoice.type, {
+    invalidAskMultipleChoiceResponse: getTemplate(),
+    saidFirstChoice: getTemplate(),
+    saidFirstChoiceTopic: getValidTopicWithoutCampaign(),
+    saidSecondChoice: getTemplate(),
+    saidSecondChoiceTopic: getValidTopicWithoutCampaign(),
+    saidThirdChoice: getTemplate(),
+    saidThirdChoiceTopic: getValidTextPostConfig(),
+  });
+}
+
+/**
+ * @return {Object}
+ */
 function getValidAskSubscriptionStatusBroadcastTopic() {
   return getValidTopicWithoutCampaign(config.types.askSubscriptionStatus.type, {
     invalidAskSubscriptionStatusResponse: getTemplate(),
@@ -111,6 +126,7 @@ function getValidAskYesNoBroadcastTopic() {
 }
 
 module.exports = {
+  getValidAskMultipleChoiceBroadcastTopic,
   getValidAskSubscriptionStatusBroadcastTopic,
   getValidAskVotingPlanStatusBroadcastTopic,
   getValidAskYesNoBroadcastTopic,

--- a/test/unit/lib/lib-helpers/request.test.js
+++ b/test/unit/lib/lib-helpers/request.test.js
@@ -382,6 +382,25 @@ test('isTwilioStudio should return true if req.query.origin is set to twilioStud
   t.truthy(requestHelper.isTwilioStudio(t.context.req));
 });
 
+// parseAskMultipleChoiceResponse
+test('parseAskMultipleChoiceResponse updates macro with helpers.rivescript.parseAskMultipleChoiceResponse result', async (t) => {
+  const mockParseMultipleChoiceResponse = stubs.getRandomWord();
+  sandbox.stub(helpers.request, 'setMacro')
+    .returns(underscore.noop);
+  sandbox.stub(message, 'updateMacro')
+    .returns(Promise.resolve());
+  sandbox.stub(helpers.rivescript, 'parseAskMultipleChoiceResponse')
+    .returns(Promise.resolve(mockParseMultipleChoiceResponse));
+  t.context.req.inboundMessage = message;
+
+  await requestHelper.parseAskMultipleChoiceResponse(t.context.req);
+  helpers.rivescript.parseAskMultipleChoiceResponse.should.have.been
+    .calledWith(message.text);
+  helpers.request.setMacro
+    .should.have.been.calledWith(t.context.req, mockParseMultipleChoiceResponse);
+  message.updateMacro.should.have.been.calledWith(mockParseMultipleChoiceResponse);
+});
+
 // parseAskYesNoResponse
 test('parseAskYesNoResponse updates macro if parseAskYesNoResponse returns isSaidYesMacro', async (t) => {
   const mockParseAskYesNoResponse = 'dragon';

--- a/test/unit/lib/lib-helpers/rivescript.test.js
+++ b/test/unit/lib/lib-helpers/rivescript.test.js
@@ -344,6 +344,18 @@ test('loadBot calls getRivescripts and creates a new Rivescript bot with result'
     .calledWith(getRivescripts);
 });
 
+// parseAskMultipleChoiceResponse
+test('parseAskMultipleChoiceResponse should call rivescriptHelper.getBotReply with ask_multiple_choice and return result text', async () => {
+  const messageText = stubs.getRandomMessageText();
+  sandbox.stub(rivescriptHelper, 'getBotReply')
+    .returns(Promise.resolve(mockRivescriptReply));
+
+  const result = await rivescriptHelper.parseAskMultipleChoiceResponse(messageText);
+  rivescriptHelper.getBotReply
+    .should.have.been.calledWith('global', 'ask_multiple_choice', messageText);
+  result.should.deep.equal(mockRivescriptReply.text);
+});
+
 // parseAskSubscriptionStatusResponse
 test('parseAskSubscriptionStatusResponse should call rivescriptHelper.getBotReply with ask_subscription_status and return result text', async () => {
   const messageText = stubs.getRandomMessageText();

--- a/test/unit/lib/lib-helpers/topic.test.js
+++ b/test/unit/lib/lib-helpers/topic.test.js
@@ -185,6 +185,14 @@ test('hasClosedCampaign returns false if topic does not have campaign', (t) => {
   t.falsy(topicHelper.hasClosedCampaign(topic));
 });
 
+// isAskMultipleChoice
+test('isAskMultipleChoice returns whether topic type is askMultipleChoice', (t) => {
+  t.truthy(topicHelper
+    .isAskMultipleChoice(topicFactory.getValidAskMultipleChoiceBroadcastTopic()));
+  t.falsy(topicHelper
+    .isAskSubscriptionStatus(topicFactory.getValidAskYesNoBroadcastTopic()));
+});
+
 // isAskSubscriptionStatus
 test('isAskSubscriptionStatus returns whether topic type is askSubscriptionStatus', (t) => {
   t.truthy(topicHelper

--- a/test/unit/lib/middleware/messages/member/topics/ask-multiple-choice.test.js
+++ b/test/unit/lib/middleware/messages/member/topics/ask-multiple-choice.test.js
@@ -1,0 +1,114 @@
+'use strict';
+
+require('dotenv').config();
+
+const test = require('ava');
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const httpMocks = require('node-mocks-http');
+const underscore = require('underscore');
+
+const helpers = require('../../../../../../../lib/helpers');
+const topicFactory = require('../../../../../../helpers/factories/topic');
+
+chai.should();
+chai.use(sinonChai);
+
+// module to be tested
+const askMultipleChoiceCatchAll = require('../../../../../../../lib/middleware/messages/member/topics/ask-multiple-choice');
+// stubs
+const askMultipleChoice = topicFactory.getValidAskMultipleChoiceBroadcastTopic();
+const error = { message: 'Epic fail' };
+
+const sandbox = sinon.sandbox.create();
+
+test.beforeEach((t) => {
+  sandbox.stub(helpers.replies, 'sendReply')
+    .returns(underscore.noop);
+  sandbox.stub(helpers.request, 'changeTopic')
+    .returns(Promise.resolve(true));
+  sandbox.stub(helpers, 'sendErrorResponse')
+    .returns(underscore.noop);
+  t.context.req = httpMocks.createRequest();
+  t.context.res = httpMocks.createResponse();
+});
+
+test.afterEach((t) => {
+  sandbox.restore();
+  t.context = {};
+});
+
+test('askMultipleChoiceCatchAll should call next if req.topic is not an askMultipleChoice', async (t) => {
+  const next = sinon.stub();
+  const middleware = askMultipleChoiceCatchAll();
+  t.context.req.topic = topicFactory.getValidAutoReply();
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+
+  next.should.have.been.called;
+  helpers.replies.sendReply.should.not.have.been.called;
+});
+
+test('askMultipleChoiceCatchAll should call sendErrorResponse if parseAskMultipleChoiceResponse fails', async (t) => {
+  const next = sinon.stub();
+  const middleware = askMultipleChoiceCatchAll();
+  sandbox.stub(helpers.request, 'parseAskMultipleChoiceResponse')
+    .returns(Promise.reject(error));
+  t.context.req.topic = askMultipleChoice;
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+
+  next.should.not.have.been.called;
+  helpers.replies.sendReply.should.not.have.been.called;
+  helpers.sendErrorResponse.should.have.been.calledWith(t.context.res, error);
+});
+
+test('askMultipleChoiceCatchAll should change topic to saidFirstChoiceTopic and send saidFirstChoice reply if request is parsed as saidFirstChoice macro', async (t) => {
+  const next = sinon.stub();
+  const macro = helpers.macro.macros.saidFirstChoice();
+  const middleware = askMultipleChoiceCatchAll();
+  t.context.req.macro = macro;
+  t.context.req.topic = askMultipleChoice;
+  sandbox.stub(helpers.request, 'parseAskMultipleChoiceResponse')
+    .returns(Promise.resolve());
+  sandbox.stub(helpers.request, 'executeInboundTopicChange')
+    .returns(Promise.resolve());
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+
+  next.should.not.have.been.called;
+  helpers.request.executeInboundTopicChange
+    .should.have.been.calledWith(t.context.req, askMultipleChoice.saidFirstChoiceTopic);
+  helpers.replies.sendReply.should.have.been.calledWith(
+    t.context.req,
+    t.context.res,
+    askMultipleChoice.saidFirstChoice,
+    macro,
+  );
+});
+
+test('askMultipleChoiceCatchAll should not change topic, sends invalidAskMultipleChoiceResponse if not a subscription status macro', async (t) => {
+  const next = sinon.stub();
+  const macro = helpers.macro.macros.invalidAskMultipleChoiceResponse();
+  const middleware = askMultipleChoiceCatchAll();
+  t.context.req.macro = macro;
+  t.context.req.topic = askMultipleChoice;
+  sandbox.stub(helpers.request, 'parseAskMultipleChoiceResponse')
+    .returns(Promise.resolve());
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+
+  next.should.not.have.been.called;
+  helpers.request.changeTopic.should.not.have.been.called;
+  helpers.replies.sendReply.should.have.been.calledWith(
+    t.context.req,
+    t.context.res,
+    askMultipleChoice.invalidAskMultipleChoiceResponse,
+    macro,
+  );
+});


### PR DESCRIPTION
#### What's this PR do?

Adds support for the `AskMultipleChoiceBroadcastTopic` introduced in https://github.com/DoSomething/graphql/pull/59. This broadcast topic asks the user a multiple choice question with options A, B, and C, and sends replies and changes user topic per configuration in Contentful.

#### How should this be reviewed?

Verify expected behavior per [2/14 Engagement Tests](https://docs.google.com/spreadsheets/u/1/d/1reL_oXWnI4I07T5AFXDUb7FV94YlY6BeASBfpB3cR1g/edit#gid=0):

* Test A - broadcast `4RYThzmwO5VD2x9tPt1l8j` (link type)
* Test B - broadcast `13y0zyxOGAdWpyzJdPSBaO` (playlists) 

#### Any background context you want to provide?

A few of these `request`, `macro`, and `rivescript` helpers used in the various broadcast topic middleware could use some major DRY, but cleanup is out of scope for now (this new broadcast type will be sent tomorrow 2/14). 

#### Relevant tickets

Resolves https://dosomething.slack.com/archives/C2C8NLNAY/p1549927228006500

#### Checklist
- [x] Documentation added for new features/changed endpoints - https://github.com/DoSomething/gambit-admin/wiki/Broadcasts#askmultiplechoice
- [x] Tests added/updated for new features/bug fixes.
- [x] Tested on staging.
- [x] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
