### PR TITLE
Adds macro and Contentful ID properties to GET /rivescript API response

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -31,7 +31,7 @@ Gambit is built with:
 * [GraphQL](https://graphql.org/learn/)
 * [MongoDB](https://www.mongodb.com/)
 * [Redis](https://redis.io/)
-* [Rivescript](https://www.rivescript.com/)
+* [RiveScript](https://www.rivescript.com/)
 
 ### Installation
 

--- a/config/lib/graphql.js
+++ b/config/lib/graphql.js
@@ -127,6 +127,7 @@ const fetchBroadcastById = `
 const fetchConversationTriggers = `
   query getConversationTriggers {
     conversationTriggers {
+      id
       trigger
       response {
         contentType

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -18,7 +18,7 @@ Endpoint | Functionality
 `GET /api/v2/broadcasts/:id` | [Retrieve a broadcast](endpoints/broadcasts.md).
 `POST /api/v2/messages` | [Create a message](endpoints/messages.md).
 `PATCH /api/v2/messages/:messageId` | [Update a message](endpoints/messages.md).
-`GET /api/v2/rivescript` | [Retrieve loaded Rivescript](endpoints/rivescript.md).
+`GET /api/v2/rivescript` | [Retrieve loaded RiveScript](endpoints/rivescript.md).
 
 ### v1
 

--- a/documentation/endpoints/rivescript.md
+++ b/documentation/endpoints/rivescript.md
@@ -10,7 +10,7 @@ We've modified the deparsed RiveScript output to append new Gambit-specific prop
 
 * `macro` - (string) If set, the raw RiveScript `reply` value corresponds to a hardcoded macro. The `reply` property will be set to the text rendered by the macro.
 
-* `hardcoded` - (boolean) Whether this trigger is defined in Contentful (only occurrs when in the default topic, `random`. Refs "Topics" section in [RiveScript docs](https://www.rivescript.com/docs/tutorial)).
+* `contentfulId` - (string) If set, the Contentful entry that defines this trigger to be loaded in the default topic, `random` (refs "Topics" section in [RiveScript docs](https://www.rivescript.com/docs/tutorial)).
 
 ### Query parameters
 
@@ -49,7 +49,7 @@ curl -X "GET" "http://localhost:5100/api/v2/rivescript?cache=false" \
           "redirect": null,
           "previous": null,
           "macro": "sendInfoMessage",
-          "hardcoded": true
+          "contentfulId": null
         },
         {
           "trigger": "help",
@@ -62,7 +62,7 @@ curl -X "GET" "http://localhost:5100/api/v2/rivescript?cache=false" \
           "redirect": "info",
           "previous": null,
           "macro": null,
-          "hardcoded": true
+          "contentfulId": null
         },
         {
           "trigger": "subscribe",
@@ -75,7 +75,7 @@ curl -X "GET" "http://localhost:5100/api/v2/rivescript?cache=false" \
           "redirect": null,
           "previous": null,
           "macro": "subscriptionStatusActive",
-          "hardcoded": true
+          "contentfulId": null
         },
         {
           "trigger": "covid",
@@ -88,7 +88,7 @@ curl -X "GET" "http://localhost:5100/api/v2/rivescript?cache=false" \
           "redirect": null,
           "previous": null,
           "macro": null,
-          "hardcoded": false
+          "contentfulId": "3ZgJy8XztZjifs4jCEazph"
         },
         ...
       ]

--- a/documentation/endpoints/rivescript.md
+++ b/documentation/endpoints/rivescript.md
@@ -1,4 +1,4 @@
-# Rivescript
+# RiveScript
 
 ```
 GET /api/v2/rivescript
@@ -10,7 +10,7 @@ We've modified the deparsed RiveScript output to append new Gambit-specific prop
 
 * `macro` - (string) If set, the raw RiveScript `reply` value corresponds to a hardcoded macro. The `reply` property will be set to the text rendered by the macro.
 
-* `hardcoded` - (boolean) Whether this trigger is defined in Contentful (only occurrs when in the default topic, `random`. (refs "Topics" section in [RiveScript docs](https://www.rivescript.com/docs/tutorial)).
+* `hardcoded` - (boolean) Whether this trigger is defined in Contentful (only occurrs when in the default topic, `random`. Refs "Topics" section in [RiveScript docs](https://www.rivescript.com/docs/tutorial)).
 
 ### Query parameters
 

--- a/documentation/endpoints/rivescript.md
+++ b/documentation/endpoints/rivescript.md
@@ -4,13 +4,19 @@
 GET /api/v2/rivescript
 ```
 
-Returns the deparsed rivescript used for outbound replies.
+Returns the [deparsed RiveScript](https://github.com/aichaos/rivescript-js/blob/master/docs/rivescript.md#user-content-data-deparse) used for outbound replies.
+
+We've modified the deparsed RiveScript output to append new Gambit-specific properties to each array property in the `topics` object:
+
+* `macro` - (string) If set, the raw RiveScript `reply` value corresponds to a hardcoded macro. The `reply` property will be set to the text rendered by the macro.
+
+* `hardcoded` - (boolean) Whether this trigger is defined in Contentful (only occurrs when in the default topic, `random`. (refs "Topics" section in [RiveScript docs](https://www.rivescript.com/docs/tutorial)).
 
 ### Query parameters
 
 Name | Type | Description
 -----|------|------------
-`cache` | string | If set to `false`, fetches additional Rivescript from Gambit Content API and sorts bot replies.
+`cache` | string | If set to `false`, fetches additional default topic triggers from Contentful, and and sorts bot replies.
 
 ## Examples
 
@@ -35,27 +41,54 @@ curl -X "GET" "http://localhost:5100/api/v2/rivescript?cache=false" \
         {
           "trigger": "info",
           "reply": [
-            "sendInfoMessage"
+            "These are Do Something Alerts - 4 messages/mo. Info help@dosomething.org or https://dosome.click/2z6uc. Txt STOP to quit. Msg&Data Rates May Apply."
           ],
-          "condition": [],
+          "condition": [
+            
+          ],
           "redirect": null,
-          "previous": null
+          "previous": null,
+          "macro": "sendInfoMessage",
+          "hardcoded": true
         },
         {
           "trigger": "help",
-          "reply": [],
-          "condition": [],
+          "reply": [
+            null
+          ],
+          "condition": [
+            
+          ],
           "redirect": "info",
-          "previous": null
+          "previous": null,
+          "macro": null,
+          "hardcoded": true
         },
         {
           "trigger": "subscribe",
           "reply": [
-            "subscriptionStatusActive"
+            "👋 Welcome to DoSomething.org! Meet the staffers who'll be texting you: https://www.dosomething.org/us/articles/meet-the-staff-sms?user_id={{user.id}}&utm_campaign=sms_compliance_message&utm_medium=sms&utm_source=content_fun\n\nMsg&DataRatesApply. Txt HELP for help, STOP to stop."
           ],
-          "condition": [],
+          "condition": [
+            
+          ],
           "redirect": null,
-          "previous": null
+          "previous": null,
+          "macro": "subscriptionStatusActive",
+          "hardcoded": true
+        },
+        {
+          "trigger": "covid",
+          "reply": [
+            "While you're stuck inside due to COVID-19, use our resources to stay healthy, fight anxiety & make a difference in your community. Do you want to:\\n\nA) Read our resource guide\\n\nB) Get actions to do from home\\n\nC) Share social distancing tips{topic=kljOPm29CnIfEcWTQtxqI}"
+          ],
+          "condition": [
+            
+          ],
+          "redirect": null,
+          "previous": null,
+          "macro": null,
+          "hardcoded": false
         },
         ...
       ]

--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -41,16 +41,22 @@ function getDeparsedRivescript() {
  */
 async function getRivescripts(resetCache = false) {
   logger.debug('getRivescripts', { resetCache });
+
   if (resetCache === true) {
     logger.debug('rivescript cache clear');
     return module.exports.fetchRivescripts();
   }
+
   const cache = await helpers.cache.rivescript.get(cacheKey);
+
   if (cache) {
     logger.debug('rivescript cache hit');
+
     return cache;
   }
+
   logger.debug('rivescript cache miss');
+
   return module.exports.fetchRivescripts();
 }
 
@@ -95,7 +101,9 @@ function isAskMultipleChoice(trigger) {
  */
 async function fetchRivescripts() {
   const conversationTriggers = await graphql.fetchConversationTriggers();
+
   logger.debug('fetchConversationTriggers success', { count: conversationTriggers.length });
+
   const transformedTriggers = conversationTriggers
     .map(module.exports.defaultTopicTriggerTransformer);
 

--- a/lib/middleware/rivescript/index.js
+++ b/lib/middleware/rivescript/index.js
@@ -34,11 +34,11 @@ module.exports = function getRivescript() {
 
            const current = data.topics[rivescriptTopicName][index];
 
-           current.reply = macro ? macro.text : replyText;
+           current.reply = macro ? [macro.text] : [replyText];
            current.macroName = macro ? macro.name : null;
 
            const dynamicTrigger = dynamicTriggers.find(item => item.trigger === current.trigger);
-  
+
            current.hardcoded = !dynamicTrigger;
         });
       });

--- a/lib/middleware/rivescript/index.js
+++ b/lib/middleware/rivescript/index.js
@@ -7,16 +7,31 @@ module.exports = function getRivescript() {
   return async (req, res) => {
     try {
       const resetCache = req.query.cache === 'false';
+
       if (resetCache === true || !helpers.rivescript.isBotReady()) {
         await helpers.rivescript.loadBot(resetCache);
       } else {
         const isCurrent = helpers.rivescript.isRivescriptCurrent();
+
         if (!isCurrent) {
           await helpers.rivescript.loadBot();
         }
       }
+
       const data = helpers.rivescript.getDeparsedRivescript();
+
       logger.debug('data.topics.random', { count: data.topics.random.length });
+
+      Object.keys(data.topics).forEach((rivescriptTopicName) => {
+        data.topics[rivescriptTopicName].forEach((rivescriptTopicTrigger, index) => {
+           const replyText = rivescriptTopicTrigger.reply[0];
+           const macro = helpers.macro.getMacro(replyText);
+
+           data.topics[rivescriptTopicName][index].reply = macro ? macro.text : replyText;
+           data.topics[rivescriptTopicName][index].macroName = macro ? macro.name : null;
+        });
+      });
+
       return res.send({ data });
     } catch (err) {
       return helpers.sendErrorResponse(res, err);

--- a/lib/middleware/rivescript/index.js
+++ b/lib/middleware/rivescript/index.js
@@ -2,6 +2,7 @@
 
 const helpers = require('../../helpers');
 const logger = require('../../logger');
+const graphql = require('../../graphql');
 
 module.exports = function getRivescript() {
   return async (req, res) => {
@@ -18,6 +19,10 @@ module.exports = function getRivescript() {
         }
       }
 
+      const dynamicTriggers = await graphql.fetchConversationTriggers();
+
+      console.log(dynamicTriggers);
+
       const data = helpers.rivescript.getDeparsedRivescript();
 
       logger.debug('data.topics.random', { count: data.topics.random.length });
@@ -27,8 +32,14 @@ module.exports = function getRivescript() {
            const replyText = rivescriptTopicTrigger.reply[0];
            const macro = helpers.macro.getMacro(replyText);
 
-           data.topics[rivescriptTopicName][index].reply = macro ? macro.text : replyText;
-           data.topics[rivescriptTopicName][index].macroName = macro ? macro.name : null;
+           const current = data.topics[rivescriptTopicName][index];
+
+           current.reply = macro ? macro.text : replyText;
+           current.macroName = macro ? macro.name : null;
+
+           const dynamicTrigger = dynamicTriggers.find(item => item.trigger === current.trigger);
+  
+           current.hardcoded = !dynamicTrigger;
         });
       });
 

--- a/lib/middleware/rivescript/index.js
+++ b/lib/middleware/rivescript/index.js
@@ -1,8 +1,9 @@
 'use strict';
 
-const helpers = require('../../helpers');
-const logger = require('../../logger');
+const lodash = require('lodash');
+
 const graphql = require('../../graphql');
+const helpers = require('../../helpers');
 
 module.exports = function getRivescript() {
   return async (req, res) => {
@@ -11,35 +12,26 @@ module.exports = function getRivescript() {
 
       if (resetCache === true || !helpers.rivescript.isBotReady()) {
         await helpers.rivescript.loadBot(resetCache);
-      } else {
-        const isCurrent = helpers.rivescript.isRivescriptCurrent();
-
-        if (!isCurrent) {
-          await helpers.rivescript.loadBot();
-        }
+      } else if (!helpers.rivescript.isRivescriptCurrent()) {
+        await helpers.rivescript.loadBot();
       }
 
       const dynamicTriggers = await graphql.fetchConversationTriggers();
 
-      console.log(dynamicTriggers);
-
       const data = helpers.rivescript.getDeparsedRivescript();
 
-      logger.debug('data.topics.random', { count: data.topics.random.length });
-
       Object.keys(data.topics).forEach((rivescriptTopicName) => {
-        data.topics[rivescriptTopicName].forEach((rivescriptTopicTrigger, index) => {
-           const replyText = rivescriptTopicTrigger.reply[0];
-           const macro = helpers.macro.getMacro(replyText);
+        data.topics[rivescriptTopicName].forEach((rivescriptTopicTrigger) => {
+          const replyText = rivescriptTopicTrigger.reply[0];
+          const macro = helpers.macro.getMacro(replyText);
+          const dynamicTrigger = dynamicTriggers
+            .find(item => item.trigger === rivescriptTopicTrigger.trigger);
 
-           const current = data.topics[rivescriptTopicName][index];
-
-           current.reply = macro ? [macro.text] : [replyText];
-           current.macroName = macro ? macro.name : null;
-
-           const dynamicTrigger = dynamicTriggers.find(item => item.trigger === current.trigger);
-
-           current.hardcoded = !dynamicTrigger;
+          lodash.assignIn(rivescriptTopicTrigger, {
+            reply: macro ? [macro.text] : [replyText],
+            macro: macro ? macro.name : null,
+            hardcoded: !dynamicTrigger,
+          });
         });
       });
 

--- a/lib/middleware/rivescript/index.js
+++ b/lib/middleware/rivescript/index.js
@@ -30,7 +30,7 @@ module.exports = function getRivescript() {
           lodash.assignIn(rivescriptTopicTrigger, {
             reply: macro ? [macro.text] : [replyText],
             macro: macro ? macro.name : null,
-            hardcoded: !dynamicTrigger,
+            contentfulId: dynamicTrigger ? dynamicTrigger.id : null,
           });
         });
       });

--- a/lib/middleware/rivescript/index.js
+++ b/lib/middleware/rivescript/index.js
@@ -24,10 +24,8 @@ module.exports = function getRivescript() {
         data.topics[rivescriptTopicName].forEach((rivescriptTopicTrigger) => {
           const replyText = rivescriptTopicTrigger.reply[0];
           const macro = helpers.macro.getMacro(replyText);
-          // If we're in the random topic, this trigger may be sourced from GraphQL.
-          const dynamicTrigger = rivescriptTopicName === helpers.topic.getDefaultTopicId()
-            ? dynamicTriggers.find(item => item.trigger === rivescriptTopicTrigger.trigger)
-            : null;
+          const dynamicTrigger = dynamicTriggers
+            .find(item => item.trigger === rivescriptTopicTrigger.trigger);
 
           lodash.assignIn(rivescriptTopicTrigger, {
             reply: macro ? [macro.text] : [replyText],

--- a/lib/middleware/rivescript/index.js
+++ b/lib/middleware/rivescript/index.js
@@ -24,8 +24,10 @@ module.exports = function getRivescript() {
         data.topics[rivescriptTopicName].forEach((rivescriptTopicTrigger) => {
           const replyText = rivescriptTopicTrigger.reply[0];
           const macro = helpers.macro.getMacro(replyText);
-          const dynamicTrigger = dynamicTriggers
-            .find(item => item.trigger === rivescriptTopicTrigger.trigger);
+          // If we're in the random topic, this trigger may be sourced from GraphQL.
+          const dynamicTrigger = rivescriptTopicName === helpers.topic.getDefaultTopicId()
+            ? dynamicTriggers.find(item => item.trigger === rivescriptTopicTrigger.trigger)
+            : null;
 
           lodash.assignIn(rivescriptTopicTrigger, {
             reply: macro ? [macro.text] : [replyText],


### PR DESCRIPTION
#### What's this PR do?

This PR surfaces whether a topic trigger loaded in the RiveScript bot corresponds to a macro (via new `macro` string property), and its Contentful entry ID if defined in Contentful (via new `contentfulId` string property).

#### How should this be reviewed?

You can spot check the data returned for `topics` in a `GET /rivescript` response. Triggers like `INFO` should have the rendered macro text set for the `reply`, property. The former value, `sendInfoMessage` will now be set as the `macro`. 

#### Any background context you want to provide?

This will be used to provide more info in Gambit Admin about what reply text is used for macros, as well as whether a given trigger is editable in Contentful.

#### Relevant tickets

Refs Pivotal [#174231934](https://www.pivotaltracker.com/n/projects/2401401/stories/174231934)

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tests added/updated for new features/bug fixes.
- [ ] ENV variables added/updated for new features/bug fixes.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
