### PR TITLE
Adds feature flag to toggle broadcastLite webhook configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,9 @@ DS_GAMBIT_CONVERSATIONS_USE_TWILIO_TEST_CREDS=true
 
 DS_BLINK_GAMBIT_BROADCAST_WEBHOOK_URL=http://blink:wink@localhost:5050/api/v1/webhooks/customerio-gambit-broadcast
 
+# This will be deprecated once we go live with Northstarless broadcasts.
+DS_GAMBIT_BROADCAST_NORTHSTARLESS=true
+
 ## Gateway JS
 DS_NORTHSTAR_API_OAUTH_CLIENT_ID=puppet
 DS_NORTHSTAR_API_OAUTH_CLIENT_SECRET=totallysecret

--- a/app/routes/broadcasts/single.js
+++ b/app/routes/broadcasts/single.js
@@ -4,6 +4,8 @@ const express = require('express');
 
 const router = express.Router({ mergeParams: true });
 
+const webhookConfig = require('../../../config/lib/middleware/broadcasts/single/webhook');
+
 // Middleware
 const paramsMiddleware = require('../../../lib/middleware/broadcasts/single/params');
 const getBroadcastMiddleware = require('../../../lib/middleware/broadcasts/single/broadcast');
@@ -13,7 +15,7 @@ const getStatsMiddleware = require('../../../lib/middleware/broadcasts/single/st
 router.get('/',
   paramsMiddleware(),
   getBroadcastMiddleware(),
-  getWebhookMiddleware(),
+  getWebhookMiddleware(webhookConfig),
   getStatsMiddleware());
 
 module.exports = router;

--- a/config/lib/helpers/broadcast.js
+++ b/config/lib/helpers/broadcast.js
@@ -12,9 +12,13 @@ module.exports = {
     legacy: 'broadcast',
   },
   customerIo: {
+    addrStateField: '{{customer.addr_state}}',
+    mobileField: '{{customer.phone}}',
+    smsStatusField: '{{customer.sms_status}}',
     userIdField: '{{customer.id}}',
   },
   blink: {
     webhookUrl: process.env.DS_BLINK_GAMBIT_BROADCAST_WEBHOOK_URL || 'http://localhost:5050/api/v1',
   },
+  isNorthstarless: process.env.DS_GAMBIT_BROADCAST_NORTHSTARLESS || false,
 };

--- a/config/lib/helpers/broadcast.js
+++ b/config/lib/helpers/broadcast.js
@@ -20,5 +20,4 @@ module.exports = {
   blink: {
     webhookUrl: process.env.DS_BLINK_GAMBIT_BROADCAST_WEBHOOK_URL || 'http://localhost:5050/api/v1',
   },
-  isNorthstarless: process.env.DS_GAMBIT_BROADCAST_NORTHSTARLESS || false,
 };

--- a/config/lib/middleware/broadcasts/single/webhook.js
+++ b/config/lib/middleware/broadcasts/single/webhook.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  isNorthstarless: process.env.DS_GAMBIT_BROADCAST_NORTHSTARLESS || false,
+};

--- a/documentation/endpoints/broadcasts.md
+++ b/documentation/endpoints/broadcasts.md
@@ -3,7 +3,7 @@
 ```
 GET /api/v2/broadcasts/:broadcastId
 ```
