### PR TITLE
Inspect action.campaign for photo/text post topics

### DIFF
--- a/config/lib/graphql.js
+++ b/config/lib/graphql.js
@@ -4,8 +4,14 @@ const actionFields = `
   action {
     id
     name
-    campaignId
     volunteerCredit
+
+    campaignId
+    campaign {
+      id
+      endDate
+      internalTitle
+    }
   }
 `;
 
@@ -65,11 +71,10 @@ const campaignTopicFragments = `
   fragment photoPostCampaign on PhotoPostTopic {
     actionId
     ${actionFields}
-    ${campaignFields}
   }
   fragment textPostCampaign on TextPostTopic {
     actionId
-    ${campaignFields}
+    ${actionFields}
   }
 `;
 

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const lodash = require('lodash');
+
 const helpers = require('../helpers');
 const logger = require('../logger');
 const analytics = require('./analytics');
@@ -324,10 +326,7 @@ function saveDraftSubmissionValue(req, key, value) {
 function setCampaign(req, campaign) {
   req.campaign = campaign;
   analytics.addCustomAttributes({ campaign });
-  /**
-   * TODO: If we remove the campaign field in contentful for some topics. We will have to
-   * tell GraphQL to fetch it from Rogue based on the action Id?
-   */
+
   if (campaign && campaign.id) {
     module.exports.setCampaignId(req, campaign.id);
   }
@@ -383,9 +382,12 @@ function setMacro(req, macro) {
 function setTopic(req, topic) {
   req.topic = topic;
   analytics.addCustomAttributes({ topicId: topic.id });
-  if (topic.campaign) {
-    module.exports.setCampaign(req, topic.campaign);
-  }
+
+
+  module.exports.setCampaign(
+    req,
+    lodash.get(topic, 'action.campaign', null) || topic.campaign,
+  );
 }
 
 /**

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -383,7 +383,6 @@ function setTopic(req, topic) {
   req.topic = topic;
   analytics.addCustomAttributes({ topicId: topic.id });
 
-
   module.exports.setCampaign(
     req,
     lodash.get(topic, 'action.campaign', null) || topic.campaign,

--- a/test/unit/lib/lib-helpers/request.test.js
+++ b/test/unit/lib/lib-helpers/request.test.js
@@ -611,16 +611,7 @@ test('setTopic should inject a topic property to req and call setCampaign if top
   requestHelper.setCampaign.should.have.been.calledWith(t.context.req, topic.campaign);
 });
 
-test('setTopic should not call setCampaign if topic.campaign undefined', (t) => {
-  sandbox.spy(requestHelper, 'setCampaign');
-  const campaignlessTopic = topicFactory.getValidTopic();
-  campaignlessTopic.campaign = null;
-  requestHelper.setTopic(t.context.req, campaignlessTopic);
-  t.context.req.topic.should.equal(campaignlessTopic);
-  helpers.analytics.addCustomAttributes
-    .should.have.been.calledWith({ topicId: campaignlessTopic.id });
-  requestHelper.setCampaign.should.not.have.been.called;
-});
+// TODO: Add test for topic.action and setting campaign.
 
 // setUserId
 test('setUserId should inject a userId property to req', (t) => {


### PR DESCRIPTION
### What's this PR do?

This pull request modifies the request helper to first check for whether a topic has an action set per new changes in https://github.com/DoSomething/graphql/pull/320.

If the topic does have an action set, use the nested action.campaign to set the `req.campaign` for the request. We'll eventually be removing the `campaign` reference field from the photo/text post topic content types, as it's redundant.

### How should this be reviewed?

👀 

### Any background context you want to provide?

Once this is in place, we can remove the `campaign` reference field from the `TextPostTopic` and `PhotoPostTopic` GraphQL types, and delete the reference field in Contentful.

### Relevant tickets

References [Pivotal #176602032](https://www.pivotaltracker.com/story/show/176602032).

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tests added/updated for new features/bug fixes.
- [ ] ENV variables added/updated for new features/bug fixes.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
