### PR TITLE
Fixes incorrect schema definition

### DIFF
--- a/config/lib/graphql.js
+++ b/config/lib/graphql.js
@@ -113,11 +113,15 @@ const fetchBroadcastById = `
       }
       ... on PhotoPostBroadcast {
         ${actionFields}
-        ${campaignTopicFields}
+        topic {
+          ...photoPostCampaign
+        }
       }
       ... on TextPostBroadcast {
         ${actionFields}
-        ${campaignTopicFields}
+        topic {
+          ...textPostCampaign
+        }
       }
     }
   }

--- a/config/lib/graphql.js
+++ b/config/lib/graphql.js
@@ -11,13 +11,6 @@ const campaignFields = `
   }
 `;
 
-const campaignTopicFields = `
-  topic {
-    id
-    ${campaignFields}
-  }
-`;
-
 const campaignTransitionTypes = `
   ...autoReplyCampaignTransition
   ...photoPostCampaignTransition


### PR DESCRIPTION
#### What's this PR do?
The `PhotoPostBroadcast` and `TextPostBroadcast` section of the `getBroadcastById` query were defined using the incorrect fragments. This PR fixes this bug introduced in #505.

#### How should this be reviewed?
- 👀 
- All tests should pass

#### Relevant tickets
Unblocks https://github.com/DoSomething/gambit-admin/pull/104
