### PR TITLE
chore: Removes `rapist` from bad words list

### DIFF
--- a/config/lib/bad-words.js
+++ b/config/lib/bad-words.js
@@ -226,7 +226,6 @@ const badWords = [
   'ragingboner',
   'rape',
   'raping',
-  'rapist',
   'rectum',
   'reversecowgirl',
   'rimjob',


### PR DESCRIPTION
#### What's this PR do?
Removed `rapist` from bad words. This will prevent words like `therapist` from triggering the bad words filter.

#### Relevant tickets
Fixes Pivotal [Card#168201910](https://www.pivotaltracker.com/story/show/168201910)

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tests added/updated for new features/bug fixes.
- [ ] ENV variables added/updated for new features/bug fixes.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
