### PR TITLE
Fixes photo posts for Slack

### DIFF
--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -45,7 +45,6 @@ async function createPhotoPost({ userId, actionId, photoPostSource, photoPostVal
   const payload = {
     northstar_id: userId,
     action_id: actionId,
-    location,
     quantity: photoPostValues.quantity,
     source: photoPostSource,
     text: photoPostValues.caption,
@@ -106,8 +105,10 @@ function createVotingPlan(user, votingPlanSource, location) {
     source: votingPlanSource,
     text: JSON.stringify(module.exports.getVotingPlanValues(user)),
     type: votingPlanPostConfig.type,
-    location,
   };
+  if (location) {
+    payload.location = location;
+  }
   logger.debug('createVotingPlan', { payload });
   return gateway.createPost(payload);
 }


### PR DESCRIPTION
#### What's this PR do?

Fixes creating photo posts via Slack, #511 fixed text posts but missed removing `location` from the payload creation and didn't fix photo posts.

#### How should this be reviewed?
Text MIRROR to Slack and create a photo post via messaging to verify a photo post is created. Reminder: you need to actually send the word `photo` to our Gambit Slack app to submit a photo (sweet feature request would be for our [Slack app](http://github.com/dosomething/gambit-slack) to parse attachments of inbound messages)

#### Any background context you want to provide?

I added the same check into creating a voting plan, but upon sending a completed voting plan (can test by texting `voting plan`), Rogue returns a 422 with "The given data was invalid". This is likely because we're not sending an action ID (refs #480) cc @ngjo 


#### Checklist
- [ ] Tested on staging.
