### PR TITLE
Updates Gambit workflow documentation

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -74,7 +74,6 @@ You>
 
 Input is posted to your localhost `api/v2/messages?origin=twilio` endpoint on behalf of the Northstar User with mobile number matching your  `DS_CONSOLEBOT_USER_MOBILE` config variable. A new Northstar User is created for the mobile number if it doesn't exist.
 
-
 ### Contributing
 
 * Run `npm test:full` to lint code and run automated tests.

--- a/.github/README.md
+++ b/.github/README.md
@@ -80,7 +80,7 @@ Input is posted to your localhost `api/v2/messages?origin=twilio` endpoint on be
 * Run `npm test:full` to lint code and run automated tests.
 * Pull Requests are expected to contain reasonable test coverage.
 
-Note: Versions exist from when we used [Wunderflow](http://wunderflow.wunder.io/) for branching. We now adhere to a [Github flow](https://guides.github.com/introduction/flow/), keeping consistent with workflow for other current DoSomething repositories.
+Note: [Git tags](https://github.com/DoSomething/gambit/tags) exist from when we used [Wunderflow](http://wunderflow.wunder.io/) for branching. We now adhere to a [Github flow](https://guides.github.com/introduction/flow/), keeping consistent with workflow for other current DoSomething repositories, and no longer create tags for each deployment.
 
 ### Troubleshooting
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -77,10 +77,10 @@ Input is posted to your localhost `api/v2/messages?origin=twilio` endpoint on be
 
 ### Contributing
 
-* Contributions to this repo must adhere to the steps in wunder.io's Git workflow:  **[Wunderflow](http://wunderflow.wunder.io/)**.
-
 * Run `npm test:full` to lint code and run automated tests.
 * Pull Requests are expected to contain reasonable test coverage.
+
+Note: Versions exist from when we used [Wunderflow](http://wunderflow.wunder.io/) for branching. We now adhere to a [Github flow](https://guides.github.com/introduction/flow/), keeping consistent with workflow for other current DoSomething repositories.
 
 ### Troubleshooting
 


### PR DESCRIPTION
#### What's this PR do?

This PR documents that we no longer will use Wunderflow to maintain a `production` branch with tags. Instead, we'll maintain a `main` branch (which is our `master` branch renamed), which our staging app will automatically build from -- and manually promote to production for deploys.

 I've made these changes to the Heroku pipeline, and this PR seemed like a good test run for a deploy (it's been almost a year!)

#### How should this be reviewed?

👀 

#### Any background context you want to provide?

I'm reading this PR template for the first time in ages, and remembering that we'd manually deploy branches to our staging app to test them out. Review apps are tough to do in this project because we'd need to change the URL's for the various front-ends (Slack app, Twilio phone number). We've usually been able to get away with using our staging app as a review app because there's rarely other folks using it at the same time.

It does bring to mind a wishlist item of moving Gambit Admin into this repo, and building out a Consolebot so devs / stakeholders could test out conversations in the UI of the review app (but even that'd require adding the review app into the dev Aurora instance like we need to for Phoenix - and we'd need to add it each time since we wouldn't want to expose the chat widget to anonymous users)

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tests added/updated for new features/bug fixes.
- [ ] ENV variables added/updated for new features/bug fixes.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
