### PR TITLE
Save campaignId to outbound message metadata [pr]

### DIFF
--- a/app/models/Message.js
+++ b/app/models/Message.js
@@ -32,8 +32,10 @@ const messageSchema = new mongoose.Schema({
   match: String,
   macro: String,
   metadata: {
-    requestId: { type: String, index: true },
-    retryCount: Number,
+    // CampaignId associated with this broadcast outbound message.
+    // Not set for inbound or non broadcast outbound messages.
+    campaignId: Number,
+    // Delivery metadata reported by Twilio via the statusCallback webhook for outbound messages
     delivery: {
       queuedAt: Date,
       deliveredAt: Date,
@@ -41,6 +43,8 @@ const messageSchema = new mongoose.Schema({
       failureData: { type: mongoose.Schema.Types.Mixed },
       totalSegments: Number,
     },
+    requestId: { type: String, index: true },
+    retryCount: Number,
   },
 }, { timestamps: true });
 

--- a/app/routes/messages/broadcast.js
+++ b/app/routes/messages/broadcast.js
@@ -24,7 +24,12 @@ const sendOutboundMessageMiddleware = require('../../../lib/middleware/messages/
 router.use(paramsMiddleware());
 router.use(getBroadcastMiddleware());
 router.use(parseBroadcastMiddleware());
-
+/**
+ * TODO: Do not fetch user from NS once we move to use Northstar-less broadcasts.
+ * We get the userId and broadcastId from the payload sent to us by Customer.io.
+ * Once we have the subscription cache (or unsubscribed blacklist) operational, we won't
+ * have to make this wound trip to Northstar for the user data.
+ */
 router.use(getUserMiddleware(getUserConfig));
 router.use(validateOutboundMessageMiddleware(outboundMessageConfig));
 

--- a/app/routes/messages/broadcast.js
+++ b/app/routes/messages/broadcast.js
@@ -28,7 +28,7 @@ router.use(parseBroadcastMiddleware());
  * TODO: Do not fetch user from NS once we move to use Northstar-less broadcasts.
  * We get the userId and broadcastId from the payload sent to us by Customer.io.
  * Once we have the subscription cache (or unsubscribed blacklist) operational, we won't
- * have to make this wound trip to Northstar for the user data.
+ * have to make this round trip to Northstar for the user data.
  */
 router.use(getUserMiddleware(getUserConfig));
 router.use(validateOutboundMessageMiddleware(outboundMessageConfig));

--- a/config/lib/graphql.js
+++ b/config/lib/graphql.js
@@ -42,6 +42,15 @@ const saidYesTopicFields = `
   }
 `;
 
+const actionFields = `
+  action {
+    id
+    name
+    campaignId
+    postType
+  }
+`;
+
 /**
  * TODO: Fetch the AskMultipleChoiceBroadcastTopic choice topics to validate that they don't change
  * topic to a campaign that has ended.
@@ -56,8 +65,12 @@ const fetchBroadcastById = `
         url
       }
       contentType
+      ... on AskVotingPlanStatusBroadcastTopic {
+        ${actionFields}
+      }
       ... on AskYesNoBroadcastTopic {
         ${saidYesTopicFields}
+        ${actionFields}
       }
       ... on AutoReplyBroadcast {
         topic {
@@ -65,9 +78,11 @@ const fetchBroadcastById = `
         }
       }
       ... on PhotoPostBroadcast {
+        ${actionFields}
         ${campaignTopicFields}
       }
       ... on TextPostBroadcast {
+        ${actionFields}
         ${campaignTopicFields}
       }
     }

--- a/lib/helpers/metadata.js
+++ b/lib/helpers/metadata.js
@@ -20,7 +20,16 @@ function registerIsARetryRequestFunction(req) {
   req.isARetryRequest = () => !!req.metadata[config.metadata.keys.retryCount];
 }
 
+/**
+ * @param {*} req
+ * @param {Object} properties
+ */
+function addMetadataProperties(req, properties = {}) {
+  Object.assign(req.metadata, properties);
+}
+
 module.exports = {
+  addMetadataProperties,
   getRequestIdFromReq,
   getRetryCountFromReq,
   registerIsARetryRequestFunction,

--- a/lib/middleware/messages/broadcast/broadcast-parse.js
+++ b/lib/middleware/messages/broadcast/broadcast-parse.js
@@ -8,13 +8,20 @@ module.exports = function parseBroadcast() {
       // Parse message to send to user.
       helpers.request.setOutboundMessageText(req, req.broadcast.text);
       helpers.request.setOutboundMessageTemplate(req, req.broadcast.contentType);
+      // The Rogue's action contains the campaign id we will associate this broadcast message with
+      if (req.broadcast.action) {
+        helpers.metadata.addMetadataProperties(req, {
+          campaignId: req.broadcast.action.campaignId,
+        });
+      }
       req.broadcast.attachments.forEach((attachment) => {
         helpers.attachments.add(req, attachment, 'outbound');
       });
-
       /**
-       * If the outbound message does not contain a topic property, this broadcast is the new topic,
-       * as we'll wait for user response to determine next topic change.
+       * If this broadcast does not contain a topic property, this broadcast's id will
+       * be the new topic. When the user responds, we will determine the topic change
+       * based on the response.
+       * Example: askYesNo, askMultipleChoice, askVotingPlanStatus, and askSubscriptionStatus.
        */
       helpers.request
         .setTopic(req, req.broadcast.topic ? req.broadcast.topic : req.broadcast);

--- a/lib/middleware/messages/broadcast/conversation-update.js
+++ b/lib/middleware/messages/broadcast/conversation-update.js
@@ -8,14 +8,14 @@ module.exports = function updateConversation() {
   return async (req, res, next) => {
     if (!req.topic) {
       return helpers.errorNoticeable
-        .sendErrorResponse(res, new UnprocessableEntityError('req.topic undefined'));
+        .sendErrorResponse(res, new UnprocessableEntityError('The broadcast topic was not set in the req object.'));
     }
 
     try {
       req.conversation.lastReceivedBroadcastId = req.broadcastId;
       req.conversation.topic = req.topic.id;
 
-      logger.debug('Updating conversation', {
+      logger.debug('Updating conversation with last broadcast metadata', {
         lastReceivedBroadcastId: req.broadcastId,
         topic: req.topic.id,
       });

--- a/lib/middleware/messages/conversation-get.js
+++ b/lib/middleware/messages/conversation-get.js
@@ -5,10 +5,12 @@ const Conversation = require('../../../app/models/Conversation');
 const helpers = require('../../helpers');
 
 module.exports = function getConversation() {
+  // Looks up the conversation by userId (northstar id) and platform (default: sms)
   return (req, res, next) => Conversation.getFromReq(req)
     .then((conversation) => {
       if (!conversation) {
         logger.debug('Conversation not found', {}, req);
+        // Continue to create one
         return next();
       }
       helpers.request.setConversation(req, conversation);

--- a/lib/middleware/messages/message-outbound-load.js
+++ b/lib/middleware/messages/message-outbound-load.js
@@ -14,7 +14,7 @@ module.exports = function loadOutboundMessage(config) {
     logger.debug('loadOutboundMessage: This request is being retried. Let\'s load the outbound message.', {}, req);
 
     /**
-     * If we are here is because this is a request that is being retried fo X reason,
+     * If we are here it's because this is a request that is being retried for X reason,
      * maybe a transient error or a timeout in Heroku that caused our broker to think
      * this request didn't make it, etc. We are going to search for it and load it if
      * it was successfully created in the previous unsuccessful attempt.
@@ -26,7 +26,7 @@ module.exports = function loadOutboundMessage(config) {
     };
 
     /**
-     * Relying on just on the requestId to determine if the outbound message exists is not so safe.
+     * Relying on just the requestId to determine if the outbound message exists is not so safe.
      * Ideally we would want to implement some hash comparison of the contents of the request
      * instead. The request id just tells us that this request is unique, but we can have two unique
      * requests with the same contents. Specially when it comes to Heroku and how they handle

--- a/lib/middleware/messages/message-outbound-load.js
+++ b/lib/middleware/messages/message-outbound-load.js
@@ -26,7 +26,7 @@ module.exports = function loadOutboundMessage(config) {
     };
 
     /**
-     * Relaying on just on the requestId to determine if the outbound message exists is not so safe.
+     * Relying on just on the requestId to determine if the outbound message exists is not so safe.
      * Ideally we would want to implement some hash comparison of the contents of the request
      * instead. The request id just tells us that this request is unique, but we can have two unique
      * requests with the same contents. Specially when it comes to Heroku and how they handle

--- a/lib/middleware/messages/message-outbound-load.js
+++ b/lib/middleware/messages/message-outbound-load.js
@@ -6,21 +6,39 @@ const Message = require('../../../app/models/Message');
 
 module.exports = function loadOutboundMessage(config) {
   return (req, res, next) => {
-    // If this is not a retry request, we have to create a new outbound message
+    // If this request is not being retried, keep going to create an outbound message.
     if (!req.isARetryRequest()) {
       return next();
     }
+
+    logger.debug('loadOutboundMessage: This request is being retried. Let\'s load the outbound message.', {}, req);
+
+    /**
+     * If we are here is because this is a request that is being retried fo X reason,
+     * maybe a transient error or a timeout in Heroku that caused our broker to think
+     * this request didn't make it, etc. We are going to search for it and load it if
+     * it was successfully created in the previous unsuccessful attempt.
+     */
+
+    // The metadata contains an up to date retry count so we want to update the message with it.
     const update = {
       metadata: req.metadata,
     };
 
-    logger.debug('loadOutboundMessage: Is a retry request. Proceeding with loading message.', {}, req);
-
+    /**
+     * Relaying on just on the requestId to determine if the outbound message exists is not so safe.
+     * Ideally we would want to implement some hash comparison of the contents of the request
+     * instead. The request id just tells us that this request is unique, but we can have two unique
+     * requests with the same contents. Specially when it comes to Heroku and how they handle
+     * timeouts.
+     * TODO: Use a hash of the contents to load an outbound retried request instead of the
+     * request id.
+     */
     return Message.updateMessageByRequestIdAndDirection(req.metadata.requestId, update,
       config.messageDirection)
       .then((message) => {
-        // If there is no loaded message, it means it was not created successfully
-        // so we should attempt to create it in later steps
+        // If the message is null, we did not find it and we need to create it in the
+        // next middleware
         if (!message) {
           logger.debug('loadOutboundMessage: Message not found', {}, req);
           return next();
@@ -32,8 +50,8 @@ module.exports = function loadOutboundMessage(config) {
          * @see https://github.com/DoSomething/gambit-conversations/issues/331
          */
         if (message && message.platformMessageId) {
-          // Exposed for monitoring
-          logger.info('loadOutboundMessage: suppress retried request outbound', {}, req);
+          // Exposed for monitoring -- Update alert if this log changes.
+          logger.info('loadOutboundMessage: Outbound was already sent to member. Suppressing.', {}, req);
           helpers.request.setSuppressOutbound(req);
         }
 

--- a/lib/middleware/messages/message-outbound-validate.js
+++ b/lib/middleware/messages/message-outbound-validate.js
@@ -5,12 +5,15 @@ const UnprocessableEntityError = require('../../../app/exceptions/UnprocessableE
 
 module.exports = function validateOutbound(config) {
   return (req, res, next) => {
+    // TODO: Check against local cache (or unsubscribed blacklist)
+    // once we move to Northstar-less broadcasts
     if (!helpers.user.isSubscriber(req.user)) {
       const error = new UnprocessableEntityError('Northstar User is unsubscribed.');
       // Expose error metadata in NewRelic
       return helpers.errorNoticeable.sendErrorResponseWithNoRetry(res, error);
     }
-
+    // TODO: Check against local cache (or unsubscribed blacklist)
+    // once we move to Northstar-less broadcasts
     if (config.shouldSendWhenPaused === false && helpers.user.isPaused(req.user)) {
       const error = new UnprocessableEntityError('Northstar User conversation is paused.');
       // Expose error metadata in NewRelic
@@ -24,6 +27,8 @@ module.exports = function validateOutbound(config) {
     try {
       /**
        * Verify that User has valid mobile number to send a SMS.
+       * TODO: Use the conversation's platformUserId instead of the user.mobile once we move to
+       * Northstar-less broadcasts
        */
       const mobileNumber = helpers.util.formatMobileNumber(req.user.mobile);
       helpers.request.setPlatformUserId(req, mobileNumber);

--- a/test/helpers/integration/hooks.js
+++ b/test/helpers/integration/hooks.js
@@ -2,6 +2,7 @@
 
 /* eslint-disable no-param-reassign */
 
+const nock = require('nock');
 const mongoose = require('mongoose');
 const supertest = require('supertest');
 
@@ -29,5 +30,8 @@ module.exports = {
     conversations: {
       removeAll: (query = {}) => Conversation.remove(query),
     },
+  },
+  interceptor: {
+    cleanAll: () => nock.cleanAll(),
   },
 };

--- a/test/helpers/integration/routes.js
+++ b/test/helpers/integration/routes.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const nock = require('nock');
 const querystring = require('querystring');
 
 const northstarConfig = require('../../../config/lib/northstar');
@@ -34,8 +35,36 @@ module.exports = {
   },
   northstar: {
     baseURI: northstarConfig.clientOptions.baseURI,
+    intercept: {
+      fetchUserById: (id, reply = {}, times = 1, status = 200) =>
+        nock(module.exports.northstar.baseURI)
+          .get(`/users/id/${id}`)
+          .times(times)
+          .reply(status, reply),
+      fetchUserByEmail: (email, reply = {}, times = 1, status = 200) =>
+        nock(module.exports.northstar.baseURI)
+          .get(`/users/email/${email}`)
+          .times(times)
+          .reply(status, reply),
+      fetchUserByMobile: (mobile, reply = {}, times = 1, status = 200) =>
+        nock(module.exports.northstar.baseURI)
+          .get(`/users/mobile/${mobile}`)
+          .times(times)
+          .reply(status, reply),
+      updateUserById: (id, reply = {}, times = 1, status = 200) =>
+        nock(module.exports.northstar.baseURI)
+          .put(`/users/_id/${id}`)
+          .times(times)
+          .reply(status, reply),
+    },
   },
   graphql: {
     baseURI: graphqlConfig.clientOptions.baseURI,
+    intercept: function intercept(reply = {}, times = 1, status = 200) {
+      return nock(this.baseURI)
+        .post('/graphql')
+        .times(times)
+        .reply(status, reply);
+    },
   },
 };

--- a/test/helpers/stubs.js
+++ b/test/helpers/stubs.js
@@ -73,27 +73,51 @@ module.exports = {
     },
   },
   graphql: {
-    getBroadcastSingleResponse: () => ({
-      data: {
-        broadcast: {
-          id: '429qioxAt2swYoMQUUymYW',
-          name: 'VoterRegistration2018_Sept24_NVRD_Staff_Test',
-          contentType: 'autoReplyBroadcast',
-          createdAt: '2018-09-24T16:29:02.299Z',
-          updatedAt: '2018-09-24T20:55:31.249Z',
-          text: "It's Tej! Happy National Voter Registration Day! Did you know 1 in 8 registrations are invalid? Don't miss out & register now. <Link>",
-          attachments: [],
-          topic: {
-            id: '6DPUt3MrTymOo4yWgUWYqk',
-            name: 'NVRD autoReply',
-            type: 'autoReply',
-            createdAt: '2018-09-24T16:30:58.210Z',
-            updatedAt: '2018-09-24T20:54:45.601Z',
-            campaign: {},
-          },
-        },
-      },
-    }),
+    getBroadcastSingleResponse: (contentType = 'autoReplyBroadcast') => {
+      const broadcast = { data: {} };
+      switch (contentType) {
+        case 'textPostBroadcast':
+          broadcast.data = {
+            broadcast: {
+              id: '1vPr1KhgVP0j8j2ZAWrKXF',
+              name: 'Prom2019_Mar25_New_FINAL',
+              contentType: 'textPostBroadcast',
+              text: 'It’s Freddie! Have a story of unfair practices at prom (like not allowing same-sex or interracial couples)? Text it back now & enter to win a scholarship!',
+              attachments: [],
+              action: {
+                id: 836,
+                name: 'default',
+                campaignId: 9004,
+                postType: 'text',
+              },
+              topic: {
+                id: '3XMMXwm4ZGXG4XDlVso68T',
+                campaign: {
+                  id: 9004,
+                  endDate: null,
+                  internalTitle: 'Mapping Prom Injustices 2019-03',
+                },
+              },
+            },
+          };
+          break;
+        default:
+          broadcast.data = {
+            broadcast: {
+              id: '429qioxAt2swYoMQUUymYW',
+              name: 'VoterRegistration2018_Sept24_NVRD_Staff_Test',
+              contentType: 'autoReplyBroadcast',
+              text: "It's Tej! Happy National Voter Registration Day! Did you know 1 in 8 registrations are invalid? Don't miss out & register now. <Link>",
+              attachments: [],
+              topic: {
+                id: '6DPUt3MrTymOo4yWgUWYqk',
+              },
+            },
+          };
+          break;
+      }
+      return broadcast;
+    },
     fetchConversationTriggers: () => ({
       data: {
         conversationTriggers: [{
@@ -136,10 +160,10 @@ module.exports = {
     };
   },
   broadcast: {
-    getCioWebhookPayload() {
+    getCioWebhookPayload(broadcastId) {
       return {
         userId: module.exports.getUserId(),
-        broadcastId: module.exports.getBroadcastId(),
+        broadcastId: broadcastId || module.exports.getBroadcastId(),
       };
     },
   },

--- a/test/helpers/stubs.js
+++ b/test/helpers/stubs.js
@@ -76,6 +76,57 @@ module.exports = {
     getBroadcastSingleResponse: (contentType = 'autoReplyBroadcast') => {
       const broadcast = { data: {} };
       switch (contentType) {
+        case 'askYesNo':
+          broadcast.data = {
+            broadcast: {
+              id: '4ml3uv0uuL6zsbYCzgt3P2',
+              name: 'MeritOverMoney2019_Apr2_Pending_FINAL',
+              contentType: 'askYesNo',
+              text: 'Hi it\'s Tej! I\'ll be taking over for Freddie! Before we get to know each other, wanna take your first action with me? Y or N',
+              attachments: [],
+              action: {
+                id: 859,
+                name: 'Merit Over Money Petition Action',
+                campaignId: 9013,
+                postType: 'text',
+              },
+              saidYesTopic: {
+                id: '4VYcFMPC5z6BR1xX9geVfj',
+                actionId: 859,
+                campaign: {
+                  id: 9013,
+                  endDate: null,
+                  internalTitle: 'Merit Over Money 2019-04',
+                },
+              },
+            },
+          };
+          break;
+        case 'photoPostBroadcast':
+          broadcast.data = {
+            broadcast: {
+              id: '5t2fmKd2iQgaCCy8Kgg0CI',
+              name: 'Test photoPostBroadcast - Mirror messages',
+              contentType: 'photoPostBroadcast',
+              text: 'Have you posted an inspirational quote lately? Text START to share your photo.',
+              attachments: [],
+              action: {
+                id: 501,
+                name: 'default',
+                campaignId: 7,
+                postType: 'photo',
+              },
+              topic: {
+                id: '6swLaA7HKE8AGI6iQuWk4y',
+                campaign: {
+                  id: 7,
+                  endDate: null,
+                  internalTitle: 'Mirror Messages Run 11',
+                },
+              },
+            },
+          };
+          break;
         case 'textPostBroadcast':
           broadcast.data = {
             broadcast: {

--- a/test/integration/app/v2-routes/messages/broadcast.test.js
+++ b/test/integration/app/v2-routes/messages/broadcast.test.js
@@ -6,6 +6,13 @@ const chai = require('chai');
 const integrationHelper = require('../../../../helpers/integration');
 const stubs = require('../../../../helpers/stubs');
 
+/**
+ * We are using Twilio Test credentials in Wercker.
+ * When this runs on wercker we are indeed making a call to the Twilio API.
+ * But we do it with the Test credentials so its free and we are not actually
+ * sending the text.
+ */
+
 chai.should();
 
 test.before(async () => {
@@ -111,12 +118,6 @@ test('POST /api/v2/messages?origin=broadcast should return 200 if broadcast is s
   integrationHelper.routes.northstar
     .intercept.fetchUserById(cioWebhookPayload.userId, reply, 1);
 
-  /**
-   * We are using Twilio Test credentials in Wercker.
-   * When this runs on wercker we are indeed making a call to the Twilio API.
-   * But we do it with the Test credentials so its free and we are not actually
-   * sending the text.
-   */
   const res = await t.context.request
     .post(integrationHelper.routes.v2.messages(false, {
       origin: 'broadcast',
@@ -144,12 +145,6 @@ test('POST /api/v2/messages?origin=broadcast should save campaign id in outbound
   integrationHelper.routes.northstar
     .intercept.fetchUserById(cioWebhookPayload.userId, reply, 1);
 
-  /**
-   * We are using Twilio Test credentials in Wercker.
-   * When this runs on wercker we are indeed making a call to the Twilio API.
-   * But we do it with the Test credentials so its free and we are not actually
-   * sending the text.
-   */
   const res = await t.context.request
     .post(integrationHelper.routes.v2.messages(false, {
       origin: 'broadcast',
@@ -162,7 +157,6 @@ test('POST /api/v2/messages?origin=broadcast should save campaign id in outbound
   res.body.data.messages[0].metadata.campaignId.should.equal(textPostBroadcast.action.campaignId);
 
   // clear cache
-  // TODO: DRY
   integrationHelper.hooks.cache.broadcasts.set(textPostBroadcast.id, null);
 });
 
@@ -182,12 +176,6 @@ test('POST /api/v2/messages?origin=broadcast should save campaign id in outbound
   integrationHelper.routes.northstar
     .intercept.fetchUserById(cioWebhookPayload.userId, reply, 1);
 
-  /**
-   * We are using Twilio Test credentials in Wercker.
-   * When this runs on wercker we are indeed making a call to the Twilio API.
-   * But we do it with the Test credentials so its free and we are not actually
-   * sending the text.
-   */
   const res = await t.context.request
     .post(integrationHelper.routes.v2.messages(false, {
       origin: 'broadcast',
@@ -200,7 +188,6 @@ test('POST /api/v2/messages?origin=broadcast should save campaign id in outbound
   res.body.data.messages[0].metadata.campaignId.should.equal(photoPostBroadcast.action.campaignId);
 
   // clear cache
-  // TODO: DRY
   integrationHelper.hooks.cache.broadcasts.set(photoPostBroadcast.id, null);
 });
 
@@ -220,12 +207,6 @@ test('POST /api/v2/messages?origin=broadcast should save campaign id in outbound
   integrationHelper.routes.northstar
     .intercept.fetchUserById(cioWebhookPayload.userId, reply, 1);
 
-  /**
-   * We are using Twilio Test credentials in Wercker.
-   * When this runs on wercker we are indeed making a call to the Twilio API.
-   * But we do it with the Test credentials so its free and we are not actually
-   * sending the text.
-   */
   const res = await t.context.request
     .post(integrationHelper.routes.v2.messages(false, {
       origin: 'broadcast',

--- a/test/integration/app/v2-routes/messages/member.test.js
+++ b/test/integration/app/v2-routes/messages/member.test.js
@@ -1,0 +1,106 @@
+'use strict';
+
+const test = require('ava');
+const chai = require('chai');
+
+const integrationHelper = require('../../../../helpers/integration');
+const stubs = require('../../../../helpers/stubs');
+const metadataParserConfig = require('../../../../../config/lib/middleware/metadata-parse');
+
+chai.should();
+
+test.before(async () => {
+  await integrationHelper.hooks.db.connect();
+});
+
+test.beforeEach((t) => {
+  integrationHelper.hooks.cache.broadcasts.set(
+    stubs.getBroadcastId(),
+    stubs.graphql.getBroadcastSingleResponse().data.broadcast,
+  );
+  integrationHelper.hooks.app(t.context);
+});
+
+test.afterEach(async () => {
+  integrationHelper.hooks.interceptor.cleanAll();
+  integrationHelper.hooks.cache.broadcasts.set(stubs.getBroadcastId(), null);
+  await integrationHelper.hooks.db.messages.removeAll();
+  await integrationHelper.hooks.db.conversations.removeAll();
+});
+
+test.after.always(async () => {
+  await integrationHelper.hooks.db.disconnect();
+});
+
+/**
+ * GET /
+ */
+test('GET /api/v2/messages should return 401 if not using valid credentials', async (t) => {
+  const res = await t.context.request.get(integrationHelper.routes.v2.messages());
+  res.status.should.be.equal(401);
+});
+
+test('GET /api/v2/messages should return 404', async (t) => {
+  const res = await t.context.request.get(integrationHelper.routes.v2.messages())
+    .set('Authorization', `Basic ${integrationHelper.getAuthKey()}`);
+  res.status.should.be.equal(404);
+});
+
+test.serial('POST /api/v2/messages?origin=twilio should not re-send message to Twilio on retry', async (t) => {
+  const member = stubs.northstar.getUser({ validUsNumber: true });
+  const inboundRequestPayload = stubs.twilio.getInboundRequestBody(member);
+  const requestId = stubs.getRequestId();
+
+  integrationHelper.routes.graphql
+    .intercept(stubs.graphql.fetchConversationTriggers(), 2);
+
+  // mock user fetch twice
+  integrationHelper.routes.northstar
+    .intercept.fetchUserByMobile(inboundRequestPayload.From, member, 2);
+
+  // mock user update twice
+  integrationHelper.routes.northstar
+    .intercept.updateUserById(member.data.id, member, 2);
+
+  /**
+   * 1st attempt
+   */
+  const res1 = await t.context.request
+    .post(integrationHelper.routes.v2.messages(false, {
+      origin: 'twilio',
+    }))
+    .set({
+      Authorization: `Basic ${integrationHelper.getAuthKey()}`,
+      [metadataParserConfig.metadata.headers.requestId]: requestId,
+    })
+    .send(inboundRequestPayload);
+
+  res1.status.should.be.equal(200);
+  res1.body.data.messages.inbound.length.should.be.equal(1);
+  res1.body.data.messages.outbound.length.should.be.equal(1);
+
+  const outboundMessage1 = res1.body.data.messages.outbound[0];
+
+  /**
+   * 2nd attempt (retry)
+   */
+  const res2 = await t.context.request
+    .post(integrationHelper.routes.v2.messages(false, {
+      origin: 'twilio',
+    }))
+    .set({
+      Authorization: `Basic ${integrationHelper.getAuthKey()}`,
+      [metadataParserConfig.metadata.headers.requestId]: requestId,
+      [metadataParserConfig.metadata.headers.retryCount]: '1',
+    })
+    .send(inboundRequestPayload);
+
+  res2.status.should.be.equal(200);
+  res2.body.data.messages.inbound.length.should.be.equal(1);
+  res2.body.data.messages.outbound.length.should.be.equal(1);
+
+  const outboundMessage2 = res2.body.data.messages.outbound[0];
+
+  // The retry should not have replaced the platformUserId of the message
+  outboundMessage1.platformMessageId.should.be.equal(outboundMessage2.platformMessageId);
+});


### PR DESCRIPTION
#### What's this PR do?
- It saves the campaign id associated with the broadcast generating the outbound message.

#### How should this be reviewed?
- 👀 
- all tests should pass

#### Any background context you want to provide?
- This campaign id will help the data team associate the amount of outbound messages per campaign.

#### Relevant tickets
Fixes Pivotal [Card#164076750](https://www.pivotaltracker.com/story/show/164076750)

#### Checklist
- [ ] Update monitoring and alerts if logs have changed.
- [ ] Documentation added for new features/changed endpoints.
- [x] Tests added/updated for new features/bug fixes.
- [ ] ENV variables added/updated for new features/bug fixes.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
