### PR TITLE
Truncate text value when posting to Rogue

### DIFF
--- a/lib/gateway.js
+++ b/lib/gateway.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const lodash = require('lodash');
 const { GatewayClient } = require('@dosomething/gateway/server');
 
 let gatewayClient;
@@ -22,7 +23,8 @@ function getConfig() {
  * @return {Promise}
  */
 function createPost(data) {
-  return module.exports.getClient().Rogue.Posts.create(data);
+  return module.exports.getClient().Rogue.Posts
+    .create(Object.assign(data, { text: lodash.truncate(data.text, { length: 256 }) }));
 }
 
 /**

--- a/test/unit/lib/gateway.test.js
+++ b/test/unit/lib/gateway.test.js
@@ -44,6 +44,8 @@ test('createPost should call gateway.getClient.Posts.create', async () => {
   result.should.deep.equal(mockGatewayResponse);
 });
 
+// TODO: Add test for truncated text post.
+
 // createSignup
 test('createSignup should call gateway.getClient.Signup.create', async () => {
   const mockPayload = { northstar_id: mockUser.id, campaignId: stubs.getCampaignId() };


### PR DESCRIPTION
#### What's this PR do?

This PR truncates any `text` values over 256 characters to prevent [text posts over 256 chars from silently failing](https://dosomething.slack.com/archives/C1V0M6RPE/p1550251161000800).

#### How should this be reviewed?

Test that sending a reply of over 256 chars to text post broadcast `2YaK1CSXVSR4tEVetRIMh2` results in a reply message, as well as a truncated text post.

#### Any background context you want to provide?

There's a separate issue for why Blink isn't retrying the 422 `The given data was invalid.` error that Gambit receives from Rogue (from what I can see in Slack, it looks like Gambit indeed does throw it), but for sake of getting this to prod sooner than later on a Friday, opening as is.

<img width="400" alt="screen shot 2019-02-15 at 10 13 42 am" src="https://user-images.githubusercontent.com/1236811/52878938-bf4a4a00-3112-11e9-8b5e-71b0ef76fba6.png">


#### Checklist
- [ ] Tests added/updated for new features/bug fixes.
- [x] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
