### PR TITLE
Fix fetching for Rivescript topic errors

### DIFF
--- a/brain/topics/deprecated.rive
+++ b/brain/topics/deprecated.rive
@@ -1,5 +1,8 @@
 // We no longer use these topics, but some old conversations may still remain in them.
 
+/**
+ * This topic was used in tandem with the deprecated conversations.campaignId property, when replies were on a campaign (before defining on topics, as we do now).
+ */
 > topic campaign includes random 
 
 + [*]
@@ -7,6 +10,10 @@
 
 < topic
 
+/**
+ * This topic was used mainly by the legacy broadcast content type, before our AutoReplyBroadcast
+ * type existed.
+ */
 > topic survey_response includes random 
 
 + [*]

--- a/brain/topics/deprecated.rive
+++ b/brain/topics/deprecated.rive
@@ -1,0 +1,15 @@
+// We no longer use these topics, but some old conversations may still remain in them.
+
+> topic campaign includes random 
+
++ [*]
+- Sorry, that campaign is no longer available. Text Q if you have a question.{topic=random}
+
+< topic
+
+> topic survey_response includes random 
+
++ [*]
+- Sorry, I didn't get that. Text Q if you have a question.{topic=random}
+
+< topic

--- a/config/lib/helpers/topic.js
+++ b/config/lib/helpers/topic.js
@@ -43,6 +43,10 @@ module.exports = {
       transitionTemplate: topicTemplates.startExternalPost,
     },
   },
