### PR TITLE
Adds support for LocationVotingInformation tags

### DIFF
--- a/app/models/Conversation.js
+++ b/app/models/Conversation.js
@@ -286,9 +286,11 @@ conversationSchema.methods.getMessagePayloadFromReq = function (req = {}, direct
  */
 conversationSchema.methods.createMessage = async function (direction, text, template, req) {
   logger.debug('createMessage', { direction }, req);
+
   let messageText;
+
   if (direction !== 'inbound') {
-    messageText = helpers.tags.render(text, req);
+    messageText = await helpers.tags.render(text, req);
 
     if (bertly.isEnabled() && bertly.textHasLinks(messageText)) {
       messageText = await bertly.parseLinksIntoRedirects(messageText);

--- a/config/lib/graphql.js
+++ b/config/lib/graphql.js
@@ -250,11 +250,25 @@ const fetchWebSignupConfirmations = `
   ${campaignTopicTransitionFragments}
 `;
 
+const fetchVotingInformationByLocation = `
+  query getLocationVotingInformation($location: String!) {
+    locationVotingInformation(location: $location) {
+      absenteeBallotRequestDeadline
+      absenteeBallotReturnDeadline
+      absenteeBallotReturnDeadlineType
+      earlyVotingEnds
+      earlyVotingStarts
+      voterRegistrationDeadline
+    }
+  }
+`;
+
 module.exports = {
   queries: {
     fetchBroadcastById,
     fetchConversationTriggers,
     fetchTopicById,
+    fetchVotingInformationByLocation,
     fetchWebSignupConfirmations,
   },
   clientOptions: {

--- a/lib/graphql.js
+++ b/lib/graphql.js
@@ -57,10 +57,24 @@ async function fetchWebSignupConfirmations() {
   return res.webSignupConfirmations;
 }
 
+/**
+ * Fetches voting information by ISO-3166-2 location.
+ *
+ * @param {String} location
+ * @return {Promise}
+ */
+async function fetchVotingInformationByLocation(location) {
+  const res = await module.exports
+    .request(config.queries.fetchVotingInformationByLocation, { location });
+
+  return res.locationVotingInformation;
+}
+
 module.exports = {
   fetchBroadcastById,
   fetchConversationTriggers,
   fetchTopicById,
+  fetchVotingInformationByLocation,
   fetchWebSignupConfirmations,
   request,
 };

--- a/lib/helpers/tags.js
+++ b/lib/helpers/tags.js
@@ -2,6 +2,8 @@
 
 const mustache = require('mustache');
 const queryString = require('query-string');
+
+const graphql = require('../graphql');
 const config = require('../../config/lib/helpers/tags');
 const userConfig = require('../../config/lib/helpers/user');
 
@@ -57,12 +59,12 @@ function getBroadcastTag(req) {
  * @param {Object} req
  * @return {Object}
  */
-function getTags(req) {
+async function getTags(req) {
   return {
     broadcast: module.exports.getBroadcastTag(req),
     links: module.exports.getLinksTag(req),
     topic: req.topic ? req.topic : {},
-    user: req.user ? module.exports.getUserTag(req.user) : {},
+    user: req.user ? await module.exports.getUserTag(req.user) : {},
   };
 }
 
@@ -84,12 +86,20 @@ function getUserLinkQueryParams(req) {
  * @param {Object} user
  * @return {Object}
  */
-function getUserTag(user) {
-  return {
-    id: user.id,
-    addrState: user.addr_state,
-    votingPlan: module.exports.getVotingPlan(user),
-  };
+async function getUserTag(user) {
+  try {
+    const stateAbbreviation = user.addr_state;
+    const locationVotingInformation = await graphql
+      .fetchVotingInformationByLocation(`US-${stateAbbreviation}`);
+
+    return Object.assign({
+      id: user.id,
+      addrState: stateAbbreviation,
+      votingPlan: module.exports.getVotingPlan(user),
+    }, locationVotingInformation);    
+  } catch (error) {
+    throw error;
+  }
 }
 
 /**
@@ -154,8 +164,8 @@ function getLinksTag(req) {
  * @param {Object} req
  * @return {String}
  */
-function render(string, req) {
-  return mustache.render(string, module.exports.getTags(req));
+async function render(string, req) {
+  return mustache.render(string, await module.exports.getTags(req));
 }
 
 module.exports = {

--- a/lib/helpers/tags.js
+++ b/lib/helpers/tags.js
@@ -96,7 +96,7 @@ async function getUserTag(user) {
       id: user.id,
       addrState: stateAbbreviation,
       votingPlan: module.exports.getVotingPlan(user),
-    }, locationVotingInformation);    
+    }, locationVotingInformation);
   } catch (error) {
     throw error;
   }

--- a/test/helpers/stubs.js
+++ b/test/helpers/stubs.js
@@ -188,6 +188,18 @@ module.exports = {
         }],
       },
     }),
+    fetchVotingInformationByLocation: () => ({
+      data: {
+        locationVotingInformation: {
+          voterRegistrationDeadline: '10/24',
+          absenteeBallotRequestDeadline: '10/1',
+          absenteeBallotReturnDeadline: '10/15',
+          absenteeBallotReturnDeadlineType: 'postmarked by',
+          earlyVotingStarts: '8/15',
+          earlyVotingEnds: '9/26',
+        }
+      }
+    })
   },
   getError,
   stubLogger,

--- a/test/helpers/stubs.js
+++ b/test/helpers/stubs.js
@@ -197,9 +197,9 @@ module.exports = {
           absenteeBallotReturnDeadlineType: 'postmarked by',
           earlyVotingStarts: '8/15',
           earlyVotingEnds: '9/26',
-        }
-      }
-    })
+        },
+      },
+    }),
   },
   getError,
   stubLogger,

