### PR TITLE
Fixes bug with transforming Topics from GraphQL [pr]

### DIFF
--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -69,7 +69,7 @@ const defaultTopicTriggerTransformer = (trigger) => {
    * to the actual broadcast id instead of a "topic". Once they respond, we will inspect one of the
    * possible answer's topic to switch the member to.
    */
-  if (module.exports.isAskMultipleChoice(trigger)) {
+  if (module.exports.isAskMultipleChoice(transformedTrigger)) {
     transformedTrigger.topic = {
       id: response.id,
       contentType: response.contentType,

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -18,7 +18,7 @@ const topicTransformer = (topic) => {
   // TODO: Refactor codebase to check for the topic GraphQL __typename, not the Contentful type name
   transformedTopic.type = transformedTopic.contentType; // eslint-disable-line
 
-  if (module.exports.isAskMultipleChoice(topic)) {
+  if (module.exports.isAskMultipleChoice(transformedTopic)) {
     transformedTopic.saidFirstChoice = topic.saidFirstChoiceTransition.text;
     transformedTopic.saidFirstChoiceTopic = topic.saidFirstChoiceTransition.topic;
     transformedTopic.saidSecondChoice = topic.saidSecondChoiceTransition.text;
@@ -35,13 +35,13 @@ const topicTransformer = (topic) => {
     transformedTopic.saidFifthChoiceTopic = topic.saidFifthChoiceTransition ?
       topic.saidFifthChoiceTransition.topic : null;
   }
-  if (module.exports.isAskSubscriptionStatus(topic)) {
+  if (module.exports.isAskSubscriptionStatus(transformedTopic)) {
     transformedTopic.saidActive = topic.saidActiveTransition.text;
     transformedTopic.saidActiveTopic = topic.saidActiveTransition.topic;
     transformedTopic.saidLess = topic.saidLessTransition.text;
     transformedTopic.saidLessTopic = topic.saidLessTransition.topic;
   }
-  if (module.exports.isAskVotingPlanStatus(topic)) {
+  if (module.exports.isAskVotingPlanStatus(transformedTopic)) {
     transformedTopic.saidCantVote = topic.saidCantVoteTransition.text;
     transformedTopic.saidCantVoteTopic = topic.saidCantVoteTransition.topic;
     transformedTopic.saidNotVoting = topic.saidNotVotingTransition.text;
@@ -49,7 +49,7 @@ const topicTransformer = (topic) => {
     transformedTopic.saidVoted = topic.saidVotedTransition.text;
     transformedTopic.saidVotedTopic = topic.saidVotedTransition.topic;
   }
-  if (module.exports.isAskYesNo(topic)) {
+  if (module.exports.isAskYesNo(transformedTopic)) {
     transformedTopic.saidNo = topic.saidNoTransition.text;
     transformedTopic.saidNoTopic = topic.saidNoTransition.topic;
     transformedTopic.saidYes = topic.saidYesTransition.text;


### PR DESCRIPTION
#### What's this PR do?
It fixes the bug seen after the GraphQL Gambini refactoring [deploy on Tuesday. July 16th](https://dosomething.slack.com/archives/C02BBP0CU/p1563285255001900). The topic transformer was inspecting the raw topic data for a property that is injected to a cloned topic. The fix was to reference the [correct object](https://github.com/DoSomething/gambit/blob/bugfix/topic-transformer-bug/lib/helpers/topic.js#L19) when determining the type of topic we are parsing.

#### How should this be reviewed?
- 👀 

#### Any background context you want to provide?
- The test failure is related to an un-intercepted auth call. Not related to this change. There is a TODO to fix.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tests added/updated for new features/bug fixes.
- [ ] ENV variables added/updated for new features/bug fixes.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
