### PR TITLE
Fixes Voting Plan creation

### DIFF
--- a/config/lib/helpers/user.js
+++ b/config/lib/helpers/user.js
@@ -58,7 +58,7 @@ module.exports = {
     },
     votingPlan: {
       type: 'text',
-      campaignId: process.env.DS_GAMBIT_CONVERSATIONS_VOTING_PLAN_CAMPAIGN_ID || 7077,
+      actionId: process.env.DS_GAMBIT_CONVERSATIONS_VOTING_PLAN_ACTION_ID || 936,
     },
   },
 };

--- a/config/lib/helpers/user.js
+++ b/config/lib/helpers/user.js
@@ -58,7 +58,7 @@ module.exports = {
     },
     votingPlan: {
       type: 'text',
-      actionId: process.env.DS_GAMBIT_CONVERSATIONS_VOTING_PLAN_ACTION_ID || 936,
+      actionId: process.env.DS_GAMBIT_CONVERSATIONS_VOTING_PLAN_ACTION_ID || 938,
     },
   },
 };

--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -100,7 +100,7 @@ async function createTextPost({ userId, actionId, textPostSource, textPostText, 
  */
 function createVotingPlan(user, votingPlanSource, location) {
   const payload = {
-    campaign_id: votingPlanPostConfig.campaignId,
+    action_id: votingPlanPostConfig.actionId,
     northstar_id: user.id,
     source: votingPlanSource,
     text: JSON.stringify(module.exports.getVotingPlanValues(user)),
@@ -175,9 +175,11 @@ function getFetchSignupsQuery(userId, campaignId) {
  * @return {Object}
  */
 function getFetchVotingPlanQuery(userId) {
-  const postTypeQuery = { 'filter[type]': votingPlanPostConfig.type };
-  return Object.assign(module.exports
-    .getFetchSignupsQuery(userId, votingPlanPostConfig.campaignId), postTypeQuery);
+  return {
+    'filter[northstar_id]': userId,
+    'filter[type]': votingPlanPostConfig.type,
+    'filter[action_id]': votingPlanPostConfig.actionId,
+  };
 }
 
 /**

--- a/test/unit/lib/lib-helpers/user.test.js
+++ b/test/unit/lib/lib-helpers/user.test.js
@@ -143,7 +143,7 @@ test('createVotingPlan passes user voting plan info to gateway.createPost', asyn
   const result = await userHelper
     .createVotingPlan(mockUser, source, t.context.req.platformUserStateISOCode);
   gateway.createPost.should.have.been.calledWith({
-    campaign_id: config.posts.votingPlan.campaignId,
+    action_id: config.posts.votingPlan.actionId,
     northstar_id: mockUser.id,
     source,
     text: details,
@@ -322,13 +322,12 @@ test('getFetchSignupsQuery should return object for querying by userId and campa
 
 // getFetchVotingPlanQuery
 test('getFetchVotingPlanQuery should return getFetchSignupsQuery result with type filter property', () => {
-  const mockQuery = { test: stubs.getRandomWord() };
-  sandbox.stub(userHelper, 'getFetchSignupsQuery')
-    .returns(mockQuery);
   const result = userHelper.getFetchVotingPlanQuery(mockUser.id);
-  result.should.deep.equal(Object.assign(mockQuery, {
+  result.should.deep.equal({
+    'filter[northstar_id]': mockUser.id,
+    'filter[action_id]': config.posts.votingPlan.actionId,
     'filter[type]': config.posts.votingPlan.type,
-  }));
+  });
 });
 
 // getVotingPlanValues


### PR DESCRIPTION
#### What's this PR do?

This PR passes an action id instead of campaign id when executing a `POST /posts` request to Rogue to create a voting plan for a user.

#### How should this be reviewed?

Upon staging deploy, text `voting plan` to Gambit. Answer yes you'll be voting, and answer all voting plan questions. Confirm a validation reply is sent, and a text post with the voting plan info is created for your user.

#### Any background context you want to provide?
We'll need to set the config voting plan action ID variable on production (using the hardcoded default which was created in Rogue QA)

#### Relevant tickets

Fixes https://www.pivotaltracker.com/story/show/169275890

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tests added/updated for new features/bug fixes.
- [ ] ENV variables added/updated for new features/bug fixes.
- [x] Tested on staging.
- [x] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
