### PR TITLE
Avoid querying GraphQL if outbound message does not have tags

### DIFF
--- a/brain/topics/dev.rive
+++ b/brain/topics/dev.rive
@@ -1,0 +1,7 @@
+// dev.rive
+
+/**
+ * These are convenience keywords to sanity check functionality (like voting info tags).
+ */
++ devtest
+- Voting in {{user.addrState}} starts on {{user.earlyVotingStarts}} and ends on {{user.earlyVotingEnds}}.

--- a/brain/topics/dev.rive
+++ b/brain/topics/dev.rive
@@ -1,7 +1,0 @@
-// dev.rive
-
-/**
- * These are convenience keywords to sanity check functionality (like voting info tags).
- */
-+ devtest
-- Voting in {{user.addrState}} starts on {{user.earlyVotingStarts}} and ends on {{user.earlyVotingEnds}}.

--- a/lib/helpers/tags.js
+++ b/lib/helpers/tags.js
@@ -3,6 +3,7 @@
 const mustache = require('mustache');
 const queryString = require('query-string');
 
+const logger = require('../logger');
 const graphql = require('../graphql');
 const config = require('../../config/lib/helpers/tags');
 const userConfig = require('../../config/lib/helpers/user');
@@ -60,12 +61,16 @@ function getBroadcastTag(req) {
  * @return {Object}
  */
 async function getTags(req) {
-  return {
+  const result = {
     broadcast: module.exports.getBroadcastTag(req),
     links: module.exports.getLinksTag(req),
     topic: req.topic ? req.topic : {},
     user: req.user ? await module.exports.getUserTag(req.user) : {},
   };
+
+  logger.debug('helpers.tags.getTags', { result }, req);
+
+  return result;
 }
 
 /**
@@ -160,12 +165,17 @@ function getLinksTag(req) {
 }
 
 /**
+ * Renders Mustache tags with req data, if tags are included in the given string.
+ *
  * @param {String} string
  * @param {Object} req
  * @return {String}
  */
 async function render(string, req) {
-  return mustache.render(string, await module.exports.getTags(req));
+  // Check for opening and closing double brackets.
+  const hasTags = /\{{.*?\}}/g.exec(string);
+
+  return hasTags ? mustache.render(string, await module.exports.getTags(req)) : string;
 }
 
 module.exports = {

--- a/lib/helpers/tags.js
+++ b/lib/helpers/tags.js
@@ -173,7 +173,7 @@ function getLinksTag(req) {
  */
 async function render(string, req) {
   // Check for opening and closing double brackets.
-  const hasTags = /\{{.*?\}}/g.exec(string);
+  const hasTags = /\{{.+?\}}/g.exec(string);
 
   return hasTags ? mustache.render(string, await module.exports.getTags(req)) : string;
 }

--- a/test/unit/lib/lib-helpers/tags.test.js
+++ b/test/unit/lib/lib-helpers/tags.test.js
@@ -86,7 +86,7 @@ test('getLinksTag should return an object', (t) => {
 });
 
 // render
-test('render should return a string', async () => {
+test('render does not call getTags if open/closed brackets are not found', async () => {
   sandbox.stub(mustache, 'render')
     .returns(mockText);
   sandbox.stub(tagsHelper, 'getTags')
@@ -94,7 +94,7 @@ test('render should return a string', async () => {
 
   const result = await tagsHelper.render(mockText, {});
 
-  mustache.render.should.have.been.calledWith(mockText, mockTags);
+  mustache.render.should.not.have.been.called;
   result.should.equal(mockText);
 });
 
@@ -104,14 +104,14 @@ test('render should throw if mustache.render fails', async () => {
   sandbox.stub(tagsHelper, 'getTags')
     .returns(Promise.resolve(mockTags));
 
-  await tagsHelper.render(mockText, mockTags).should.throw;
+  await tagsHelper.render('Hello {{user.id}}', mockTags).should.throw;
 });
 
 test('render should throw if getTags fails', async () => {
   sandbox.stub(tagsHelper, 'getTags')
     .returns(Promise.resolve(new Error()));
 
-  await tagsHelper.render(mockText, mockTags).should.throw;
+  await tagsHelper.render('Hello {{user.id}}', mockTags).should.throw;
 });
 
 test('render should replace user vars', async (t) => {


### PR DESCRIPTION
#### What's this PR do?

This PR adds a check into the tags helper's `render` function so that we only call `getTags` (which queries GraphQL for a user's `LocationVotingInformation`) if opening and closing double brackets exist within the outbound message text. Refs https://github.com/DoSomething/gambit/pull/527#issuecomment-686774337

#### How should this be reviewed?

👀 

#### Any background context you want to provide?

I've been having a tough time figuring out how to run individual unit tests instead of `npm run test:unit`, which runs them all. I've been trying to use [`npx ava --match='*test*'`](https://github.com/avajs/ava/blob/master/docs/05-command-line.md#running-tests-with-matching-titles), but some tests fail (whereas they won't when running all tests via the `npm run test:unit` command). 

#### Relevant tickets

[#174179498](https://www.pivotaltracker.com/story/show/174179498)

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tests added/updated for new features/bug fixes.
- [ ] ENV variables added/updated for new features/bug fixes.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
