### PR TITLE
Update Bertly Integration - Short Link Usage

### DIFF
--- a/lib/bertly/index.js
+++ b/lib/bertly/index.js
@@ -88,7 +88,7 @@ async function parseLinksIntoRedirects(text = '') {
     const redirects = await Promise.map(links, link => module.exports.getRedirectForUrl(link.url));
 
     redirects.forEach((redirect) => {
-      parsedMessage = parsedMessage.replace(redirect.originalUrl, redirect.redirect.url);
+      parsedMessage = parsedMessage.replace(redirect.originalUrl, redirect.redirect.url_short);
     });
 
     return parsedMessage;

--- a/lib/bertly/index.js
+++ b/lib/bertly/index.js
@@ -47,7 +47,7 @@ function findAllLinks(text) {
  *                     as well the original link value.
  *
  * @async
- * @see {@link https://github.com/DoSomething/bertly#create-redirect|Response}
+ * @see {@link https://github.com/DoSomething/bertly/blob/master/documentation/README.md#create-link|Response}
  * @param  {String} url
  * @return {Promise<Object>}
  */

--- a/test/unit/lib/bertly.test.js
+++ b/test/unit/lib/bertly.test.js
@@ -69,6 +69,6 @@ test.serial('bertly.parseLinksIntoRedirects should get redirect for found links'
   bertly.__set__('restClient', { createRedirect: () => Promise.resolve(getRedirect()) });
   const textWithLink = stubs.getBroadcastMessageTextWithLink();
   const parsedText = await bertly.parseLinksIntoRedirects(textWithLink);
-  parsedText.should.include(getRedirect().url);
+  parsedText.should.include(getRedirect().url_short);
   bertly.__set__('restClient', bertlyRestClient);
 });


### PR DESCRIPTION
#### What's this PR do?
tell us, what have you changed?
Swapped from using our [Bertly integration](https://github.com/DoSomething/bertly) short link creation response's soon-to-be-deprecated `url` property to the new `url_short` property.

#### How should this be reviewed?
tell us, how can we review, to test that this works
I ran a couple of topic triggers with Consolebot (`help`, `health`, etc.) to confirm that the short links are still being generated properly.

#### Any background context you want to provide?
what else?
Berly's waiting on our app to update to the new property so the legacy `url` can be deprecated.

#### Relevant tickets
Fixes Pivotal [Card#174267470](https://www.pivotaltracker.com/story/show/174267470)

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [x] Tests added/updated for new features/bug fixes.
- [ ] ENV variables added/updated for new features/bug fixes.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