--- a/test/integration/app/v2-routes/messages/member.test.js
+++ b/test/integration/app/v2-routes/messages/member.test.js
@@ -55,6 +55,9 @@ function mockExternalCallsForUserInputMessage(message) {
   integrationHelper.routes.graphql
     .intercept(stubs.graphql.fetchConversationTriggers(), 1);
 
+  integrationHelper.routes.graphql
+    .intercept(stubs.graphql.fetchVotingInformationByLocation(), 1);
+
   // mock user fetch
   integrationHelper.routes.northstar
     .intercept.fetchUserByMobile(message.From, member, 1);

--- a/test/integration/app/v2-routes/messages/subscription-status-active.test.js
+++ b/test/integration/app/v2-routes/messages/subscription-status-active.test.js
@@ -80,7 +80,8 @@ test.serial('POST /api/v2/messages?origin=subscriptionStatusActive should create
   const outboundMessage = await Message.findOne({ conversationId: conversation.id });
   should.exist(outboundMessage);
   outboundMessage.template.should.be.equal(subscriptionStatusActiveData.name);
-  const renderedText = await tagsHelper.render(subscriptionStatusActiveData.text, { user: user.data });
+  const renderedText = await tagsHelper
+    .render(subscriptionStatusActiveData.text, { user: user.data });
   outboundMessage.text.should.be.equal(renderedText);
 });
 
@@ -111,7 +112,8 @@ test.serial('POST /api/v2/messages?origin=subscriptionStatusActive should not cr
   messages.length.should.be.equal(1);
   const message = messages[0];
   message.template.should.be.equal(subscriptionStatusActiveData.name);
-  const renderedText = await tagsHelper.render(subscriptionStatusActiveData.text, { user: user.data });
+  const renderedText = await tagsHelper
+    .render(subscriptionStatusActiveData.text, { user: user.data });
   message.text.should.be.equal(renderedText);
 });
 

--- a/test/integration/app/v2-routes/messages/subscription-status-active.test.js
+++ b/test/integration/app/v2-routes/messages/subscription-status-active.test.js
@@ -80,7 +80,7 @@ test.serial('POST /api/v2/messages?origin=subscriptionStatusActive should create
   const outboundMessage = await Message.findOne({ conversationId: conversation.id });
   should.exist(outboundMessage);
   outboundMessage.template.should.be.equal(subscriptionStatusActiveData.name);
-  const renderedText = tagsHelper.render(subscriptionStatusActiveData.text, { user: user.data });
+  const renderedText = await tagsHelper.render(subscriptionStatusActiveData.text, { user: user.data });
   outboundMessage.text.should.be.equal(renderedText);
 });
 
@@ -111,7 +111,7 @@ test.serial('POST /api/v2/messages?origin=subscriptionStatusActive should not cr
   messages.length.should.be.equal(1);
   const message = messages[0];
   message.template.should.be.equal(subscriptionStatusActiveData.name);
-  const renderedText = tagsHelper.render(subscriptionStatusActiveData.text, { user: user.data });
+  const renderedText = await tagsHelper.render(subscriptionStatusActiveData.text, { user: user.data });
   message.text.should.be.equal(renderedText);
 });
 

--- a/test/unit/lib/lib-helpers/tags.test.js
+++ b/test/unit/lib/lib-helpers/tags.test.js
@@ -39,14 +39,8 @@ const mockText = stubs.getRandomMessageText();
 const mockTopic = topicFactory.getValidTopic();
 const mockUser = userFactory.getValidUserWithAddress();
 const mockTags = { season: 'winter' };
