### PR TITLE
Adds broadcastLite route for Northstarless broadcasts

### DIFF
--- a/app/routes/messages/broadcast-lite.js
+++ b/app/routes/messages/broadcast-lite.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const express = require('express');
+
+const router = express.Router();
+
+// Middleware configs
+const outboundMessageConfig = require('../../../config/lib/middleware/messages/message-outbound');
+
+// Middleware
+const paramsMiddleware = require('../../../lib/middleware/messages/broadcast-lite/params');
+const getBroadcastMiddleware = require('../../../lib/middleware/messages/broadcast/broadcast-get');
+const parseBroadcastMiddleware = require('../../../lib/middleware/messages/broadcast/broadcast-parse');
+const validateOutboundMessageMiddleware = require('../../../lib/middleware/messages/message-outbound-validate');
+const getConversationMiddleware = require('../../../lib/middleware/messages/conversation-get');
+const createConversationMiddleware = require('../../../lib/middleware/messages/conversation-create');
+const updateConversationMiddleware = require('../../../lib/middleware/messages/broadcast/conversation-update');
+const loadOutboundMessageMiddleware = require('../../../lib/middleware/messages/message-outbound-load');
+const createOutboundMessageMiddleware = require('../../../lib/middleware/messages/message-outbound-create');
+const sendOutboundMessageMiddleware = require('../../../lib/middleware/messages/message-outbound-send');
+
+router.use(paramsMiddleware());
+router.use(getBroadcastMiddleware());
+router.use(parseBroadcastMiddleware());
+
+router.use(validateOutboundMessageMiddleware(outboundMessageConfig));
+
+router.use(getConversationMiddleware());
+router.use(createConversationMiddleware());
+router.use(updateConversationMiddleware());
+
+router.use(loadOutboundMessageMiddleware(outboundMessageConfig));
+router.use(createOutboundMessageMiddleware(outboundMessageConfig));
+router.use(sendOutboundMessageMiddleware());
+
+module.exports = router;

--- a/app/routes/messages/index.js
+++ b/app/routes/messages/index.js
@@ -7,6 +7,7 @@ const router = express.Router();
 
 const analyticsHelper = require('../../../lib/helpers/analytics');
 const broadcastMessagesRoute = require('./broadcast');
+const broadcastLiteMessagesRoute = require('./broadcast-lite');
 const frontMessagesRoute = require('./front');
 const memberMessagesRoute = require('./member');
 const subscriptionStatusActiveRoute = require('./subscription-status-active');
