### PR TITLE
Subscription Status Active config var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,6 +57,7 @@ DS_CONSOLEBOT_USER_MEDIA_URL=http://placekitten.com/g/300/300
 DS_CONSOLEBOT_USER_MEDIA_TYPE=image/jpg
 
 DS_GAMBIT_CONVERSATIONS_COMPLETED_VOTING_PLAN_TEXT=Great job!
+DS_GAMBIT_CONVERSATIONS_SUBSCRIPTION_STATUS_ACTIVE_TEXT=Hi I'm Freddie from DoSomething.org! Welcome to my weekly updates (up to 8msg/month). Things to know: Msg&DataRatesApply. Text HELP for help, text STOP to stop.
 DS_GAMBIT_CONVERSATIONS_VOTING_PLAN_CAMPAIGN_ID=71
 DS_GAMBIT_CREATE_USER_SOURCE=sms
 

--- a/.env.example
+++ b/.env.example
@@ -57,7 +57,7 @@ DS_CONSOLEBOT_USER_MEDIA_URL=http://placekitten.com/g/300/300
 DS_CONSOLEBOT_USER_MEDIA_TYPE=image/jpg
 
 DS_GAMBIT_CONVERSATIONS_COMPLETED_VOTING_PLAN_TEXT=Great job!
-DS_GAMBIT_CONVERSATIONS_SUBSCRIPTION_STATUS_ACTIVE_TEXT=Hi I'm Freddie from DoSomething.org! Welcome to my weekly updates (up to 8msg/month). Things to know: Msg&DataRatesApply. Text HELP for help, text STOP to stop.
+DS_GAMBIT_CONVERSATIONS_SUBSCRIPTION_STATUS_ACTIVE_TEXT="Hi I'm Freddie from DoSomething.org! Welcome to my weekly updates (up to 8msg/month). Things to know: Msg&DataRatesApply. Text HELP for help, text STOP to stop."
 DS_GAMBIT_CONVERSATIONS_VOTING_PLAN_CAMPAIGN_ID=71
 DS_GAMBIT_CREATE_USER_SOURCE=sms
 

--- a/config/lib/helpers/macro.js
+++ b/config/lib/helpers/macro.js
@@ -7,7 +7,7 @@ const defaultTopic = rivescriptTopics.default;
 const invalidAnswerText = 'Sorry, I didn\'t get that.';
 
 // Subscription status.
-const activeSubscriptionStatusText = 'Hi I\'m Freddie from DoSomething.org! Welcome to my weekly updates (up to 8msg/month). Things to know: Msg&DataRatesApply. Text HELP for help, text STOP to stop.';
+const activeSubscriptionStatusText = process.env.DS_GAMBIT_CONVERSATIONS_SUBSCRIPTION_STATUS_ACTIVE_TEXT || 'Hi I\'m Freddie from DoSomething.org! Welcome to my weekly updates (up to 8msg/month). Things to know: Msg&DataRatesApply. Text HELP for help, text STOP to stop.';
 const lessSubscriptionStatusText = 'Great, you\'ll start to receive 1 monthly update from Freddie at DoSomething.org! Things to know: Msg&DataRatesApply. Text HELP for help, text STOP to stop.';
 
 // Voting plan.

--- a/documentation/endpoints/messages.md
+++ b/documentation/endpoints/messages.md
@@ -286,6 +286,8 @@ Creates an outbound `subscriptionStatusActive` (Welcome) message in given User's
 
 * Sends the message if given platform is SMS.
 
+**Note**: This message text can be overridden by setting the `DS_GAMBIT_CONVERSATIONS_SUBSCRIPTION_STATUS_ACTIVE_TEXT` config var in `.env`.
+
 ### Input
 
 Name | Type | Description


### PR DESCRIPTION
#### What's this PR do?

Adds a `DS_GAMBIT_CONVERSATIONS_SUBSCRIPTION_STATUS_ACTIVE_TEXT` config variable to edit the welcome message sent without needing to deploy code changes. 

#### How should this be reviewed?

Add a `DS_GAMBIT_CONVERSATIONS_SUBSCRIPTION_STATUS_ACTIVE_TEXT` to your `.env`, restart Gambit, and text JOIN. Confirm override is returned.

#### Any background context you want to provide?

This is a minimal PR to get this to prod for tomorrow, a little more TLC would include integration tests to verify expected messaging based on whether config var is set.

#### Relevant tickets
Fixes https://dosomething.slack.com/archives/C2C8NLNAY/p1552326330046800

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- ~[ ] Tests added/updated for new features/bug fixes.~ - skipping for now
- [x] ENV variables added/updated for new features/bug fixes.
- [x] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
