### PR TITLE
Ensure re-used promises are transformed as well.

### DIFF
--- a/lib/helpers/broadcast.js
+++ b/lib/helpers/broadcast.js
@@ -41,7 +41,7 @@ async function fetchById(id) {
   // If we have an in-flight request, return existing promise:
   if (fetchers[id]) {
     logger.debug('Using pending request for broadcast', { id });
-    return fetchers[id];
+    return broadcastTransformer(await fetchers[id]);
   }
 
   // Otherwise, start a new request, keeping a record of it

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -67,7 +67,7 @@ async function fetchById(id) {
   // If we have an in-flight request, return existing promise:
   if (fetchers[id]) {
     logger.debug('Using pending request for topic', { id });
-    return fetchers[id];
+    return topicTransformer(await fetchers[id]);
   }
 
   // Otherwise, start a new request, keeping a record of it


### PR DESCRIPTION
### What's this PR do?

This pull request fixes a bug where reused "in-flight" promises weren't being transformed ([logs](https://my.papertrailapp.com/systems/gambit-conversations-prod/events?q=system%3Agambit-conversations-prod+cannot+read+property&focus=1344061238149926937&selected=1344061238149926937)):

```
Jun 22 14:26:33 gambit-conversations-prod app/web.1 pid=35 code=500 response#message="Cannot read property 'campaign' of undefined" request_id=8828e69e-bf18-4a29-9c3f-00495494bb10 level=error message=sendResponseWithStatusCode 
```

This is because we were returning the request directly, rather than running it through our transformer to format it.

### How should this be reviewed?

👀

### Any background context you want to provide?

I noticed this when looking at logs for yesterday's broadcast! Affected broadcast messages 500'd at this point & so would have been retried without affecting users, but we should handle this correctly the first time around!

### Relevant tickets

References [Pivotal #177168378](https://www.pivotaltracker.com/story/show/177168378).

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tests added/updated for new features/bug fixes.
- [ ] ENV variables added/updated for new features/bug fixes.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