+  /**
+   * TODO: Instead of defining these here, the topic helpers that reference these should inspect the
+   * loaded Rivescript topics.
+   */
   rivescriptTopics: {
     askVotingPlanAttendingWith: {
       id: 'ask_voting_plan_attending_with',
@@ -64,25 +68,6 @@ module.exports = {
     },
     unsubscribed: {
       id: 'unsubscribed',
-    },
-    /**
-     * Deprecated topics.
-     *
-     * The campaign topic was used before we began supporting multiple types of conversations for a
-     * a campaign. This topic no longer gets saved, and has been deprecated by saving Contentful IDs
-     * as the conversation topic.
-     */
-    campaign: {
-      id: 'campaign',
-      deprecated: true,
-    },
-    /**
-     * The survey_response topic has been deprecated by the autoReply and autoReplyBroadcast content
-     * types.
-     */
-    surveyResponse: {
-      id: 'survey_response',
-      deprecated: true,
     },
   },
 };

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -199,14 +199,6 @@ function isBroadcastable(topic) {
  * @param {Object} topic
  * @return {Boolean}
  */
-function isDeprecated(topic) {
-  return topic.deprecated === true;
-}
-
-/**
- * @param {Object} topic
- * @return {Boolean}
- */
 function isPhotoPostConfig(topic) {
   return topic.type === config.types.photoPostConfig.type;
 }
@@ -257,7 +249,6 @@ module.exports = {
   isAutoReply,
   isBroadcastable,
   isDefaultTopicId,
-  isDeprecated,
   isPhotoPostConfig,
   isRivescriptTopicId,
   isTextPostConfig,

--- a/lib/middleware/messages/member/topic-get.js
+++ b/lib/middleware/messages/member/topic-get.js
@@ -1,22 +1,14 @@
 'use strict';
 
 const helpers = require('../../../helpers');
-const logger = require('../../../logger');
 
 module.exports = function getCurrentTopic() {
-  /**
-   * If we've made it this far - we haven't found a reply to send yet.
-   * Get the current topic to determine the reply later.
-   */
+  // If we've made it this far, fetch topic by ID to determine reply to send.
   return async (req, res, next) => {
     try {
       const topic = await helpers.topic.getById(req.currentTopicId);
+      // Saves req.topic
       helpers.request.setTopic(req, topic);
-
-      if (helpers.topic.isDeprecated(topic)) {
-        logger.debug('topic is deprecated', { topicId: topic.id }, req);
-        return await helpers.replies.noCampaign(req, res);
-      }
 
       return next();
     } catch (error) {

--- a/test/unit/lib/lib-helpers/topic.test.js
+++ b/test/unit/lib/lib-helpers/topic.test.js
@@ -228,12 +228,6 @@ test('isBroadcastable returns whether topic is rivescriptTopics.askVotingPlanSta
   t.falsy(topicHelper.isBroadcastable(mockTopic));
 });
 
-// isDeprecated
-test('isDeprecated should return true when topic.deprecated property is set to true', (t) => {
-  t.falsy(topicHelper.isDeprecated(config.rivescriptTopics.unsubscribed));
-  t.truthy(topicHelper.isDeprecated(config.rivescriptTopics.campaign));
-});
-
 // isRivescriptTopicId
 test('isRivescriptTopicId should return whether topicId exists deparsed rivescript topics', (t) => {
   t.truthy(topicHelper.isRivescriptTopicId(mockRivescriptTopicId));

--- a/test/unit/lib/middleware/messages/member/topic-get.test.js
+++ b/test/unit/lib/middleware/messages/member/topic-get.test.js
@@ -29,8 +29,6 @@ const error = stubs.getError();
 test.beforeEach((t) => {
   sandbox.stub(helpers, 'sendErrorResponse')
     .returns(underscore.noop);
-  sandbox.stub(helpers.replies, 'noCampaign')
-    .returns(underscore.noop);
   t.context.req = httpMocks.createRequest();
   t.context.req.currentTopicId = stubs.getContentfulId();
   t.context.res = httpMocks.createResponse();
@@ -41,37 +39,20 @@ test.afterEach((t) => {
   t.context = {};
 });
 
-test('getTopic calls next if topic.getById result is not deprecated', async (t) => {
+test('getTopic calls next after calling setTopic with getById result', async (t) => {
   const next = sinon.stub();
   const middleware = getTopic();
   sandbox.stub(helpers.topic, 'getById')
     .returns(Promise.resolve(topic));
   sandbox.stub(helpers.request, 'setTopic')
     .returns(underscore.noop);
-  sandbox.stub(helpers.topic, 'isDeprecated')
-    .returns(false);
 
   await middleware(t.context.req, t.context.res, next);
   helpers.topic.getById.should.have.been.calledWith(t.context.req.currentTopicId);
   helpers.request.setTopic.should.have.been.calledWith(t.context.req, topic);
-  helpers.replies.noCampaign.should.not.have.been.called;
   next.should.have.been.called;
 });
 
-test('getTopic sends noCampaign reply if topic.getById result is deprecated', async (t) => {
-  const next = sinon.stub();
-  const middleware = getTopic();
-  sandbox.stub(helpers.topic, 'getById')
-    .returns(Promise.resolve(topic));
-  sandbox.stub(helpers.request, 'setTopic')
-    .returns(underscore.noop);
-  sandbox.stub(helpers.topic, 'isDeprecated')
-    .returns(true);
-
-  await middleware(t.context.req, t.context.res, next);
-  helpers.replies.noCampaign.should.have.been.calledWith(t.context.req, t.context.res);
-  next.should.not.have.been.called;
-});
 
 test('getTopic calls sendErrorResponse if topic.getById returns error', async (t) => {
   const next = sinon.stub();


### PR DESCRIPTION
#### What's this PR do?

Defines the Rivescript topics we no longer use via actual Rivescript in `brain/topics`, instead of the topic helper. 

This avoids the errors we receive when querying GraphQL by the deprecated `campaign` or `survey_response` topic ID's, which happens when Gambit receives an inbound message from a (very old) conversation in these topics. 

#### How should this be reviewed?

Manually set your `conversation.topic` to `campaign`, and send Gambit a message. Verify a reply is sent, and your topic is changed to `random`.

Repeat for `survey_response` topic.


#### Relevant tickets
Fixes https://dosomething.slack.com/archives/CAPHYCR8V/p1550595993000900?thread_ts=1550570618.000100&cid=CAPHYCR8V

#### Checklist
- [x] Tests added/updated for new features/bug fixes.
- [x] Tested on staging - https://gambit-admin-staging.herokuapp.com/requests/2456ad2f-fe9c-47c5-9161-e8774ae5acc3, https://gambit-admin-staging.herokuapp.com/requests/8f3e8cc7-47f2-4b86-b591-1fe4d7b02d5f
