### PR TITLE
log rate limit key

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -35,6 +35,13 @@ module.exports.sendErrorResponseWithNoRetry = function (res, err) {
   return exports.sendErrorResponse(res, err, false);
 };
 
+/**
+ * Sends a 429 status response.
+ * Adds rate limiting response headers.
+ * Sends No Retry headers.
+ * @param {Response} res
+ * @param {RateLimiterRes} rateLimiterRes
+ */
 module.exports.sendRateLimitedResponse = function (res, rateLimiterRes = {}) {
   const error = new RateLimitedError();
   const resHeaders = {

--- a/lib/middleware/messages/member/rate-limiter.js
+++ b/lib/middleware/messages/member/rate-limiter.js
@@ -25,8 +25,14 @@ module.exports = function getMembersRateLimiter() {
       // Otherwise, response headers will not contain correct values.
       // @see https://github.com/animir/node-rate-limiter-flexible/wiki/API-methods#ratelimiterconsumekey-points--1
       .catch((rateLimiterRes) => {
+        const loggedAttributes = {
+          rateLimiterRes,
+          rateLimitKey: req.platformUserId,
+        };
         // Exposed as info for monitoring
-        logger.info('member route Rate Limiter (Limit reached)', rateLimiterRes, req);
+        logger.info('member route Rate Limiter (Limit reached)', loggedAttributes, req);
+        // Logged so we can actually search for the rate limited member
+        helpers.analytics.addCustomAttributes(loggedAttributes);
         // @see https://github.com/animir/node-rate-limiter-flexible#ratelimiterres-object
         return helpers.errorNoticeable
           .sendRateLimitedResponse(res, rateLimiterRes);


### PR DESCRIPTION
#### What's this PR do?
Logs key (`platformUserId`) being rate limited.

#### How should this be reviewed?
- 👀 

#### Any background context you want to provide?
We can detect rate limited requests but can't attribute them to an specific member without this info.
