### PR TITLE
Adds support for hours_spent field on Posts

### DIFF
--- a/app/routes/messages/member.js
+++ b/app/routes/messages/member.js
@@ -34,6 +34,7 @@ const createDraftPhotoPostMiddleware = require('../../../lib/middleware/messages
 const draftQuantityPhotoPostMiddleware = require('../../../lib/middleware/messages/member/topics/posts/photo/draft-quantity');
 const draftPhotoPhotoPostMiddleware = require('../../../lib/middleware/messages/member/topics/posts/photo/draft-photo');
 const draftCaptionPhotoPostMiddleware = require('../../../lib/middleware/messages/member/topics/posts/photo/draft-caption');
+const draftHoursSpentPhotoPostMiddleware = require('../../../lib/middleware/messages/member/topics/posts/photo/draft-hours-spent');
 const draftWhyParticipatedPhotoPostMiddleware = require('../../../lib/middleware/messages/member/topics/posts/photo/draft-why-participated');
 const createPhotoPostMiddleware = require('../../../lib/middleware/messages/member/topics/posts/photo/post-create');
 const createTextPostMiddleware = require('../../../lib/middleware/messages/member/topics/posts/text/post-create');
@@ -105,6 +106,7 @@ router.use(createDraftPhotoPostMiddleware());
 router.use(draftQuantityPhotoPostMiddleware());
 router.use(draftPhotoPhotoPostMiddleware());
 router.use(draftCaptionPhotoPostMiddleware());
+router.use(draftHoursSpentPhotoPostMiddleware());
 router.use(draftWhyParticipatedPhotoPostMiddleware());
 router.use(createPhotoPostMiddleware());
 

--- a/config/lib/graphql.js
+++ b/config/lib/graphql.js
@@ -1,5 +1,14 @@
 'use strict';
 
+const actionFields = `
+  action {
+    id
+    name
+    campaignId
+    volunteerCredit
+  }
+`;
+
 const campaignFields = `
   legacyCampaign {
     campaignId
@@ -55,19 +64,12 @@ const campaignTopicFragments = `
   }
   fragment photoPostCampaign on PhotoPostTopic {
     actionId
+    ${actionFields}
     ${campaignFields}
   }
   fragment textPostCampaign on TextPostTopic {
     actionId
     ${campaignFields}
-  }
-`;
-
-const actionFields = `
-  action {
-    id
-    name
-    campaignId
   }
 `;
 

--- a/config/lib/helpers/replies.js
+++ b/config/lib/helpers/replies.js
@@ -10,6 +10,10 @@ const supportText = `Text ${commands.support} if you have a question.`;
 
 // Static Templates
 module.exports = {
+  askHoursSpent: {
+    name: 'askHoursSpent',
+    text: 'How many hours did this action take?'
+  },
   badWords: {
     name: 'badWords',
     text: `Not cool. I'm a real person & that offends me. I send out these texts to help young ppl take action. If you don't want my texts, text ${commands.stop} or ${commands.less} to get less.`,
@@ -17,6 +21,10 @@ module.exports = {
   campaignClosed: {
     name: 'campaignClosed',
     text: process.env.GAMBIT_CONVERSATIONS_CAMPAIGN_CLOSED_TEXT || `Sorry, this campaign is no longer available. ${supportText}`,
+  },
+  invalidHoursSpent: {
+    name: 'invalidHoursSpent',
+    text: `Whoops, I didn't understand that. How many hours did this action take? Be sure to text in a number, not a word (i.e. “4”, not “four”)`
   },
   noCampaign: {
     name: 'noCampaign',

--- a/config/lib/helpers/replies.js
+++ b/config/lib/helpers/replies.js
@@ -12,7 +12,7 @@ const supportText = `Text ${commands.support} if you have a question.`;
 module.exports = {
   askHoursSpent: {
     name: 'askHoursSpent',
-    text: 'How many hours did this action take?'
+    text: 'How many hours did this action take?',
   },
   badWords: {
     name: 'badWords',
@@ -24,7 +24,7 @@ module.exports = {
   },
   invalidHoursSpent: {
     name: 'invalidHoursSpent',
-    text: `Whoops, I didn't understand that. How many hours did this action take? Be sure to text in a number, not a word (i.e. “4”, not “four”)`
+    text: 'Whoops, I didn\'t understand that. How many hours did this action take? Be sure to text in a number, not a word (i.e. “4”, not “four”)',
   },
   noCampaign: {
     name: 'noCampaign',

--- a/config/lib/helpers/topic.js
+++ b/config/lib/helpers/topic.js
@@ -28,6 +28,7 @@ module.exports = {
       transitionTemplate: topicTemplates.startPhotoPost,
       draftSubmissionValuesMap: {
         caption: 'caption',
+        hoursSpent: 'hoursSpent',
         quantity: 'quantity',
         url: 'url',
         whyParticipated: 'whyParticipated',

--- a/lib/helpers/replies.js
+++ b/lib/helpers/replies.js
@@ -164,8 +164,13 @@ module.exports.startPhotoPostAutoReply = function (req, res) {
 };
 
 module.exports.sendReplyWithStaticTemplate = function (req, res, templateName) {
-  const text = config[templateName].text;
+  const { text } = config[templateName];
+
   return exports.sendReply(req, res, text, templateName);
+};
+
+module.exports.askHoursSpent = function (req, res) {
+  return exports.sendReplyWithStaticTemplate(req, res, 'askHoursSpent');
 };
 
 module.exports.badWords = function (req, res) {
@@ -174,6 +179,10 @@ module.exports.badWords = function (req, res) {
 
 module.exports.campaignClosed = function (req, res) {
   return exports.sendReplyWithStaticTemplate(req, res, 'campaignClosed');
+};
+
+module.exports.invalidHoursSpent = function (req, res) {
+  return exports.sendReplyWithStaticTemplate(req, res, 'invalidHoursSpent');
 };
 
 module.exports.noCampaign = function (req, res) {

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -259,6 +259,14 @@ function isTextPostConfig(topic) {
 }
 
 /**
+ * @param {Object} topic
+ * @return {Boolean}
+ */
+function isVolunteerCredit(topic) {
+  return lodash.get(topic, 'action.volunteerCredit', false);
+}
+
+/**
  * @param {String} topicId
  * @return {Boolean}
  */
@@ -289,4 +297,5 @@ module.exports = {
   isPhotoPostConfig,
   isRivescriptTopicId,
   isTextPostConfig,
+  isVolunteerCredit,
 };

--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -43,21 +43,29 @@ async function createSignup(user, campaign, signupSource, signupSourceDetails) {
  */
 async function createPhotoPost({ userId, actionId, photoPostSource, photoPostValues, location }) {
   const payload = {
-    northstar_id: userId,
     action_id: actionId,
+    northstar_id: userId,
     quantity: photoPostValues.quantity,
     source: photoPostSource,
     text: photoPostValues.caption,
     type: config.posts.photo.type,
   };
+
+  if (photoPostValues.hoursSpent) {
+    payload.hours_spent = photoPostValues.hoursSpent;
+  }
+
   if (location) {
     payload.location = location;
   }
+
   if (photoPostValues.whyParticipated) {
     payload.why_participated = photoPostValues.whyParticipated;
   }
+
   // log payload before fetching image.
   logger.debug('createPhotoPost payload', { payload });
+
   payload[gatewayClientConfig.photoPostCreation.fileProperty] = await helpers.util
     .fetchImageFileFromUrl(photoPostValues.url);
 

--- a/lib/middleware/messages/member/topics/posts/photo/draft-caption.js
+++ b/lib/middleware/messages/member/topics/posts/photo/draft-caption.js
@@ -3,9 +3,7 @@
 const helpers = require('../../../../../../helpers');
 
 /**
- * This middleware is step 3 of 4 for photo post creation: saving caption to draft.
- *
- * Upon saving caption to draft, moves to step 4 to save or skip whyParticipated.
+ * Upon saving caption to draft, check whether to ask for hours spent or why participated.
  */
 const captionKey = helpers.topic.getPhotoPostDraftSubmissionValuesMap().caption;
 
@@ -22,6 +20,10 @@ module.exports = function draftCaption() {
 
       if (helpers.util.isValidTextFieldValue(req.inboundMessageText)) {
         await helpers.request.saveDraftSubmissionValue(req, captionKey, req.inboundMessageText);
+
+        if (helpers.topic.isVolunteerCredit(req.topic)) {
+          return await helpers.replies.askHoursSpent(req, res);
+        }
 
         if (await helpers.request.hasSignupWithWhyParticipated(req)) {
           return next();

--- a/lib/middleware/messages/member/topics/posts/photo/draft-hours-spent.js
+++ b/lib/middleware/messages/member/topics/posts/photo/draft-hours-spent.js
@@ -23,7 +23,6 @@ module.exports = function draftHoursSent() {
         return next();
       }
 
-      // TODO: Handle decimal support?
       const hoursSpentValue = Number(req.inboundMessageText);
 
       if (!hoursSpentValue) {

--- a/lib/middleware/messages/member/topics/posts/photo/draft-hours-spent.js
+++ b/lib/middleware/messages/member/topics/posts/photo/draft-hours-spent.js
@@ -4,7 +4,7 @@ const helpers = require('../../../../../../helpers');
 
 const key = helpers.topic.getPhotoPostDraftSubmissionValuesMap().hoursSpent;
 
-module.exports = function askHoursSent() {
+module.exports = function draftHoursSent() {
   return async (req, res, next) => {
     try {
       if (!helpers.topic.isPhotoPostConfig(req.topic)) {
@@ -17,14 +17,13 @@ module.exports = function askHoursSent() {
         return next();
       }
 
-      if (helpers.util.isValidTextFieldValue(req.inboundMessageText)) {
-        await helpers.request.saveDraftSubmissionValue(req, key, req.inboundMessageText);
+      // TODO: Cast as decimal?
+      const hoursSpentValue = Number(req.inboundMessageText);
 
-        if (await helpers.request.hasSignupWithWhyParticipated(req)) {
-          return next();
-        }
+      if (hoursSpent) {
+        await helpers.request.saveDraftSubmissionValue(req, key, hoursSpentValue);
 
-        return await helpers.replies.askWhyParticipated(req, res);
+        return await helpers.replies.askPhoto(req, res);
       }
 
       return await helpers.replies.invalidCaption(req, res);

--- a/lib/middleware/messages/member/topics/posts/photo/draft-hours-spent.js
+++ b/lib/middleware/messages/member/topics/posts/photo/draft-hours-spent.js
@@ -25,7 +25,7 @@ module.exports = function draftHoursSent() {
 
       const hoursSpentValue = Number(req.inboundMessageText);
 
-      if (!hoursSpentValue) {
+      if (!hoursSpentValue || hoursSpentValue > 999999) {
         return await helpers.replies.invalidHoursSpent(req, res);
       }
 

--- a/lib/middleware/messages/member/topics/posts/photo/draft-hours-spent.js
+++ b/lib/middleware/messages/member/topics/posts/photo/draft-hours-spent.js
@@ -2,7 +2,10 @@
 
 const helpers = require('../../../../../../helpers');
 
-const key = helpers.topic.getPhotoPostDraftSubmissionValuesMap().hoursSpent;
+/**
+ * Upon saving hours spent to draft, check whether to ask for why participated.
+ */
+const hoursSpentKey = helpers.topic.getPhotoPostDraftSubmissionValuesMap().hoursSpent;
 
 module.exports = function draftHoursSent() {
   return async (req, res, next) => {
@@ -11,22 +14,29 @@ module.exports = function draftHoursSent() {
         return next();
       }
 
-      // TODO: Check if the topic action counts for volunteer credit.
-
-      if (helpers.request.hasDraftSubmissionValue(req, key)) {
+      // If this action is not volunteer credit, no need to collect hours spent.
+      if (!helpers.topic.isVolunteerCredit(req.topic)) {
         return next();
       }
 
-      // TODO: Cast as decimal?
-      const hoursSpentValue = Number(req.inboundMessageText);
-
-      if (hoursSpent) {
-        await helpers.request.saveDraftSubmissionValue(req, key, hoursSpentValue);
-
-        return await helpers.replies.askPhoto(req, res);
+      if (helpers.request.hasDraftSubmissionValue(req, hoursSpentKey)) {
+        return next();
       }
 
-      return await helpers.replies.invalidCaption(req, res);
+      // TODO: Handle decimal support?
+      const hoursSpentValue = Number(req.inboundMessageText);
+
+      if (!hoursSpentValue) {
+        return await helpers.replies.invalidHoursSpent(req, res);
+      }
+
+      await helpers.request.saveDraftSubmissionValue(req, hoursSpentKey, hoursSpentValue);
+
+      if (await helpers.request.hasSignupWithWhyParticipated(req)) {
+        return next();
+      }
+
+      return await helpers.replies.askWhyParticipated(req, res);
     } catch (err) {
       return helpers.sendErrorResponse(res, err);
     }

--- a/lib/middleware/messages/member/topics/posts/photo/draft-hours-spent.js
+++ b/lib/middleware/messages/member/topics/posts/photo/draft-hours-spent.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const helpers = require('../../../../../../helpers');
+
+const key = helpers.topic.getPhotoPostDraftSubmissionValuesMap().hoursSpent;
+
+module.exports = function askHoursSent() {
+  return async (req, res, next) => {
+    try {
+      if (!helpers.topic.isPhotoPostConfig(req.topic)) {
+        return next();
+      }
+
+      // TODO: Check if the topic action counts for volunteer credit.
+
+      if (helpers.request.hasDraftSubmissionValue(req, key)) {
+        return next();
+      }
+
+      if (helpers.util.isValidTextFieldValue(req.inboundMessageText)) {
+        await helpers.request.saveDraftSubmissionValue(req, key, req.inboundMessageText);
+
+        if (await helpers.request.hasSignupWithWhyParticipated(req)) {
+          return next();
+        }
+
+        return await helpers.replies.askWhyParticipated(req, res);
+      }
+
+      return await helpers.replies.invalidCaption(req, res);
+    } catch (err) {
+      return helpers.sendErrorResponse(res, err);
+    }
+  };
+};

--- a/lib/middleware/messages/member/topics/posts/photo/draft-photo.js
+++ b/lib/middleware/messages/member/topics/posts/photo/draft-photo.js
@@ -3,9 +3,7 @@
 const helpers = require('../../../../../../helpers');
 
 /**
- * This middleware is step 2 of 4 for photo post creation: saving url to draft.
- *
- * Upon saving url to draft, moves to step 3 to ask for a caption.
+ * Upon saving url to draft, asks for a caption.
  */
 const urlKey = helpers.topic.getPhotoPostDraftSubmissionValuesMap().url;
 
@@ -22,6 +20,7 @@ module.exports = function draftPhoto() {
 
       if (req.mediaUrl) {
         await helpers.request.saveDraftSubmissionValue(req, urlKey, req.mediaUrl);
+
         return await helpers.replies.askCaption(req, res);
       }
 

--- a/lib/middleware/messages/member/topics/posts/photo/draft-quantity.js
+++ b/lib/middleware/messages/member/topics/posts/photo/draft-quantity.js
@@ -22,10 +22,13 @@ module.exports = function draftQuantity() {
       }
 
       const quantity = Number(req.inboundMessageText);
+
       if (quantity) {
         await helpers.request.saveDraftSubmissionValue(req, quantityKey, quantity);
+
         return await helpers.replies.askPhoto(req, res);
       }
+
       return await helpers.replies.invalidQuantity(req, res);
     } catch (err) {
       return helpers.sendErrorResponse(res, err);

--- a/lib/middleware/messages/member/topics/posts/photo/draft-quantity.js
+++ b/lib/middleware/messages/member/topics/posts/photo/draft-quantity.js
@@ -3,10 +3,7 @@
 const helpers = require('../../../../../../helpers');
 
 /**
- * This middleware is step 1 of 4 for photo post creation: saving quantity to draft. We ask
- * this question first to ask them next for a photo, asking to prove they really did {{quantity}}.
- *
- * Upon saving quantity to draft, moves to step 2 to ask for a photo.
+ * Upon saving quantity to draft, asks for a photo.
  */
 const quantityKey = helpers.topic.getPhotoPostDraftSubmissionValuesMap().quantity;
 

--- a/lib/middleware/messages/member/topics/posts/photo/draft-why-participated.js
+++ b/lib/middleware/messages/member/topics/posts/photo/draft-why-participated.js
@@ -4,7 +4,7 @@ const helpers = require('../../../../../../helpers');
 const logger = require('../../../../../../logger');
 
 /**
- * Saves whyParticipated to draft if it doesn't exist.
+ * Saves why participated to draft if it doesn't exist.
  * Calls next to submit a photo post with the completed draft values.
  */
 const whyParticipatedKey = helpers.topic.getPhotoPostDraftSubmissionValuesMap().whyParticipated;

--- a/lib/middleware/messages/member/topics/posts/photo/draft-why-participated.js
+++ b/lib/middleware/messages/member/topics/posts/photo/draft-why-participated.js
@@ -4,9 +4,7 @@ const helpers = require('../../../../../../helpers');
 const logger = require('../../../../../../logger');
 
 /**
- * This middleware is step 4 of 4 for photo post creation: saving whyParticipated to draft, but only
- * if a value doesn't exist on the user's signup for the campaign.
- *
+ * Saves whyParticipated to draft if it doesn't exist.
  * Calls next to submit a photo post with the completed draft values.
  */
 const whyParticipatedKey = helpers.topic.getPhotoPostDraftSubmissionValuesMap().whyParticipated;


### PR DESCRIPTION
#### What's this PR do?

This PR asks a member to provide an `hours_spent` value when reporting back via photo for an action that counts as volunteer credit. It adds new static replies, `askHoursSpent` and `invalidHoursSpent`.

#### How should this be reviewed?

* Test with the `mask` keyword to verify that `hours_spent` is collected and saved to your photo post.
* Test with the `greener` keyword to verify that `hours_spent` is not collected.

#### Any background context you want to provide?

There's an unexpected bug where we're asking `why_participated` each time a user reports back on a photo post -- expected behavior is that user should only be asked for `why_participated` for the first photo post on the action. There's a [thread here](https://dosomething.slack.com/archives/CUQMU4Q6B/p1610497494009900) about what looks like a Rogue bug -- but also seems like it's not a high priority issue per this [Slack thread](https://dosomething.slack.com/archives/C03T8SDMS/p1610563126003800).

#### Relevant tickets

[#176368428](https://www.pivotaltracker.com/story/show/176368428)


#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tests added/updated for new features/bug fixes.
- [ ] ENV variables added/updated for new features/bug fixes.
- [x] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
