### PR TITLE
Adds missing topic IDs in GraphQL queries

### DIFF
--- a/config/lib/graphql.js
+++ b/config/lib/graphql.js
@@ -107,12 +107,14 @@ const fetchBroadcastById = `
       ... on PhotoPostBroadcast {
         ${actionFields}
         topic {
+          id
           ...photoPostCampaign
         }
       }
       ... on TextPostBroadcast {
         ${actionFields}
         topic {
+          id
           ...textPostCampaign
         }
       }

--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -51,6 +51,9 @@ async function createPhotoPost({ userId, actionId, photoPostSource, photoPostVal
     text: photoPostValues.caption,
     type: config.posts.photo.type,
   };
+  if (location) {
+    payload.location = location;
+  }
   if (photoPostValues.whyParticipated) {
     payload.why_participated = photoPostValues.whyParticipated;
   }
@@ -78,11 +81,13 @@ async function createTextPost({ userId, actionId, textPostSource, textPostText, 
   const payload = {
     northstar_id: userId,
     action_id: actionId,
-    location,
     source: textPostSource,
     text: textPostText,
     type: config.posts.text.type,
   };
+  if (location) {
+    payload.location = location;
+  }
   logger.debug('createTextPost payload', { payload });
 
   return gateway.createPost(payload);


### PR DESCRIPTION
#### What's this PR do?
Fixes bug where sending a text post broadcast sets the conversation topic to null.

But I'm not sure about actually sending back the text post, when I send one from Slack I get an error about an empty field... which I'm thinking might be `location`


<img width="400" alt="Screen Shot 2019-08-12 at 11 43 09 AM" src="https://user-images.githubusercontent.com/1236811/62889505-6856b380-bcf6-11e9-9ce5-a35d9e20d05d.png">


#### How should this be reviewed?

Send yourself a text post broadcast, verify topic is changed on conversation


#### Relevant tickets
#506
https://dosomething.slack.com/archives/C03T8SDMS/p1565632114073000

#### Checklist
- [ ] Tests added/updated for new features/bug fixes.
- [ ] ENV variables added/updated for new features/bug fixes.
- [ ] Tested on staging.