-Fetches a broadcast from [Gambit Content API](https://github.com/DoSomething/gambit-content/tree/master/documentation), and returns additional data properties for send configuration and message stats. 
+Fetches a broadcast from GraphQL, and returns additional data properties for send configuration and message stats. 
 
 
 ## Examples
@@ -40,10 +40,13 @@ curl -X "GET" "http://localhost:5100/api/v2/broadcasts/1S4pnWcZ3qeK0IyU6u4gYE" \
       "headers": {
         "Content-Type": "application/json"
       },
-      "url": "http://<secret>:<secret>@localhost:5050/api/v1/webhooks/customerio-gambit-broadcast",
+      "url": "http://<secret>:<secret>@localhost:5050/api/v1/webhooks/customerio-gambit-broadcast?origin=broadcastLite",
       "body": {
-        "northstarId": "{{customer.id}}",
-        "broadcastId": "257eBFFXnay6QoUOCuuiS0"
+        "broadcastId": "2IkRmKYUqySjPTEEHDS8q1",
+        "userId": "{{customer.id}}",
+        "addrState": "{{customer.addr_state}}",
+        "mobile": "{{customer.phone}}",
+        "smsStatus": "{{customer.sms_status}}"
       }
     },
     "stats": {

--- a/documentation/endpoints/messages.md
+++ b/documentation/endpoints/messages.md
@@ -49,7 +49,7 @@ The v2 POST Messages resource requires an `origin` query parameter, with possibl
 POST /v2/messages?origin=broadcast
 ```
 
-Sends a Broadcast message to a Member.
+Sends a Broadcast message to a Member (queries Northstar first to fetch all user properties).
 
 ### Input
 
@@ -107,6 +107,68 @@ curl -X "POST" "http://localhost:5100/api/v2/messages?origin=broadcast" \
       }
     ]
   }
+}
+```
+
+</details>
+
+## Broadcast Lite
+
+```
+POST /v2/messages?origin=broadcastLite
+```
+
+Sends a Broadcast message to a Member (does not query Northstar to fetch all user properties).
+
+<details>
+<summary><strong>Example Request</strong></summary>
+
+```
+curl --location --request POST 'http://localhost:5100/api/v2/messages?origin=broadcastLite' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: Basic cHVwcGV0OnRvdGFsbHlzZWNyZXQ=' \
+--data-raw '{
+    "addrState": "CA",
+    "userId": "5547be89469c64ec7d8b518d",
+    "broadcastId": "2IkRmKYUqySjPTEEHDS8q1",
+    "mobile": "+5555555555",
+    "smsStatus": "active"
+}'
+```
+
+</details>
+
+<details>
+<summary><strong>Example Response</strong></summary>
+
+```
+{
+    "data": {
+        "messages": [
+            {
+                "metadata": {
+                    "delivery": {
+                        "queuedAt": "2021-03-16T22:39:52.000Z",
+                        "totalSegments": 3
+                    },
+                    "requestId": "8436e982-6ed5-469c-8506-6d8591c99747"
+                },
+                "attachments": [],
+                "_id": "605133b6ff01cabc70fb9aae",
+                "text": "Jackie here! Spring break might not be the same this year, but you can still enjoy a vacation at home! Plan your perfect staycation: https://www.dosomething.org/us/articles/how-to-plan-a-covid-19-staycation?utm_source=content_campaign&utm_medium=sms&utm_campaign=sms_pending_2021_03_16&user_id=5547be89469c64ec7d8b518d&broadcast_id=2IkRmKYUqySjPTEEHDS8q1",
+                "direction": "outbound-api-send",
+                "template": "autoReplyBroadcast",
+                "conversationId": "6050ec27b507033e05e7ef01",
+                "topic": "61RPZx8atiGyeoeaqsckOE",
+                "userId": "5547be89469c64ec7d8b518d",
+                "broadcastId": "2IkRmKYUqySjPTEEHDS8q1",
+                "createdAt": "2021-03-16T22:39:50.973Z",
+                "updatedAt": "2021-03-16T22:39:52.388Z",
+                "__v": 0,
+                "platformMessageId": "SMc984aa9c58414ab29b3b8c4e36f78c8c"
+            }
+        ]
+    }
 }
 ```
 

--- a/lib/helpers/broadcast.js
+++ b/lib/helpers/broadcast.js
@@ -96,15 +96,22 @@ function isLegacyBroadcast(broadcast) {
  * getWebhookBodyForBroadcastId
  *
  * @param {string} broadcastId
+ * @param {boolean} isNorthstarless
  * @return {object}
  *
  * Returns the body of the POST request to Conversations /v2/messages?origin=broadcast.
  */
-function getWebhookBodyForBroadcastId(broadcastId) {
-  return {
-    northstarId: config.customerIo.userIdField,
+function getWebhookBodyForBroadcastId(broadcastId, isNorthstarless) {
+  const result = {
     broadcastId,
+    userId: config.customerIo.userIdField,
   };
+
+  return isNorthstarless ? Object.assign(result, {
+    addrState: config.customerIo.addrStateField,
+    mobile: config.customerIo.mobileField,
+    smsStatus: config.customerIo.smsStatusField,
+  }) : result;
 }
 
 /**
@@ -170,19 +177,20 @@ module.exports = {
   isAskVotingPlanStatus,
   isLegacyBroadcast,
   /**
-   * @param {boolean} useApiVersion2
+   * @param {object} req
    * @return {object}
    */
   getWebhook: function getWebhook(req) {
-    const data = {
+    const isNorthstarless = config.isNorthstarless;
+    const url = config.blink.webhookUrl;
+
+    return {
       headers: {
         'Content-Type': 'application/json',
       },
+      url: isNorthstarless ? `${url}?origin=broadcastLite` : url,
+      body: getWebhookBodyForBroadcastId(req.broadcastId, isNorthstarless),
     };
-
-    data.url = config.blink.webhookUrl;
-    data.body = getWebhookBodyForBroadcastId(req.broadcastId);
-    return data;
   },
   getStatusCallbackUrl: function getStatusCallbackUrl(broadcastId) {
     return `${config.blink.smsBroadcastWebhookUrl}?broadcastId=${broadcastId}`;

--- a/lib/helpers/broadcast.js
+++ b/lib/helpers/broadcast.js
@@ -178,10 +178,10 @@ module.exports = {
   isLegacyBroadcast,
   /**
    * @param {object} req
+   * @param {boolean} isNorthstarless
    * @return {object}
    */
-  getWebhook: function getWebhook(req) {
-    const isNorthstarless = config.isNorthstarless;
+  getWebhook: function getWebhook(req, isNorthstarless) {
     const url = config.blink.webhookUrl;
 
     return {

--- a/lib/middleware/broadcasts/single/webhook.js
+++ b/lib/middleware/broadcasts/single/webhook.js
@@ -3,12 +3,12 @@
 const logger = require('../../../logger');
 const helpers = require('../../../helpers');
 
-module.exports = function broadcastWebhook() {
+module.exports = function broadcastWebhook({ isNorthstarless }) {
   return (req, res, next) => {
     logger.debug('broadcastWebhook', { broadcastId: req.params.broadcastId }, req);
 
     try {
-      req.data.webhook = helpers.broadcast.getWebhook(req);
+      req.data.webhook = helpers.broadcast.getWebhook(req, isNorthstarless);
     } catch (error) {
       return helpers.sendErrorResponse(res, error);
     }

--- a/test/unit/lib/lib-helpers/broadcast.test.js
+++ b/test/unit/lib/lib-helpers/broadcast.test.js
@@ -124,7 +124,7 @@ test('getById should return fetchById if cached broadcasts undefined', async () 
 });
 
 // getWebhook
-test('getWebhook should return an object with body of a POST Broadcast Message request', () => {
+test('getWebhook should return an object with body of a POST Broadcast Message request with falsy Northstarless param', () => {
   const mockRequest = {
     broadcastId,
   };
@@ -132,9 +132,27 @@ test('getWebhook should return an object with body of a POST Broadcast Message r
   const result = broadcastHelper.getWebhook(mockRequest);
 
   result.headers['Content-Type'].should.equal(webhookContentTypeHeader);
-  result.body.userId.should.equal(config.customerIo.userIdField);
+  result.url.should.equal(config.blink.webhookUrl);
   result.body.broadcastId.should.equal(broadcastId);
-  result.should.have.property('url');
+  result.body.userId.should.equal(config.customerIo.userIdField);
+  result.body.should.not.have.property('addrState');
+  result.body.should.not.have.property('mobile');
+  result.body.should.not.have.property('smsStatus')
+});
+
+test('getWebhook should return an object with body of a POST BroadcastLite Message request with truthy Northstarless param', () => {
+  const mockRequest = {
+    broadcastId,
+  };
+
+  const result = broadcastHelper.getWebhook(mockRequest, 'true');
+
+  result.headers['Content-Type'].should.equal(webhookContentTypeHeader);
+  result.url.should.equal(`${config.blink.webhookUrl}?origin=broadcastLite`);
+  result.body.broadcastId.should.equal(broadcastId);
+  result.body.addrState.should.equal(config.customerIo.addrStateField);
+  result.body.smsStatus.should.equal(config.customerIo.smsStatusField);
+  result.body.userId.should.equal(config.customerIo.userIdField);
 });
 
 // isAskSubscriptionStatus

--- a/test/unit/lib/lib-helpers/broadcast.test.js
+++ b/test/unit/lib/lib-helpers/broadcast.test.js
@@ -128,9 +128,11 @@ test('getWebhook should return an object with body of a POST Broadcast Message r
   const mockRequest = {
     broadcastId,
   };
+
   const result = broadcastHelper.getWebhook(mockRequest);
+
   result.headers['Content-Type'].should.equal(webhookContentTypeHeader);
-  result.body.northstarId.should.equal(config.customerIo.userIdField);
+  result.body.userId.should.equal(config.customerIo.userIdField);
   result.body.broadcastId.should.equal(broadcastId);
   result.should.have.property('url');
 });

--- a/test/unit/lib/lib-helpers/broadcast.test.js
+++ b/test/unit/lib/lib-helpers/broadcast.test.js
@@ -124,7 +124,7 @@ test('getById should return fetchById if cached broadcasts undefined', async () 
 });
 
 // getWebhook
-test('getWebhook should return an object with body of a POST Broadcast Message request with falsy Northstarless param', () => {
+test('getWebhook should return an object with body of a POST Broadcast Message request with falsy isNorthstarless', () => {
   const mockRequest = {
     broadcastId,
   };
@@ -137,10 +137,10 @@ test('getWebhook should return an object with body of a POST Broadcast Message r
   result.body.userId.should.equal(config.customerIo.userIdField);
   result.body.should.not.have.property('addrState');
   result.body.should.not.have.property('mobile');
-  result.body.should.not.have.property('smsStatus')
+  result.body.should.not.have.property('smsStatus');
 });
 
-test('getWebhook should return an object with body of a POST BroadcastLite Message request with truthy Northstarless param', () => {
+test('getWebhook should return an object with body of a POST BroadcastLite Message request with truthy isNorthstarless', () => {
   const mockRequest = {
     broadcastId,
   };


### PR DESCRIPTION
### What's this PR do?

This pull request continues on #552, adding a `DS_GAMBIT_BROADCAST_NORTHSTARLESS` environment variable to toggle whether the API response of a `GET /v2/broadcasts/:id` should send broadcast messages to the new `broadcastLite` origin per https://github.com/DoSomething/blink/pull/257.

The response of the `GET /v2/broadcasts/:id` endpoint is used in Gambit Admin, allowing admins to copy/paste into Customer.io when sending a broadcast. When we're ready to go live with the broadcastLite route, we'll set the `DS_GAMBIT_BROADCAST_NORTHSTARLESS` config variable and flag for our admins that they'll need to copy/paste the new payload from Gambit Admin (not copy from an existing Customer.io webhook)

<img  src="https://user-images.githubusercontent.com/1236811/111390741-7c9c2880-8670-11eb-8b11-014c57eb8d97.png">


### How should this be reviewed?

👀 

### Any background context you want to provide?

Last up is writing some integration tests for the `POST /v2/messages?origin=broadcastLite` route to verify the user is set as expected... but saving for another PR to keep these easier to review. By the time we get around to writing the integration test, it could just make sense to deprecate the old `broadcast` route that queries Northstar entirely...  

### Relevant tickets

References [Pivotal #177168378](https://www.pivotaltracker.com/story/show/177168378).

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Tests added/updated for new features/bug fixes.
- [ ] ENV variables added/updated for new features/bug fixes.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