-const mockLocationVotingInformation = {
-  voterRegistrationDeadline: '10/24',
-  absenteeBallotRequestDeadline: '10/1',
-  absenteeBallotReturnDeadline: '10/15',
-  absenteeBallotReturnDeadlineType: 'postmarked by',
-  earlyVotingStarts: '8/15',
-  earlyVotingEnds: '9/26',
-};
+const mockLocationVotingInformation = stubs.graphql.fetchVotingInformationByLocation()
+  .data.locationVotingInformation;
 
 test.beforeEach((t) => {
   t.context.req = httpMocks.createRequest();

--- a/test/unit/lib/lib-helpers/tags.test.js
+++ b/test/unit/lib/lib-helpers/tags.test.js
@@ -9,17 +9,16 @@ const sinonChai = require('sinon-chai');
 const httpMocks = require('node-mocks-http');
 const queryString = require('query-string');
 
-const logger = require('../../../../lib/logger');
 const graphql = require('../../../../lib/graphql');
 const config = require('../../../../config/lib/helpers/tags');
 const userConfig = require('../../../../config/lib/helpers/user');
 
+// stubs
 const stubs = require('../../../helpers/stubs');
+const userFactory = require('../../../helpers/factories/user');
+const topicFactory = require('../../../helpers/factories/topic');
 const broadcastFactory = require('../../../helpers/factories/broadcast');
 const conversationFactory = require('../../../helpers/factories/conversation');
-const topicFactory = require('../../../helpers/factories/topic');
-const userFactory = require('../../../helpers/factories/user');
-
 
 // setup "x.should.y" assertion style
 chai.should();
@@ -40,18 +39,16 @@ const mockText = stubs.getRandomMessageText();
 const mockTopic = topicFactory.getValidTopic();
 const mockUser = userFactory.getValidUserWithAddress();
 const mockTags = { season: 'winter' };
-const mockLocationVotingInformation = {  
-  voterRegistrationDeadline: "10/24",
-  absenteeBallotRequestDeadline: "10/1",
-  absenteeBallotReturnDeadline: "10/15",
-  absenteeBallotReturnDeadlineType: "postmarked by",
-  earlyVotingStarts: "8/15",
-  earlyVotingEnds: "9/26",
+const mockLocationVotingInformation = {
+  voterRegistrationDeadline: '10/24',
+  absenteeBallotRequestDeadline: '10/1',
+  absenteeBallotReturnDeadline: '10/15',
+  absenteeBallotReturnDeadlineType: 'postmarked by',
+  earlyVotingStarts: '8/15',
+  earlyVotingEnds: '9/26',
 };
 
 test.beforeEach((t) => {
-  // This test complains about attempting to wrap warn when errors occur (so you can't see the errors)
-  // stubs.stubLogger(sandbox, logger);
   t.context.req = httpMocks.createRequest();
 });
 


### PR DESCRIPTION
#### What's this PR do?

This PR adds support to query GraphQL for the `LocationVotingInformation` relevant to a user per their `addr_state` Northstar property, and display them as new [user tags](https://github.com/dosomething/gambit-admin/wiki/tags#user).

Example message content:

> Don't forget! Early voting in {{user.addrState}} beings on {{user.earlyVotingStarts}} and ends on {{user.earlyVotingEnds}}.

Example rendered message:

> Don't forget! Early voting in MA beings on 9/12 and ends on 10/13.


#### How should this be reviewed?

This can be manually tested by sending yourself this [test broadcast, 7BKADblVGm0o67HyORvDm4,](https://app.contentful.com/spaces/owik07lyerdj/entries/7BKADblVGm0o67HyORvDm4) which includes `earlyVotingStarts` and `earlyVotingEnds` user tags.

#### Any background context you want to provide?

* A few functions and related tests needed to be refactored as async to do this, and I'm second guessing making the GraphQL query from the tags helper, vs adding into get/create user functions -- but because there are so many routes that load a user, this still feels like maybe the cleanest. 

* Adding Prettier to this repo's commit hooks would truly be the jam

* I'll update the Gambit wiki to list these new [tags](https://github.com/dosomething/gambit-admin/wiki/tags#user), and mull over where the ideal home of SMS documentation for non-devs should live (for now, it's here and I'd think Anthony's google doc)

#### Relevant tickets

* Refs https://github.com/DoSomething/graphql/pull/275

* Closes https://www.pivotaltracker.com/story/show/174179498

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [x] Tests added/updated for new features/bug fixes.
- [ ] ENV variables added/updated for new features/bug fixes.
- [x] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