@@ -26,6 +27,10 @@ router.post('/', (req, res, next) => {
   switch (origin) {
     case 'broadcast':
       broadcastMessagesRoute(req, res, next);
+      break;
+
+    case 'broadcastLite':
+      broadcastLiteMessagesRoute(req, res, next);
       break;
 
     case 'front':

--- a/lib/middleware/messages/broadcast-lite/params.js
+++ b/lib/middleware/messages/broadcast-lite/params.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const logger = require('../../../logger');
+const helpers = require('../../../helpers');
+const UnprocessableEntityError = require('../../../../app/exceptions/UnprocessableEntityError');
+
+/**
+ * sendMissingFieldError
+ *
+ * @param {Response} res
+ * @param {String} field
+ */
+function sendMissingFieldError(res, field) {
+  return helpers.sendErrorResponse(res, new UnprocessableEntityError(`Missing required ${field}`));
+}
+
+module.exports = function params() {
+  return (req, res, next) => {
+    logger.debug('origin=broadcastLite', { params: req.body }, req);
+
+    const {
+      addrState,
+      broadcastId,
+      mobile,
+      platform,
+      smsStatus,
+      userId,
+    } = req.body;
+
+    if (!broadcastId) {
+      return sendMissingFieldError(res, 'broadcastId');
+    }
+
+    if (!mobile) {
+      return sendMissingFieldError(res, 'mobile');
+    }
+
+    if (!userId) {
+      return sendMissingFieldError(res, 'userId');
+    }
+
+    helpers.request.setBroadcastId(req, broadcastId);
+
+    /**
+     * Construct a Northstar user based on our request parameters.
+     * TODO: Add voting plan fields.
+     */
+    helpers.request.setUser(req, {
+      addr_state: addrState,
+      id: userId,
+      mobile,
+      sms_status: smsStatus,
+    });
+
+    helpers.request.setPlatform(req, platform);
+
+    return next();
+  };
+};

--- a/lib/middleware/messages/broadcast-lite/params.js
+++ b/lib/middleware/messages/broadcast-lite/params.js
@@ -16,13 +16,7 @@ module.exports = function params() {
       'smsStatus',
       'userId',
     ];
-    const missingFields = [];
-
-    requiredFields.forEach((fieldName) => {
-      if (!body[fieldName]) {
-        missingFields.push(fieldName);
-      }
-    });
+    const missingFields = requiredFields.filter(fieldName => !body[fieldName]);
 
     if (missingFields.length) {
       const errorMessage = `Missing required fields: ${missingFields.join(', ')}`;

--- a/lib/middleware/messages/broadcast-lite/params.js
+++ b/lib/middleware/messages/broadcast-lite/params.js
@@ -4,19 +4,31 @@ const logger = require('../../../logger');
 const helpers = require('../../../helpers');
 const UnprocessableEntityError = require('../../../../app/exceptions/UnprocessableEntityError');
 
-/**
- * sendMissingFieldError
- *
- * @param {Response} res
- * @param {String} field
- */
-function sendMissingFieldError(res, field) {
-  return helpers.sendErrorResponse(res, new UnprocessableEntityError(`Missing required ${field}`));
-}
-
 module.exports = function params() {
   return (req, res, next) => {
-    logger.debug('origin=broadcastLite', { params: req.body }, req);
+    const { body } = req;
+
+    logger.debug('origin=broadcastLite', { params: body }, req);
+
+    const requiredFields = [
+      'broadcastId',
+      'mobile',
+      'smsStatus',
+      'userId',
+    ];
+    const missingFields = [];
+
+    requiredFields.forEach((fieldName) => {
+      if (!body[fieldName]) {
+        missingFields.push(fieldName);
+      }
+    });
+
+    if (missingFields.length) {
+      const errorMessage = `Missing required fields: ${missingFields.join(', ')}`;
+
+      return helpers.sendErrorResponse(res, new UnprocessableEntityError(errorMessage));
+    }
 
     const {
       addrState,
@@ -25,22 +37,10 @@ module.exports = function params() {
       platform,
       smsStatus,
       userId,
-    } = req.body;
-
-    if (!broadcastId) {
-      return sendMissingFieldError(res, 'broadcastId');
-    }
-
-    if (!mobile) {
-      return sendMissingFieldError(res, 'mobile');
-    }
-
-    if (!userId) {
-      return sendMissingFieldError(res, 'userId');
-    }
+    } = body;
 
     helpers.request.setBroadcastId(req, broadcastId);
-
+    helpers.request.setPlatform(req, platform);
     /**
      * Construct a Northstar user based on our request parameters.
      * TODO: Add voting plan fields.
@@ -51,8 +51,6 @@ module.exports = function params() {
       mobile,
       sms_status: smsStatus,
     });
-
-    helpers.request.setPlatform(req, platform);
 
     return next();
   };


### PR DESCRIPTION
### What's this PR do?

This pull request resurrects the `broadcastLite` origin parameter for a `POST /v2/messages` API request to send a Northstarless broadcast,  excluding the `getUser` middleware that queries Northstar to validate SMS status.

When the `broadcastLite` origin is passed instead of `broadcast`, we require all user properties needed for sending a broadcast to be sent as API request parameters -- which we can easily do from Customer.io by adding each user's profile property -- and use to them set the `req.user` that the other middleware depend on.

Example request:
```
curl --location --request POST 'http://localhost:5100/api/v2/messages?origin=broadcastLite' \
--header 'Content-Type: application/json' \
--header 'Authorization: Basic cHVwcGV0OnRvdGFsbHlzZWNyZXQ=' \
--data-raw '{
    "userId": "5547be89469c64ec7d8b518d",
    "broadcastId": "2IkRmKYUqySjPTEEHDS8q1",
    "mobile": "[removed]",
    "smsStatus": "active"
}'
```

Example response:
```
{
    "data": {
        "messages": [
            {
                "metadata": {
                    "delivery": {
                        "queuedAt": "2021-03-16T18:07:16.000Z",
                        "totalSegments": 3
                    },
                    "requestId": "c223ecfe-46ef-4555-ac05-7b74b595f17d"
                },
                "attachments": [],
                "_id": "6050f3d2b507033e05e7ef06",
                "text": "Jackie here! Spring break might not be the same this year, but you can still enjoy a vacation at home! Plan your perfect staycation: https://www.dosomething.org/us/articles/how-to-plan-a-covid-19-staycation?utm_source=content_campaign&utm_medium=sms&utm_campaign=sms_pending_2021_03_16&user_id=5547be89469c64ec7d8b518d&broadcast_id=2IkRmKYUqySjPTEEHDS8q1",
                "direction": "outbound-api-send",
                "template": "autoReplyBroadcast",
                "conversationId": "6050ec27b507033e05e7ef01",
                "topic": "61RPZx8atiGyeoeaqsckOE",
                "userId": "5547be89469c64ec7d8b518d",
                "broadcastId": "2IkRmKYUqySjPTEEHDS8q1",
                "createdAt": "2021-03-16T18:07:14.833Z",
                "updatedAt": "2021-03-16T18:07:15.460Z",
                "__v": 0,
                "platformMessageId": "SM191fe426998e4689a4811419a4803b6a"
            }
        ]
    }
}
```
### How should this be reviewed?

👀 

### Any background context you want to provide?


Holding off on unit tests and API docs to keep this easier to review as we've got a few more steps until this is ready to go live.

Next up for repo -- we'll need to add something like a `DS_BROADCASTLITE_ENABLED` feature flag, which will modify the `url` and `webhook` properties in the response of a `GET /v2/broadcasts/:id` API request to toggle between sending to the `broadcast` and `broadcastLite` origins.

We'll also need to [update Blink](https://github.com/DoSomething/blink/blob/3e45354d1a7024a006462a7a07cfb990243ec088/src/workers/CustomerIoGambitBroadcastWorker.js#L25-L28) to send through any parameters we may receive from the Customer.io webhook (e.g. `smsStatus`).

### Relevant tickets

References [Pivotal #177168378](https://www.pivotaltracker.com/story/show/177168378).

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tests added/updated for new features/bug fixes.
- [ ] ENV variables added/updated for new features/bug fixes.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
