### PR TITLE
Fix conversation. lastReceivedBroadcastId

### DIFF
--- a/app/models/Conversation.js
+++ b/app/models/Conversation.js
@@ -27,10 +27,12 @@ const conversationSchema = new mongoose.Schema({
   },
   topic: String,
   campaignId: Number,
+  // Used to determine how to reply to an inbound messages for the conversation.
   lastOutboundMessage: {
     type: mongoose.Schema.Types.ObjectId,
     ref: 'Message',
   },
+  // Used to support rendering a {{broadcast}} tag in outbound messages for the conversation.
   lastReceivedBroadcastId: String,
 }, { timestamps: true });
 

--- a/app/models/Conversation.js
+++ b/app/models/Conversation.js
@@ -26,7 +26,6 @@ const conversationSchema = new mongoose.Schema({
     index: true,
   },
   topic: String,
-  campaignId: Number,
   // Used to determine how to reply to an inbound messages for the conversation.
   lastOutboundMessage: {
     type: mongoose.Schema.Types.ObjectId,
@@ -107,25 +106,15 @@ conversationSchema.statics.findOneAndPopulateLastOutboundMessage = function (que
 };
 
 /**
- * Saves topicId as topic property, updates the campaignId property if topic contains a campaign.
+ * Saves topicId as topic property, saves last .
  *
  * @param {Object} topic
  * @return {Promise}
  */
-conversationSchema.methods.setTopic = function (topic) {
+conversationSchema.methods.setTopic = function (topic, broadcastId) {
   const topicId = topic.id;
   this.topic = topicId;
-  if (helpers.topic.isBroadcastable(topic)) {
-    this.lastReceivedBroadcastId = topicId;
-  }
   logger.debug('updating conversation.topic', { topicId });
-  if (topic.campaign && topic.campaign.id) {
-    const campaignId = topic.campaign.id;
-    if (this.campaignId !== campaignId) {
-      logger.debug('updating conversation.campaignId', { campaignId });
-      this.campaignId = campaignId;
-    }
-  }
   return this.save();
 };
 

--- a/app/models/Conversation.js
+++ b/app/models/Conversation.js
@@ -106,12 +106,12 @@ conversationSchema.statics.findOneAndPopulateLastOutboundMessage = function (que
 };
 
 /**
- * Saves topicId as topic property, saves last .
+ * Saves topicId as topic property.
  *
  * @param {Object} topic
  * @return {Promise}
  */
-conversationSchema.methods.setTopic = function (topic, broadcastId) {
+conversationSchema.methods.setTopic = function (topic) {
   const topicId = topic.id;
   this.topic = topicId;
   logger.debug('updating conversation.topic', { topicId });

--- a/lib/helpers/broadcast.js
+++ b/lib/helpers/broadcast.js
@@ -15,6 +15,8 @@ async function fetchById(id) {
   logger.debug('Fetching broadcast', { id });
 
   const broadcast = await graphql.fetchBroadcastById(id);
+  // TODO: Refactor codebase to check for the topic GraphQL __typename, not the Contentful type name
+  Object.assign(broadcast, { type: broadcast.contentType });
 
   return helpers.cache.broadcasts.set(id, broadcast);
 }

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -4,7 +4,6 @@ const graphql = require('../graphql');
 const helpers = require('../helpers');
 const logger = require('../logger');
 const config = require('../../config/lib/helpers/topic');
-const broadcastConfig = require('../../config/lib/helpers/broadcast');
 const repliesConfig = require('../../config/lib/helpers/replies');
 // TODO: Move templateConfig into repliesConfig.
 const templateConfig = require('../../config/lib/helpers/template');
@@ -191,14 +190,6 @@ function isAutoReply(topic) {
  * @param {Object} topic
  * @return {Boolean}
  */
-function isBroadcastable(topic) {
-  return broadcastConfig.types[topic.type];
-}
-
-/**
- * @param {Object} topic
- * @return {Boolean}
- */
 function isPhotoPostConfig(topic) {
   return topic.type === config.types.photoPostConfig.type;
 }
@@ -247,7 +238,6 @@ module.exports = {
   isAskVotingPlanStatus,
   isAskYesNo,
   isAutoReply,
-  isBroadcastable,
   isDefaultTopicId,
   isPhotoPostConfig,
   isRivescriptTopicId,

--- a/lib/middleware/messages/broadcast/conversation-update.js
+++ b/lib/middleware/messages/broadcast/conversation-update.js
@@ -1,16 +1,29 @@
 'use strict';
 
 const helpers = require('../../../helpers');
+const logger = require('../../../logger');
 const UnprocessableEntityError = require('../../../../app/exceptions/UnprocessableEntityError');
 
 module.exports = function updateConversation() {
-  return (req, res, next) => {
+  return async (req, res, next) => {
     if (!req.topic) {
-      return helpers.sendErrorResponse(res, new UnprocessableEntityError('req.topic undefined'));
+      return helpers.errorNoticeable
+        .sendErrorResponse(res, new UnprocessableEntityError('req.topic undefined'));
     }
 
-    return helpers.request.updateTopicIfChanged(req, req.topic)
-      .then(() => next())
-      .catch(err => helpers.sendErrorResponse(res, err));
+    try {
+      req.conversation.lastReceivedBroadcastId = req.broadcastId;
+      req.conversation.topic = req.topic.id;
+
+      logger.debug('Updating conversation', {
+        lastReceivedBroadcastId: req.broadcastId,
+        topic: req.topic.id,
+      });
+      await req.conversation.save();
+
+      return next();
+    } catch (error) {
+      return helpers.errorNoticeable.sendErrorResponse(res, error);
+    }
   };
 };

--- a/test/helpers/factories/conversation.js
+++ b/test/helpers/factories/conversation.js
@@ -20,7 +20,6 @@ module.exports.getRawConversationData = function getRawConversationData(platform
     createdAt: date,
     updatedAt: date,
     lastOutboundMessage: messageFactory.getValidMessage(),
-    campaignId: stubs.getCampaignId(),
     lastReceivedBroadcastId: stubs.getContentfulId(),
   };
 };

--- a/test/helpers/stubs.js
+++ b/test/helpers/stubs.js
@@ -29,7 +29,6 @@ function getContentfulId() {
   return '72mon4jUeQOaokEIkQMaoa';
 }
 
-
 /**
  * @return {Object}
  */
@@ -241,7 +240,7 @@ module.exports = {
   getTemplate() {
     return 'askQuantity';
   },
-  // TODO: Refator this -- this is ancient, before we had topic objects and id's.
+  // TODO: Refactor or remove this -- this is ancient, before we had topic objects and id's.
   getTopic() {
     return 'random';
   },

--- a/test/helpers/stubs.js
+++ b/test/helpers/stubs.js
@@ -241,6 +241,7 @@ module.exports = {
   getTemplate() {
     return 'askQuantity';
   },
+  // TODO: Refator this -- this is ancient, before we had topic objects and id's.
   getTopic() {
     return 'random';
   },

--- a/test/helpers/stubs.js
+++ b/test/helpers/stubs.js
@@ -79,7 +79,6 @@ module.exports = {
         broadcast: {
           id: '429qioxAt2swYoMQUUymYW',
           name: 'VoterRegistration2018_Sept24_NVRD_Staff_Test',
-          type: 'autoReplyBroadcast',
           contentType: 'autoReplyBroadcast',
           createdAt: '2018-09-24T16:29:02.299Z',
           updatedAt: '2018-09-24T20:55:31.249Z',

--- a/test/unit/app/models/conversation.test.js
+++ b/test/unit/app/models/conversation.test.js
@@ -15,7 +15,6 @@ const helpers = require('../../../../lib/helpers');
 const front = require('../../../../lib/front');
 const twilio = require('../../../../lib/twilio');
 const stubs = require('../../../helpers/stubs');
-const broadcastFactory = require('../../../helpers/factories/broadcast');
 const conversationFactory = require('../../../helpers/factories/conversation');
 const messageFactory = require('../../../helpers/factories/message');
 const topicFactory = require('../../../helpers/factories/topic');

--- a/test/unit/app/models/conversation.test.js
+++ b/test/unit/app/models/conversation.test.js
@@ -200,27 +200,10 @@ test('setTopic calls save for new topic', async () => {
   const mockTopic = topicFactory.getValidTopic();
   const mockResult = conversationFactory.getValidConversation();
   mockResult.topic = mockTopic.id;
-  sandbox.stub(helpers.topic, 'isBroadcastable')
-    .returns(false);
-  mockResult.campaignId = mockTopic.campaign.id;
   sandbox.stub(mockConversation, 'save')
     .returns(Promise.resolve(mockResult));
 
   await mockConversation.setTopic(mockTopic);
   mockConversation.save.should.have.been.called;
   mockConversation.topic.should.equal(mockResult.topic);
-  mockConversation.campaignId.should.equal(mockResult.campaignId);
-});
-
-test('setTopic sets lastReceivedBroadcastId if topic arg is broadcastable', async () => {
-  const mockConversation = conversationFactory.getValidConversation();
-  const mockTopic = broadcastFactory.getValidAutoReplyBroadcast();
-  sandbox.stub(helpers.topic, 'isBroadcastable')
-    .returns(true);
-  sandbox.stub(mockConversation, 'save')
-    .returns(Promise.resolve(conversationFactory.getValidConversation()));
-
-  await mockConversation.setTopic(mockTopic);
-  mockConversation.save.should.have.been.called;
-  mockConversation.lastReceivedBroadcastId.should.equal(mockTopic.id);
 });

--- a/test/unit/lib/lib-helpers/broadcast.test.js
+++ b/test/unit/lib/lib-helpers/broadcast.test.js
@@ -69,7 +69,7 @@ test('fetchById should return graphql.fetchBroadcastById', async () => {
     .returns(Promise.resolve(broadcast));
 
   const result = await broadcastHelper.fetchById(broadcastId);
-  Object.assign(result, { type: result.contentType }).should.deep.equal(broadcast);
+  Object.assign(broadcast, { type: broadcast.contentType }).should.deep.equal(result);
   graphql.fetchBroadcastById.should.have.been.calledWith(broadcastId);
 });
 

--- a/test/unit/lib/lib-helpers/broadcast.test.js
+++ b/test/unit/lib/lib-helpers/broadcast.test.js
@@ -69,7 +69,7 @@ test('fetchById should return graphql.fetchBroadcastById', async () => {
     .returns(Promise.resolve(broadcast));
 
   const result = await broadcastHelper.fetchById(broadcastId);
-  result.should.deep.equal(broadcast);
+  Object.assign(result, { type: result.contentType }).should.deep.equal(broadcast);
   graphql.fetchBroadcastById.should.have.been.calledWith(broadcastId);
 });
 

--- a/test/unit/lib/lib-helpers/topic.test.js
+++ b/test/unit/lib/lib-helpers/topic.test.js
@@ -221,13 +221,6 @@ test('isAutoReply returns whether topic type is autoReply', (t) => {
   t.falsy(topicHelper.isAutoReply(topicFactory.getValidTextPostConfig()));
 });
 
-// isBroadcastable
-test('isBroadcastable returns whether topic is rivescriptTopics.askVotingPlanStatus', (t) => {
-  const mockTopic = topicFactory.getValidTopic();
-  t.truthy(topicHelper.isBroadcastable(topicFactory.getValidAskVotingPlanStatusBroadcastTopic()));
-  t.falsy(topicHelper.isBroadcastable(mockTopic));
-});
-
 // isRivescriptTopicId
 test('isRivescriptTopicId should return whether topicId exists deparsed rivescript topics', (t) => {
   t.truthy(topicHelper.isRivescriptTopicId(mockRivescriptTopicId));

--- a/test/unit/lib/middleware/messages/broadcast/conversation-update.test.js
+++ b/test/unit/lib/middleware/messages/broadcast/conversation-update.test.js
@@ -12,6 +12,7 @@ const underscore = require('underscore');
 const helpers = require('../../../../../../lib/helpers');
 const stubs = require('../../../../../helpers/stubs');
 const conversationFactory = require('../../../../../helpers/factories/conversation');
+const topicFactory = require('../../../../../helpers/factories/topic');
 
 // setup "x.should.y" assertion style
 chai.should();
@@ -21,14 +22,16 @@ chai.use(sinonChai);
 const updateConversation = require('../../../../../../lib/middleware/messages/broadcast/conversation-update');
 
 const conversation = conversationFactory.getValidConversation();
+const topic = topicFactory.getValidAutoReply();
 
 // sinon sandbox object
 const sandbox = sinon.sandbox.create();
 
 test.beforeEach((t) => {
-  sandbox.stub(helpers, 'sendErrorResponse')
+  sandbox.stub(helpers.errorNoticeable, 'sendErrorResponse')
     .returns(underscore.noop);
   t.context.req = httpMocks.createRequest();
+  t.context.req.broadcastId = stubs.getContentfulId();
   t.context.req.conversation = conversation;
   t.context.res = httpMocks.createResponse();
 });
@@ -41,46 +44,45 @@ test.afterEach((t) => {
 test('updateConversation should call sendErrorResponse if req.topic undefined', async (t) => {
   const next = sinon.stub();
   const middleware = updateConversation();
-  sandbox.stub(helpers.request, 'updateTopicIfChanged')
+  sandbox.stub(t.context.req.conversation, 'save')
     .returns(Promise.resolve());
 
   // test
   await middleware(t.context.req, t.context.res, next);
 
-  helpers.request.updateTopicIfChanged.should.not.have.been.called;
-  helpers.sendErrorResponse.should.have.been.called;
+  t.context.req.conversation.save.should.not.have.have.been.called;
+  helpers.errorNoticeable.sendErrorResponse.should.have.been.called;
   next.should.not.have.been.called;
 });
 
-test('updateConversation should call conversation.setTopic if req.topic is set', async (t) => {
+test('updateConversation should save lastBroadcastId and topic if req.topic is set', async (t) => {
   const next = sinon.stub();
   const middleware = updateConversation();
-  const topic = stubs.getTopic();
   t.context.req.topic = topic;
-  sandbox.stub(helpers.request, 'updateTopicIfChanged')
-    .returns(Promise.resolve());
+  sandbox.stub(t.context.req.conversation, 'save')
+    .returns(Promise.resolve(true));
 
   // test
   await middleware(t.context.req, t.context.res, next);
 
-  helpers.request.updateTopicIfChanged.should.have.been.calledWith(t.context.req, topic);
+  t.context.req.conversation.save.should.have.have.been.called;
+  t.context.req.conversation.topic.should.equal(topic.id);
+  t.context.req.conversation.lastReceivedBroadcastId.should.equal(t.context.req.broadcastId);
   next.should.have.been.called;
-  helpers.sendErrorResponse.should.not.have.been.called;
+  helpers.errorNoticeable.sendErrorResponse.should.not.have.been.called;
 });
 
-test('updateConversation should call sendErrorResponse if changeTopic throws', async (t) => {
+test('updateConversation should call sendErrorResponse if save throws', async (t) => {
   const next = sinon.stub();
   const middleware = updateConversation();
-  const topic = stubs.getTopic();
   t.context.req.topic = topic;
   const error = { message: 'Epic fail' };
-  sandbox.stub(helpers.request, 'updateTopicIfChanged')
+  sandbox.stub(t.context.req.conversation, 'save')
     .returns(Promise.reject(error));
 
   // test
   await middleware(t.context.req, t.context.res, next);
 
-  helpers.request.updateTopicIfChanged.should.have.been.called;
-  helpers.sendErrorResponse.should.have.been.calledWith(t.context.res, error);
+  helpers.errorNoticeable.sendErrorResponse.should.have.been.calledWith(t.context.res, error);
   next.should.not.have.been.called;
 });

--- a/test/unit/lib/middleware/messages/broadcast/conversation-update.test.js
+++ b/test/unit/lib/middleware/messages/broadcast/conversation-update.test.js
@@ -31,7 +31,7 @@ test.beforeEach((t) => {
   sandbox.stub(helpers.errorNoticeable, 'sendErrorResponse')
     .returns(underscore.noop);
   t.context.req = httpMocks.createRequest();
-  t.context.req.broadcastId = stubs.getContentfulId();
+  t.context.req.broadcastId = stubs.getBroadcastId();
   t.context.req.conversation = conversation;
   t.context.res = httpMocks.createResponse();
 });


### PR DESCRIPTION
#### What's this PR do?

Adds a `type` parameter to a broadcast to get the `isBroadcastable` topic helper working per #488. This bug was introduced in #465, when changing broadcast source content to GraphQL instead of Gambit Content.

#### How should this be reviewed?

Send yourself a broadcast, verify the conversation `lastReceivedBroadcastId` is set. Can also verify the `{{broadcast.id}}` tag renders correctly in NO responses to broadcasts like `1nnpJqvtHLJNbcF0GSVg5B`

<img width="500" alt="Screen Shot 2019-03-22 at 7 01 58 AM" src="https://user-images.githubusercontent.com/1236811/54828018-843ab980-4c70-11e9-8375-31a4c3c4239e.png">


#### Any background context you want to provide?

I've copied over the TODO of replacing the `type` property with `__typename`.. and eventually thought I'd take on those changes, but it touches quite a bit of code. I do think it's nice-to-have, as we can easily swap out the GraphQL types with different Contentful types.. but it'd most likely make sense to rename all of the helpers as well if we went this route (e.g. `isAskYesNoBroadcastTopic` vs `isAskYesNo`)

#### Relevant tickets
Fixes #488 

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Tests added/updated for new features/bug fixes.
- [x] Tested on staging.
