### PR TITLE
Removes npm key from engines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   # Install dependencies & run tests.
   build:
     docker:
-      - image: circleci/node:12.20.1
+      - image: circleci/node:12.20
       - image: circleci/mongo:3.6.21
       - image: circleci/redis
     steps:

--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
     ]
   },
   "engines": {
-    "node": "12.20.1",
-    "npm": "6.9.0"
+    "node": "12.20.1"
   },
   "dependencies": {
     "@dosomething/gateway": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     ]
   },
   "engines": {
-    "node": "12.20.1"
+    "node": "12.x"
   },
   "dependencies": {
     "@dosomething/gateway": "^2.0.1",


### PR DESCRIPTION
### What's this PR do?

This pull request follows instructions in [this Heroku article](https://help.heroku.com/ZV7S7D6T/why-is-my-node-build-is-suddenly-displaying-npm-err-cb-apply-is-not-a-function) to avoid the ` npm ERR! cb.apply is not a function` error that occurred when trying to build #547 

### How should this be reviewed?

👀 

### Any background context you want to provide?

🚑 

### Relevant tickets

References [Pivotal #176647327](https://www.pivotaltracker.com/story/show/176647327).

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tests added/updated for new features/bug fixes.
- [ ] ENV variables added/updated for new features/bug fixes.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
