### PR TITLE
Updates GraphQL queries [pr]

### DIFF
--- a/config/lib/graphql.js
+++ b/config/lib/graphql.js
@@ -214,9 +214,6 @@ const fetchTopicById = `
         ...autoReplyCampaign
         autoReply
       }
-      ... on AutoReplyTopic {
-        autoReply
-      }
       ... on PhotoPostTopic {
         ...photoPostCampaign
         askCaption

--- a/config/lib/graphql.js
+++ b/config/lib/graphql.js
@@ -122,27 +122,29 @@ const fetchBroadcastById = `
     }
   }
   ${campaignTopicFragments}
+  ${campaignTopicTransitionFragments}
 `;
 
 const fetchConversationTriggers = `
   query getConversationTriggers {
     conversationTriggers {
       trigger
-      reply
-      topic {
+      response {
+        contentType
         id
-        ... on AutoReplyTopic {
-          ${campaignFields}
+        ... on AskMultipleChoiceBroadcastTopic {
+          id
+          text
         }
-        ... on PhotoPostTopic {
-          ${campaignFields}
+        ... on FaqAnswerTopic {
+          text
         }
-        ... on TextPostTopic {
-          ${campaignFields}
-        }
+        ${campaignTransitionTypes}
       }
     }
   }
+  ${campaignTopicFragments}
+  ${campaignTopicTransitionFragments}
 `;
 
 const fetchTopicById = `

--- a/config/lib/graphql.js
+++ b/config/lib/graphql.js
@@ -106,6 +106,11 @@ const fetchBroadcastById = `
       }
       contentType
       ... on AskVotingPlanStatusBroadcastTopic {
+        # need to ask for saidVotedTransition so we can receive action info
+        # since it depends on it's topic!
+        saidVotedTransition {
+          ${campaignTransitionTypes}
+        }
         ${actionFields}
       }
       ... on AskYesNoBroadcastTopic {

--- a/config/lib/graphql.js
+++ b/config/lib/graphql.js
@@ -203,12 +203,12 @@ const fetchTopicById = `
       }
       ... on AskYesNoBroadcastTopic {
         invalidAskYesNoResponse
-        saidNo
-        saidNoTopic {
-          id
+        saidNoTransition {
+          ${campaignTransitionTypes}
         }
-        saidYes
-        ${saidYesTopicFields}
+        saidYesTransition {
+          ${campaignTransitionTypes}
+        }
       }
       ... on AutoReplyTopic {
         ...autoReplyCampaign

--- a/config/lib/graphql.js
+++ b/config/lib/graphql.js
@@ -94,7 +94,7 @@ const fetchBroadcastById = `
       contentType
       ... on AskVotingPlanStatusBroadcastTopic {
         # need to ask for saidVotedTransition so we can receive action info
-        # since it depends on it's topic!
+        # since it depends on its topic!
         saidVotedTransition {
           ${campaignTransitionTypes}
         }

--- a/config/lib/graphql.js
+++ b/config/lib/graphql.js
@@ -40,6 +40,7 @@ const campaignTopicTransitionFragments = `
     ${campaignTransitionFields}
     topic {
       id
+      contentType
       ...autoReplyCampaign
     }
   }
@@ -47,6 +48,7 @@ const campaignTopicTransitionFragments = `
     ${campaignTransitionFields}
     topic {
       id
+      contentType
       ...photoPostCampaign
     }
   }
@@ -54,6 +56,7 @@ const campaignTopicTransitionFragments = `
     ${campaignTransitionFields}
     topic {
       id
+      contentType
       ...textPostCampaign
     }
   }

--- a/config/lib/graphql.js
+++ b/config/lib/graphql.js
@@ -18,12 +18,6 @@ const campaignTopicFields = `
   }
 `;
 
-const campaignTopicTypes = `
-  ...autoReplyCampaign
-  ...photoPostCampaign
-  ...textPostCampaign
-`;
-
 const campaignTransitionTypes = `
   ...autoReplyCampaignTransition
   ...photoPostCampaignTransition
@@ -76,13 +70,6 @@ const campaignTopicFragments = `
   }
 `;
 
-const saidYesTopicFields = `
-  saidYesTopic {
-    id
-    ${campaignTopicTypes}
-  }
-`;
-
 const actionFields = `
   action {
     id
@@ -114,7 +101,9 @@ const fetchBroadcastById = `
         ${actionFields}
       }
       ... on AskYesNoBroadcastTopic {
-        ${saidYesTopicFields}
+        saidYesTransition {
+          ${campaignTransitionTypes}
+        }
         ${actionFields}
       }
       ... on AutoReplyBroadcast {

--- a/config/lib/graphql.js
+++ b/config/lib/graphql.js
@@ -1,6 +1,9 @@
 'use strict';
 
 const campaignFields = `
+  legacyCampaign {
+    campaignId
+  }
   campaign {
     id
     endDate
@@ -16,13 +19,48 @@ const campaignTopicFields = `
 `;
 
 const campaignTopicTypes = `
-  ...autoReplySignupCampaign
+  ...autoReplyCampaign
   ...photoPostCampaign
   ...textPostCampaign
 `;
 
+const campaignTransitionTypes = `
+  ...autoReplyCampaignTransition
+  ...photoPostCampaignTransition
+  ...textPostCampaignTransition
+`;
+
+const campaignTransitionFields = `
+  id
+  text
+`;
+
+const campaignTopicTransitionFragments = `
+  fragment autoReplyCampaignTransition on AutoReplyTransition {
+    ${campaignTransitionFields}
+    topic {
+      id
+      ...autoReplyCampaign
+    }
+  }
+  fragment photoPostCampaignTransition on PhotoPostTransition {
+    ${campaignTransitionFields}
+    topic {
+      id
+      ...photoPostCampaign
+    }
+  }
+  fragment textPostCampaignTransition on TextPostTransition {
+    ${campaignTransitionFields}
+    topic {
+      id
+      ...textPostCampaign
+    }
+  }
+`;
+
 const campaignTopicFragments = `
-  fragment autoReplySignupCampaign on AutoReplySignupTopic {
+  fragment autoReplyCampaign on AutoReplyTopic {
     ${campaignFields}
   }
   fragment photoPostCampaign on PhotoPostTopic {
@@ -96,7 +134,7 @@ const fetchConversationTriggers = `
       reply
       topic {
         id
-        ... on AutoReplySignupTopic {
+        ... on AutoReplyTopic {
           ${campaignFields}
         }
         ... on PhotoPostTopic {
@@ -117,30 +155,20 @@ const fetchTopicById = `
       contentType
       ... on AskMultipleChoiceBroadcastTopic {
         invalidAskMultipleChoiceResponse
-        saidFirstChoice
-        saidFirstChoiceTopic {
-          id
-          ${campaignTopicTypes}
+        saidFirstChoiceTransition {
+          ${campaignTransitionTypes}
         }
-        saidSecondChoice
-        saidSecondChoiceTopic {
-          id
-          ${campaignTopicTypes}
+        saidSecondChoiceTransition {
+          ${campaignTransitionTypes}
         }
-        saidThirdChoice
-        saidThirdChoiceTopic {
-          id
-          ${campaignTopicTypes}
+        saidThirdChoiceTransition {
+          ${campaignTransitionTypes}
         }
-        saidFourthChoice
-        saidFourthChoiceTopic {
-          id
-          ${campaignTopicTypes}
+        saidFourthChoiceTransition {
+          ${campaignTransitionTypes}
         }
-        saidFifthChoice
-        saidFifthChoiceTopic {
-          id
-          ${campaignTopicTypes}
+        saidFifthChoiceTransition {
+          ${campaignTransitionTypes}
         }
       }
       ... on AskSubscriptionStatusBroadcastTopic {
@@ -178,8 +206,8 @@ const fetchTopicById = `
         saidYes
         ${saidYesTopicFields}
       }
-      ... on AutoReplySignupTopic {
-        ...autoReplySignupCampaign
+      ... on AutoReplyTopic {
+        ...autoReplyCampaign
         autoReply
       }
       ... on AutoReplyTopic {
@@ -207,6 +235,7 @@ const fetchTopicById = `
     }
   }
   ${campaignTopicFragments}
+  ${campaignTopicTransitionFragments}
 `;
 
 const fetchWebSignupConfirmations = `

--- a/config/lib/graphql.js
+++ b/config/lib/graphql.js
@@ -242,12 +242,13 @@ const fetchWebSignupConfirmations = `
         id
         endDate
       }
-      text
       topic {
-        id
+        ${campaignTransitionTypes}
       }
     }
   }
+  ${campaignTopicFragments}
+  ${campaignTopicTransitionFragments}
 `;
 
 module.exports = {

--- a/config/lib/graphql.js
+++ b/config/lib/graphql.js
@@ -191,17 +191,14 @@ const fetchTopicById = `
         }
       }
       ... on AskVotingPlanStatusBroadcastTopic {
-        saidCantVote
-        saidCantVoteTopic {
-          id
+        saidCantVoteTransition {
+          ${campaignTransitionTypes}
         }
-        saidNotVoting
-        saidNotVotingTopic {
-          id
+        saidNotVotingTransition {
+          ${campaignTransitionTypes}
         }
-        saidVoted
-        saidVotedTopic {
-          id
+        saidVotedTransition {
+          ${campaignTransitionTypes}
         }
       }
       ... on AskYesNoBroadcastTopic {

--- a/config/lib/graphql.js
+++ b/config/lib/graphql.js
@@ -177,13 +177,17 @@ const fetchTopicById = `
       ... on AskSubscriptionStatusBroadcastTopic {
         invalidAskSubscriptionStatusResponse
         saidNeedMoreInfo
-        saidActive
-        saidActiveTopic {
-          id
+        saidActiveTransition {
+          text
+          topic {
+            id
+          }
         }
-        saidLess
-        saidLessTopic {
-          id
+        saidLessTransition {
+          text
+          topic {
+            id
+          }
         }
       }
       ... on AskVotingPlanStatusBroadcastTopic {

--- a/config/lib/helpers/rivescript.js
+++ b/config/lib/helpers/rivescript.js
@@ -4,15 +4,6 @@
  * @see @see https://www.rivescript.com/docs/tutorial#the-code-explained
  */
 module.exports = {
-  // Used to determine how to transform defaultTrigger response contentTypes
-  // when fetching from GraphQl
-  response: {
-    types: {
-      askMultipleChoice: {
-        type: 'askMultipleChoice',
-      },
-    },
-  },
   cacheKey: 'contentApi',
   commands: {
     // A continuation is needed if a reply contains line breaks.
@@ -22,6 +13,15 @@ module.exports = {
     redirect: '@',
     reply: '-',
     trigger: '+',
+  },
+  // Used to determine how to transform defaultTrigger response contentTypes
+  // when fetching from GraphQl
+  response: {
+    types: {
+      askMultipleChoice: {
+        type: 'askMultipleChoice',
+      },
+    },
   },
   separators: {
     command: ' ',

--- a/config/lib/helpers/rivescript.js
+++ b/config/lib/helpers/rivescript.js
@@ -4,6 +4,15 @@
  * @see @see https://www.rivescript.com/docs/tutorial#the-code-explained
  */
 module.exports = {
+  // Used to determine how to transform defaultTrigger response contentTypes
+  // when fetching from GraphQl
+  response: {
+    types: {
+      askMultipleChoice: {
+        type: 'askMultipleChoice',
+      },
+    },
+  },
   cacheKey: 'contentApi',
   commands: {
     // A continuation is needed if a reply contains line breaks.

--- a/config/lib/northstar.js
+++ b/config/lib/northstar.js
@@ -4,6 +4,11 @@ module.exports = {
   clientOptions: {
     apiKey: process.env.DS_NORTHSTAR_API_KEY,
     baseURI: process.env.DS_NORTHSTAR_API_BASEURI,
+    // TODO: Use this in the routes integration test helper to intercept calls to get credentials
+    oauth: {
+      host: process.env.DS_NORTHSTAR_API_OAUTH_TOKEN_HOST,
+      path: process.env.DS_NORTHSTAR_API_OAUTH_TOKEN_PATH,
+    },
   },
   getUserFields: {
     id: 'id',

--- a/lib/helpers/broadcast.js
+++ b/lib/helpers/broadcast.js
@@ -8,13 +8,34 @@ const Message = require('../../app/models/Message');
 const config = require('../../config/lib/helpers/broadcast');
 
 /**
+ * Transforms GraphQL response to be compatible with the legacy contract.
+ * @param {Topic} topic
+ */
+const broadcastTransformer = (topic) => {
+  let transformedBroadcast = topic;
+  if (module.exports.isAskVotingPlanStatus(topic)) {
+    transformedBroadcast = {
+      ...topic,
+      saidVotedTopic: topic.saidVotedTransition.topic,
+    };
+  }
+  if (module.exports.isAskYesNo(topic)) {
+    transformedBroadcast = {
+      ...topic,
+      saidYesTopic: topic.saidYesTransition.topic,
+    };
+  }
+  return transformedBroadcast;
+};
+
+/**
  * @param {String} id
  * @return {Promise}
  */
 async function fetchById(id) {
   logger.debug('Fetching broadcast', { id });
 
-  const broadcast = await graphql.fetchBroadcastById(id);
+  const broadcast = broadcastTransformer(await graphql.fetchBroadcastById(id));
   // TODO: Refactor codebase to check for the topic GraphQL __typename, not the Contentful type name
   Object.assign(broadcast, { type: broadcast.contentType });
 
@@ -51,6 +72,14 @@ function isAskSubscriptionStatus(broadcast) {
  */
 function isAskYesNo(broadcast) {
   return broadcast.contentType === config.types.askYesNo;
+}
+
+/**
+ * @param {Object} broadcast
+ * @return {Boolean}
+ */
+function isAskVotingPlanStatus(broadcast) {
+  return broadcast.contentType === config.types.askVotingPlanStatus;
 }
 
 /**
@@ -136,6 +165,7 @@ module.exports = {
   getById,
   isAskSubscriptionStatus,
   isAskYesNo,
+  isAskVotingPlanStatus,
   isLegacyBroadcast,
   /**
    * @param {boolean} useApiVersion2

--- a/lib/helpers/broadcast.js
+++ b/lib/helpers/broadcast.js
@@ -12,7 +12,11 @@ const config = require('../../config/lib/helpers/broadcast');
  * @param {Topic} topic
  */
 const broadcastTransformer = (topic) => {
+  // TODO: Refactor codebase to check for the topic GraphQL __typename, not the Contentful type name
+  topic.type = topic.contentType; // eslint-disable-line
+
   let transformedBroadcast = topic;
+
   if (module.exports.isAskVotingPlanStatus(topic)) {
     transformedBroadcast = {
       ...topic,
@@ -36,8 +40,6 @@ async function fetchById(id) {
   logger.debug('Fetching broadcast', { id });
 
   const broadcast = broadcastTransformer(await graphql.fetchBroadcastById(id));
-  // TODO: Refactor codebase to check for the topic GraphQL __typename, not the Contentful type name
-  Object.assign(broadcast, { type: broadcast.contentType });
 
   return helpers.cache.broadcasts.set(id, broadcast);
 }

--- a/lib/helpers/campaign.js
+++ b/lib/helpers/campaign.js
@@ -2,7 +2,6 @@
 
 const dateFns = require('date-fns');
 
-
 const graphql = require('../graphql');
 const logger = require('../logger');
 const cache = require('./cache').webSignupConfirmations;

--- a/lib/helpers/campaign.js
+++ b/lib/helpers/campaign.js
@@ -41,7 +41,7 @@ async function fetchWebSignupConfirmations() {
     const webSignupConfirmations = await graphql.fetchWebSignupConfirmations();
     logger.debug('fetchWebSignupConfirmations success', { count: webSignupConfirmations.length });
     const transformedWebSignupConfirmations = webSignupConfirmations
-      .map(webSignupConfirmationTransformer);
+      .map(module.exports.webSignupConfirmationTransformer);
     return cache.set(transformedWebSignupConfirmations);
   } catch (error) {
     throw error;
@@ -90,4 +90,5 @@ module.exports = {
   getWebSignupConfirmationByCampaignId,
   getWebSignupConfirmations,
   isClosedCampaign,
+  webSignupConfirmationTransformer,
 };

--- a/lib/helpers/campaign.js
+++ b/lib/helpers/campaign.js
@@ -1,9 +1,35 @@
 'use strict';
 
 const dateFns = require('date-fns');
+
+
 const graphql = require('../graphql');
 const logger = require('../logger');
 const cache = require('./cache').webSignupConfirmations;
+
+/**
+ * Transforms GraphQL response to be compatible with the legacy contract.
+ * @param {Topic} confirmation
+ */
+function webSignupConfirmationTransformer(confirmation) {
+  const transformedConfirmation = {};
+  /**
+   * TODO: topic should be renamed to transition in GraphQL
+   * to avoid the confusing topic.topic property
+   */
+  const transition = confirmation.topic;
+
+  transformedConfirmation.text = null;
+  // Campaign info injected using the Rogue schema in GraphQL
+  transformedConfirmation.campaign = confirmation.campaign;
+
+  if (transition) {
+    transformedConfirmation.text = transition.text;
+    transformedConfirmation.topic = transition.topic;
+  }
+
+  return transformedConfirmation;
+}
 
 /**
  * Fetches all WebSignupConfirmations from GraphQL and caches the result.
@@ -12,8 +38,11 @@ const cache = require('./cache').webSignupConfirmations;
  */
 async function fetchWebSignupConfirmations() {
   try {
-    const res = await graphql.fetchWebSignupConfirmations();
-    return cache.set(res);
+    const webSignupConfirmations = await graphql.fetchWebSignupConfirmations();
+    logger.debug('fetchWebSignupConfirmations success', { count: webSignupConfirmations.length });
+    const transformedWebSignupConfirmations = webSignupConfirmations
+      .map(webSignupConfirmationTransformer);
+    return cache.set(transformedWebSignupConfirmations);
   } catch (error) {
     throw error;
   }

--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const underscore = require('underscore');
+const lodash = require('lodash');
 const helpers = require('../helpers');
 const logger = require('../logger');
 const graphql = require('../graphql');
@@ -58,7 +59,7 @@ async function getRivescripts(resetCache = false) {
  * @param {Topic} trigger
  */
 const defaultTopicTriggerTransformer = (trigger) => {
-  const transformedTrigger = trigger;
+  const transformedTrigger = lodash.cloneDeep(trigger);
   const response = trigger.response || {};
 
   transformedTrigger.type = response.contentType;

--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -55,7 +55,7 @@ async function getRivescripts(resetCache = false) {
 
 /**
  * Transforms GraphQL response to be compatible with the legacy contract.
- * @param {Topic} topic
+ * @param {Topic} trigger
  */
 const defaultTopicTriggerTransformer = (trigger) => {
   const transformedTrigger = trigger;

--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -54,14 +54,51 @@ async function getRivescripts(resetCache = false) {
 }
 
 /**
+ * Transforms GraphQL response to be compatible with the legacy contract.
+ * @param {Topic} topic
+ */
+const defaultTopicTriggerTransformer = (trigger) => {
+  const transformedTrigger = trigger;
+  const response = trigger.response || {};
+
+  transformedTrigger.type = response.contentType;
+  transformedTrigger.reply = response.text;
+  /**
+   * We check for the especial case of isAskMultipleChoice because we switch the member
+   * to the actual broadcast id instead of a "topic". Once they respond, we will inspect one of the
+   * possible answer's topic to switch the member to.
+   */
+  if (module.exports.isAskMultipleChoice(trigger)) {
+    transformedTrigger.topic = {
+      id: response.id,
+      contentType: response.contentType,
+    };
+  // photoPostConfig, textPostConfig, and autoReply topics are returned from GraphQL
+  // in the case of faqAnswer the topic is not returned it will be assigned null here
+  } else {
+    transformedTrigger.topic = response.topic || null;
+  }
+  return transformedTrigger;
+};
+
+/**
+ * @param {Object} trigger
+ * @return {Boolean}
+ */
+function isAskMultipleChoice(trigger) {
+  return trigger.type === config.response.types.askMultipleChoice.type;
+}
+
+/**
  * @return {Promise}
  */
 async function fetchRivescripts() {
   const conversationTriggers = await graphql.fetchConversationTriggers();
   logger.debug('fetchConversationTriggers success', { count: conversationTriggers.length });
+  const transformedTriggers = conversationTriggers.map(defaultTopicTriggerTransformer);
 
   return helpers.cache.rivescript
-    .set(cacheKey, conversationTriggers.map(module.exports.parseRivescript));
+    .set(cacheKey, transformedTriggers.map(module.exports.parseRivescript));
 }
 
 /**
@@ -299,6 +336,7 @@ module.exports = {
   getBotReply,
   getDeparsedRivescript,
   getRivescripts,
+  isAskMultipleChoice,
   isBotReady,
   isRivescriptCurrent,
   joinRivescriptLines,

--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -96,7 +96,8 @@ function isAskMultipleChoice(trigger) {
 async function fetchRivescripts() {
   const conversationTriggers = await graphql.fetchConversationTriggers();
   logger.debug('fetchConversationTriggers success', { count: conversationTriggers.length });
-  const transformedTriggers = conversationTriggers.map(defaultTopicTriggerTransformer);
+  const transformedTriggers = conversationTriggers
+    .map(module.exports.defaultTopicTriggerTransformer);
 
   return helpers.cache.rivescript
     .set(cacheKey, transformedTriggers.map(module.exports.parseRivescript));
@@ -330,6 +331,7 @@ function parseAskYesNoResponse(messageText) {
 module.exports = {
   appendEscapedLinebreak,
   appendTopicTag,
+  defaultTopicTriggerTransformer,
   fetchRivescripts,
   formatReplyRivescript,
   formatRivescriptLine,

--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -64,7 +64,7 @@ const defaultTopicTriggerTransformer = (trigger) => {
   transformedTrigger.type = response.contentType;
   transformedTrigger.reply = response.text;
   /**
-   * We check for the especial case of isAskMultipleChoice because we switch the member
+   * We check for the special case of isAskMultipleChoice because we switch the member
    * to the actual broadcast id instead of a "topic". Once they respond, we will inspect one of the
    * possible answer's topic to switch the member to.
    */

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -9,13 +9,43 @@ const repliesConfig = require('../../config/lib/helpers/replies');
 const templateConfig = require('../../config/lib/helpers/template');
 
 /**
+ * Transforms GraphQL response to be compatible with the legacy contract.
+ * @param {Topic} topic
+ */
+const topicTransformer = (topic) => {
+  let transformedTopic = topic;
+
+  if (module.exports.isAskMultipleChoice(topic)) {
+    transformedTopic = {
+      ...topic,
+      saidFirstChoice: topic.saidFirstChoiceTransition.text,
+      saidFirstChoiceTopic: topic.saidFirstChoiceTransition.topic,
+      saidSecondChoice: topic.saidSecondChoiceTransition.text,
+      saidSecondChoiceTopic: topic.saidSecondChoiceTransition.topic,
+      saidThirdChoice: topic.saidThirdChoiceTransition.text,
+      saidThirdChoiceTopic: topic.saidThirdChoiceTransition.topic,
+      // Optional
+      saidFourthChoice: topic.saidFourthChoiceTransition ?
+        topic.saidFourthChoiceTransition.text : null,
+      saidFourthChoiceTopic: topic.saidFourthChoiceTransition ?
+        topic.saidFourthChoiceTransition.topic : null,
+      saidFifthChoice: topic.saidFifthChoiceTransition ?
+        topic.saidFifthChoiceTransition.text : null,
+      saidFifthChoiceTopic: topic.saidFifthChoiceTransition ?
+        topic.saidFifthChoiceTransition.topic : null,
+    };
+  }
+  return transformedTopic;
+};
+
+/**
  * @param {String} id
  * @return {Promise}
  */
 async function fetchById(id) {
   logger.debug('Fetching topic', { id });
 
-  const topic = await graphql.fetchTopicById(id);
+  const topic = topicTransformer(await graphql.fetchTopicById(id));
 
   // TODO: Refactor codebase to check for the topic GraphQL __typename, not the Contentful type name
   Object.assign(topic, { type: topic.contentType });

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -55,6 +55,15 @@ const topicTransformer = (topic) => {
       saidVotedTopic: topic.saidVotedTransition.topic,
     };
   }
+  if (module.exports.isAskYesNo(topic)) {
+    transformedTopic = {
+      ...topic,
+      saidNo: topic.saidNoTransition.text,
+      saidNoTopic: topic.saidNoTransition.topic,
+      saidYes: topic.saidYesTransition.text,
+      saidYesTopic: topic.saidYesTransition.topic,
+    };
+  }
   return transformedTopic;
 };
 

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -7,12 +7,14 @@ const config = require('../../config/lib/helpers/topic');
 const repliesConfig = require('../../config/lib/helpers/replies');
 // TODO: Move templateConfig into repliesConfig.
 const templateConfig = require('../../config/lib/helpers/template');
-
 /**
  * Transforms GraphQL response to be compatible with the legacy contract.
  * @param {Topic} topic
  */
 const topicTransformer = (topic) => {
+  // TODO: Refactor codebase to check for the topic GraphQL __typename, not the Contentful type name
+  topic.type = topic.contentType; // eslint-disable-line
+
   let transformedTopic = topic;
 
   if (module.exports.isAskMultipleChoice(topic)) {
@@ -75,9 +77,6 @@ async function fetchById(id) {
   logger.debug('Fetching topic', { id });
 
   const topic = topicTransformer(await graphql.fetchTopicById(id));
-
-  // TODO: Refactor codebase to check for the topic GraphQL __typename, not the Contentful type name
-  Object.assign(topic, { type: topic.contentType });
 
   return helpers.cache.topics.set(id, topic);
 }

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const lodash = require('lodash');
+
 const graphql = require('../graphql');
 const helpers = require('../helpers');
 const logger = require('../logger');
@@ -12,59 +14,46 @@ const templateConfig = require('../../config/lib/helpers/template');
  * @param {Topic} topic
  */
 const topicTransformer = (topic) => {
+  const transformedTopic = lodash.cloneDeep(topic);
   // TODO: Refactor codebase to check for the topic GraphQL __typename, not the Contentful type name
-  topic.type = topic.contentType; // eslint-disable-line
-
-  let transformedTopic = topic;
+  transformedTopic.type = transformedTopic.contentType; // eslint-disable-line
 
   if (module.exports.isAskMultipleChoice(topic)) {
-    transformedTopic = {
-      ...topic,
-      saidFirstChoice: topic.saidFirstChoiceTransition.text,
-      saidFirstChoiceTopic: topic.saidFirstChoiceTransition.topic,
-      saidSecondChoice: topic.saidSecondChoiceTransition.text,
-      saidSecondChoiceTopic: topic.saidSecondChoiceTransition.topic,
-      saidThirdChoice: topic.saidThirdChoiceTransition.text,
-      saidThirdChoiceTopic: topic.saidThirdChoiceTransition.topic,
-      // Optional
-      saidFourthChoice: topic.saidFourthChoiceTransition ?
-        topic.saidFourthChoiceTransition.text : null,
-      saidFourthChoiceTopic: topic.saidFourthChoiceTransition ?
-        topic.saidFourthChoiceTransition.topic : null,
-      saidFifthChoice: topic.saidFifthChoiceTransition ?
-        topic.saidFifthChoiceTransition.text : null,
-      saidFifthChoiceTopic: topic.saidFifthChoiceTransition ?
-        topic.saidFifthChoiceTransition.topic : null,
-    };
+    transformedTopic.saidFirstChoice = topic.saidFirstChoiceTransition.text;
+    transformedTopic.saidFirstChoiceTopic = topic.saidFirstChoiceTransition.topic;
+    transformedTopic.saidSecondChoice = topic.saidSecondChoiceTransition.text;
+    transformedTopic.saidSecondChoiceTopic = topic.saidSecondChoiceTransition.topic;
+    transformedTopic.saidThirdChoice = topic.saidThirdChoiceTransition.text;
+    transformedTopic.saidThirdChoiceTopic = topic.saidThirdChoiceTransition.topic;
+    // Optional
+    transformedTopic.saidFourthChoice = topic.saidFourthChoiceTransition ?
+      topic.saidFourthChoiceTransition.text : null;
+    transformedTopic.saidFourthChoiceTopic = topic.saidFourthChoiceTransition ?
+      topic.saidFourthChoiceTransition.topic : null;
+    transformedTopic.saidFifthChoice = topic.saidFifthChoiceTransition ?
+      topic.saidFifthChoiceTransition.text : null;
+    transformedTopic.saidFifthChoiceTopic = topic.saidFifthChoiceTransition ?
+      topic.saidFifthChoiceTransition.topic : null;
   }
   if (module.exports.isAskSubscriptionStatus(topic)) {
-    transformedTopic = {
-      ...topic,
-      saidActive: topic.saidActiveTransition.text,
-      saidActiveTopic: topic.saidActiveTransition.topic,
-      saidLess: topic.saidLessTransition.text,
-      saidLessTopic: topic.saidLessTransition.topic,
-    };
+    transformedTopic.saidActive = topic.saidActiveTransition.text;
+    transformedTopic.saidActiveTopic = topic.saidActiveTransition.topic;
+    transformedTopic.saidLess = topic.saidLessTransition.text;
+    transformedTopic.saidLessTopic = topic.saidLessTransition.topic;
   }
   if (module.exports.isAskVotingPlanStatus(topic)) {
-    transformedTopic = {
-      ...topic,
-      saidCantVote: topic.saidCantVoteTransition.text,
-      saidCantVoteTopic: topic.saidCantVoteTransition.topic,
-      saidNotVoting: topic.saidNotVotingTransition.text,
-      saidNotVotingTopic: topic.saidNotVotingTransition.topic,
-      saidVoted: topic.saidVotedTransition.text,
-      saidVotedTopic: topic.saidVotedTransition.topic,
-    };
+    transformedTopic.saidCantVote = topic.saidCantVoteTransition.text;
+    transformedTopic.saidCantVoteTopic = topic.saidCantVoteTransition.topic;
+    transformedTopic.saidNotVoting = topic.saidNotVotingTransition.text;
+    transformedTopic.saidNotVotingTopic = topic.saidNotVotingTransition.topic;
+    transformedTopic.saidVoted = topic.saidVotedTransition.text;
+    transformedTopic.saidVotedTopic = topic.saidVotedTransition.topic;
   }
   if (module.exports.isAskYesNo(topic)) {
-    transformedTopic = {
-      ...topic,
-      saidNo: topic.saidNoTransition.text,
-      saidNoTopic: topic.saidNoTransition.topic,
-      saidYes: topic.saidYesTransition.text,
-      saidYesTopic: topic.saidYesTransition.topic,
-    };
+    transformedTopic.saidNo = topic.saidNoTransition.text;
+    transformedTopic.saidNoTopic = topic.saidNoTransition.topic;
+    transformedTopic.saidYes = topic.saidYesTransition.text;
+    transformedTopic.saidYesTopic = topic.saidYesTransition.topic;
   }
   return transformedTopic;
 };

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -44,6 +44,17 @@ const topicTransformer = (topic) => {
       saidLessTopic: topic.saidLessTransition.topic,
     };
   }
+  if (module.exports.isAskVotingPlanStatus(topic)) {
+    transformedTopic = {
+      ...topic,
+      saidCantVote: topic.saidCantVoteTransition.text,
+      saidCantVoteTopic: topic.saidCantVoteTransition.topic,
+      saidNotVoting: topic.saidNotVotingTransition.text,
+      saidNotVotingTopic: topic.saidNotVotingTransition.topic,
+      saidVoted: topic.saidVotedTransition.text,
+      saidVotedTopic: topic.saidVotedTransition.topic,
+    };
+  }
   return transformedTopic;
 };
 

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -35,6 +35,15 @@ const topicTransformer = (topic) => {
         topic.saidFifthChoiceTransition.topic : null,
     };
   }
+  if (module.exports.isAskSubscriptionStatus(topic)) {
+    transformedTopic = {
+      ...topic,
+      saidActive: topic.saidActiveTransition.text,
+      saidActiveTopic: topic.saidActiveTransition.topic,
+      saidLess: topic.saidLessTransition.text,
+      saidLessTopic: topic.saidLessTransition.topic,
+    };
+  }
   return transformedTopic;
 };
 

--- a/lib/middleware/messages/member/rate-limiter.js
+++ b/lib/middleware/messages/member/rate-limiter.js
@@ -12,7 +12,6 @@ module.exports = function getMembersRateLimiter() {
     const isTwilioRequest = helpers.request.isTwilio(req);
     // If not Twilio request or is a retry request, skip rate limiter
     if (!isTwilioRequest || req.isARetryRequest()) {
-      logger.debug(`Not a twilio request ${req.platformUserId}`);
       return next();
     }
     return memberRouteRateLimiter.consume(req.platformUserId)

--- a/lib/middleware/messages/member/rate-limiter.js
+++ b/lib/middleware/messages/member/rate-limiter.js
@@ -10,8 +10,8 @@ const { memberRoute: memberRouteRateLimiter } = require('../../../rate-limiters'
 module.exports = function getMembersRateLimiter() {
   return async (req, res, next) => {
     const isTwilioRequest = helpers.request.isTwilio(req);
-    // If not Twilio request skip rate limiter
-    if (!isTwilioRequest) {
+    // If not Twilio request or is a retry request, skip rate limiter
+    if (!isTwilioRequest || req.isARetryRequest()) {
       logger.debug(`Not a twilio request ${req.platformUserId}`);
       return next();
     }
@@ -26,7 +26,7 @@ module.exports = function getMembersRateLimiter() {
       // @see https://github.com/animir/node-rate-limiter-flexible/wiki/API-methods#ratelimiterconsumekey-points--1
       .catch((rateLimiterRes) => {
         const loggedAttributes = {
-          rateLimiterRes,
+          ...rateLimiterRes,
           rateLimitKey: req.platformUserId,
         };
         // Exposed as info for monitoring

--- a/test/helpers/factories/conversationTrigger.js
+++ b/test/helpers/factories/conversationTrigger.js
@@ -2,10 +2,18 @@
 
 const stubs = require('../stubs');
 
-function getValidConversationTrigger() {
+function getValidConversationTrigger(type) {
   return {
     trigger: stubs.getRandomWord(),
-    reply: stubs.getRandomMessageText(),
+    /**
+     * askMultipleChoice, faqAnswer, photoPostTransition, textPostTransition
+     * or autoReplyTransition
+     */
+    response: {
+      contentType: type || 'photoPostTransition',
+      text: stubs.getRandomMessageText(),
+      topic: {},
+    },
   };
 }
 

--- a/test/helpers/stubs.js
+++ b/test/helpers/stubs.js
@@ -73,6 +73,7 @@ module.exports = {
     },
   },
   graphql: {
+    // TODO: Refactor to respond with new schema contracts
     getBroadcastSingleResponse: (contentType = 'autoReplyBroadcast') => {
       const broadcast = { data: {} };
       switch (contentType) {
@@ -173,9 +174,16 @@ module.exports = {
       data: {
         conversationTriggers: [{
           trigger: 'thetalk',
-          reply: 'Sorry, The Talk is no longer available. Text Q if you have a question.',
-          topic: {
-            id: '6gg4Ce09FK6UG6K6cyC6aa',
+          response: {
+            contentType: 'autoReplyTransition',
+            id: '8vuIobzBrUGGUUoK8y0cO',
+            text: 'Sorry, The Talk is no longer available. Text Q if you have a question.',
+            topic: {
+              id: '6gg4Ce09FK6UG6K6cyC6aa',
+              contentType: 'autoReply',
+              legacyCampaign: null,
+              campaign: null,
+            },
           },
         }],
       },

--- a/test/unit/lib/lib-helpers/campaign.test.js
+++ b/test/unit/lib/lib-helpers/campaign.test.js
@@ -28,14 +28,15 @@ test.afterEach(() => {
 // fetchWebSignupConfirmations
 test('fetchWebSignupConfirmations returns cached graphql.fetchWebSignupConfirmations result', async () => {
   const data = [123, 345];
+  sandbox.spy(campaignHelper, 'webSignupConfirmationTransformer');
   sandbox.stub(graphql, 'fetchWebSignupConfirmations')
     .returns(Promise.resolve(data));
   sandbox.stub(helpers.cache.webSignupConfirmations, 'set')
     .returns(Promise.resolve(data));
 
-  const result = await campaignHelper.fetchWebSignupConfirmations();
-  helpers.cache.webSignupConfirmations.set.should.have.been.calledWith(data);
-  result.should.deep.equal(data);
+  await campaignHelper.fetchWebSignupConfirmations();
+  campaignHelper.webSignupConfirmationTransformer.should.have.been.called;
+  helpers.cache.webSignupConfirmations.set.should.have.been.called;
 });
 
 test('fetchWebSignupConfirmations throws if graphql.fetchWebSignupConfirmations fails', async (t) => {


### PR DESCRIPTION
#### What's this PR do?
The GraphQL query schema is updated to reflect the changes implemented in https://github.com/DoSomething/graphql/pull/103. 

##### Query schemas to be updated:
- `getTopicById`:
  - [x] `AskMultipleChoiceBroadcastTopic`
  - [x] `AskSubscriptionStatusBroadcastTopic`
  - [x] `AskVotingPlanStatusBroadcastTopic`
  - [x] `AskYesNoBroadcastTopic`
  - [x] `AutoReplyTopic`
- `getBroadcastById`
  - [x] `AskVotingPlanStatusBroadcastTopic`
  - [x] `AskYesNoBroadcastTopic`
- `getConversationTriggers`
  - [x] `AskMultipleChoiceBroadcastTopic`
  - [x] `FaqAnswerTopic`
  - [x] `AutoReplyTopic` (transition)
  - [x] `PhotoPostTopic` (transition)
  - [x] `TextPostTopic` (transition)
- `getWebSignupConfirmations` (Deprecated soon?)
  - [x] add transformer


#### How should this be reviewed?
- 👀 
- All tests should pass

#### Any background context you want to provide?
In order to have automatic cache busting in GraphQL for individual Contentful entries. The way GraphQL was caching the Contentful responses in the Gambit space had to be refactored to not include nested entries and/or assets. Gambit however expects this nested data already. For this reason, we have to update how Gambit queries GraphQL for the desired data.

#### Relevant tickets
Fixes Pivotal [Card#165504993](https://www.pivotaltracker.com/story/show/165504993)

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [x] Tests added/updated for new features/bug fixes.
- [x] ENV variables added/updated for new features/bug fixes.
- [x] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
