### PR TITLE
Only make one request for a broadcast/topic at a time.

### DIFF
--- a/lib/helpers/broadcast.js
+++ b/lib/helpers/broadcast.js
@@ -53,7 +53,7 @@ async function fetchById(id) {
 
   // Once we've finished the request, store the result
   // in cache and clear our "pending request" record:
-  helpers.cache.topics.set(id, broadcast);
+  helpers.cache.broadcasts.set(id, broadcast);
   delete fetchers[id];
 
   return broadcast;

--- a/lib/helpers/broadcast.js
+++ b/lib/helpers/broadcast.js
@@ -36,12 +36,27 @@ const broadcastTransformer = (topic) => {
  * @param {String} id
  * @return {Promise}
  */
+const fetchers = {};
 async function fetchById(id) {
+  // If we have an in-flight request, return existing promise:
+  if (fetchers[id]) {
+    logger.debug('Using pending request for broadcast', { id });
+    return fetchers[id];
+  }
+
+  // Otherwise, start a new request, keeping a record of it
+  // in case we fetch this same ID again before it resolves:
   logger.debug('Fetching broadcast', { id });
+  fetchers[id] = graphql.fetchBroadcastById(id);
 
-  const broadcast = broadcastTransformer(await graphql.fetchBroadcastById(id));
+  const broadcast = broadcastTransformer(await fetchers[id]);
 
-  return helpers.cache.broadcasts.set(id, broadcast);
+  // Once we've finished the request, store the result
+  // in cache and clear our "pending request" record:
+  helpers.cache.topics.set(id, broadcast);
+  delete fetchers[id];
+
+  return broadcast;
 }
 
 /**
@@ -56,7 +71,6 @@ async function getById(id) {
     return broadcast;
   }
 
-  logger.debug('Topic cache miss', { id });
   return module.exports.fetchById(id);
 }
 

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -58,16 +58,32 @@ const topicTransformer = (topic) => {
   return transformedTopic;
 };
 
+
 /**
  * @param {String} id
  * @return {Promise}
  */
+const fetchers = {};
 async function fetchById(id) {
+  // If we have an in-flight request, return existing promise:
+  if (fetchers[id]) {
+    logger.debug('Using pending request for topic', { id });
+    return fetchers[id];
+  }
+
+  // Otherwise, start a new request, keeping a record of it
+  // in case we fetch this same ID again before it resolves:
   logger.debug('Fetching topic', { id });
+  fetchers[id] = graphql.fetchTopicById(id);
 
-  const topic = topicTransformer(await graphql.fetchTopicById(id));
+  const topic = topicTransformer(await fetchers[id]);
 
-  return helpers.cache.topics.set(id, topic);
+  // Once we've finished the request, store the result
+  // in cache and clear our "pending request" record:
+  helpers.cache.topics.set(id, topic);
+  delete fetchers[id];
+
+  return topic;
 }
 
 /**

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -58,7 +58,6 @@ const topicTransformer = (topic) => {
   return transformedTopic;
 };
 
-
 /**
  * @param {String} id
  * @return {Promise}


### PR DESCRIPTION
### What's this PR do?

This pull request ensures we only make one request for a broadcast or topic at a time (and therefore, only one concurrent request per dyno to Northstar's `v3/campaigns` and `v3/actions` endpoints). This should fix an issue where we'd fire off thousands of requests while waiting for that first in-flight request to complete & get saved to cache.

### How should this be reviewed?

Let me know if this reads clearly! I spent a bit of time trying to abstract this into a general helper that could be used in both of these functions, but it seemed to make things harder to follow at a glance so I've held back on it.

</details>


### Any background context you want to provide?

This should address some of the big spikes in Northstar traffic we've seen over the past couple months.

### Relevant tickets

References [Pivotal #177168378](https://www.pivotaltracker.com/story/show/177168378).

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tests added/updated for new features/bug fixes.
- [ ] ENV variables added/updated for new features/bug fixes.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
