### PR TITLE
WIP: Noticing more errors in New Relic

### DIFF
--- a/lib/helpers/replies.js
+++ b/lib/helpers/replies.js
@@ -55,8 +55,7 @@ module.exports.sendReply = async function (req, res, messageText, messageTemplat
     return helpers.response.sendData(res, { messages });
   } catch (err) {
     /**
-     * This catches a user update error or post to platform error.
-     * I think we should expose this error metadata in NewRelic.
+     * Expose user update errors, post to platform errors in NewRelic.
      */
     return helpers.errorNoticeable.sendErrorResponse(res, err);
   }

--- a/lib/middleware/messages/member/topics/posts/photo/draft-create.js
+++ b/lib/middleware/messages/member/topics/posts/photo/draft-create.js
@@ -29,7 +29,10 @@ module.exports = function createDraftSubmission() {
 
       return await helpers.replies.startPhotoPostAutoReply(req, res);
     } catch (err) {
-      return helpers.sendErrorResponse(res, err);
+      /**
+       * Expose create draft submission errors in NewRelic.
+       */
+      return helpers.errorNoticeable.sendErrorResponse(res, err);
     }
   };
 };

--- a/lib/middleware/messages/member/topics/posts/photo/post-create.js
+++ b/lib/middleware/messages/member/topics/posts/photo/post-create.js
@@ -23,8 +23,10 @@ module.exports = function createPhotoPost() {
 
       return await helpers.replies.completedPhotoPost(req, res);
     } catch (err) {
-      // TODO: Prompt user to send a diffferent photo if Rogue returns error for image file size.
-      return helpers.sendErrorResponse(res, err);
+      /**
+       * Expose create photo post errors in NewRelic.
+       */
+      return helpers.errorNoticeable.sendErrorResponse(res, err);
     }
   };
 };

--- a/lib/middleware/messages/member/topics/posts/text/post-create.js
+++ b/lib/middleware/messages/member/topics/posts/text/post-create.js
@@ -21,7 +21,10 @@ module.exports = function createTextPost() {
 
       return await helpers.replies.completedTextPost(req, res);
     } catch (err) {
-      return helpers.sendErrorResponse(res, err);
+      /**
+       * Expose create text post errors in NewRelic.
+       */
+      return helpers.errorNoticeable.sendErrorResponse(res, err);
     }
   };
 };


### PR DESCRIPTION
#### What's this PR do?

This PR adds the `errorNoticeable` helper introduced in #468 to notice Rogue errors, per #477. It looks like we need to add this into all middleware in `lib/middleware/messages`... 

#### Any background context you want to provide?

* Should `helpers.sendErrorResponse` notice errors by default, like it did prior to #468 ? 


#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tests added/updated for new features/bug fixes.
- [ ] ENV variables added/updated for new features/bug fixes.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
